### PR TITLE
Landmark search now uses a CornerIcon to toggle the search window.

### DIFF
--- a/Blish HUD/Controls/ContextMenuStrip.cs
+++ b/Blish HUD/Controls/ContextMenuStrip.cs
@@ -64,6 +64,8 @@ namespace Blish_HUD.Controls {
                 newChild.Height = ITEM_HEIGHT;
                 newChild.Width = this.Width - BORDER_PADDING * 2;
                 newChild.Left = BORDER_PADDING;
+
+                newChild.Click += delegate { this.Visible = false; };
             }
 
             int lastBottom = -4;

--- a/Blish HUD/Controls/CornerIcon.cs
+++ b/Blish HUD/Controls/CornerIcon.cs
@@ -149,7 +149,7 @@ namespace Blish_HUD.Controls {
 
         // TODO: Use a shader to replace "HoverIcon"
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
-            if (this.HoverIcon == null) return;
+            if (this.Icon == null) return;
 
             if (this.MouseOver) {
                 if (this.HoverIcon == null) {

--- a/Blish HUD/GameServices/ContentService.cs
+++ b/Blish HUD/GameServices/ContentService.cs
@@ -136,6 +136,7 @@ namespace Blish_HUD {
                         }
                     } else {
                         #if DEBUG
+                        Directory.CreateDirectory(@"ref\to-include");
 
                         // Makes it easy to know what's in use so that it can be added to the ref archive later
                         if (File.Exists($@"ref\{filepath}")) File.Copy($@"ref\{filepath}", $@"ref\to-include\{filepath}", true);

--- a/Blish HUD/Modules/PoiLookup/PoiLookup.cs
+++ b/Blish HUD/Modules/PoiLookup/PoiLookup.cs
@@ -13,6 +13,7 @@ namespace Blish_HUD.Modules.PoiLookup {
 
         private PoiLookupWindow LandmarkSearchWindow;
         private SkillBox LandmarkSearch;
+        private CornerIcon landmarkSearchIcon;
 
         public override ModuleInfo GetModuleInfo() {
             return new ModuleInfo(
@@ -39,19 +40,35 @@ namespace Blish_HUD.Modules.PoiLookup {
                 Location = GameService.Graphics.SpriteScreen.Size / new Point(2)
             };
 
-            var testMenu = new ContextMenuStrip();
-            testMenu.AddMenuItem("Use");
-            testMenu.AddMenuItem("Mail item to...");
-            testMenu.AddMenuItem("Destroy");
-            testMenu.AddMenuItem("Use All");
-
             LandmarkSearch = new SkillBox() {
                 Location = new Point(GameService.Graphics.WindowWidth / 4 * 1 - 30, 0),
                 Icon     = GameService.Content.GetTexture("landmark-search-icon"),
                 Parent   = GameService.Graphics.SpriteScreen,
-                Menu     = testMenu
+                Menu     = new ContextMenuStrip(),
+                Visible  = false
             };
 
+            LandmarkSearch.Menu.AddMenuItem("Use small icon").Click += delegate {
+                LandmarkSearch.Visible     = false;
+                landmarkSearchIcon.Visible = true;
+            };
+
+            landmarkSearchIcon = new CornerIcon() {
+                Icon = GameService.Content.GetTexture("landmark-search"),
+                HoverIcon = GameService.Content.GetTexture("landmark-search-hover"),
+                Menu             = new ContextMenuStrip(),
+                BasicTooltipText = "Landmark Search",
+                Priority         = 5,
+            };
+
+            landmarkSearchIcon.Menu.AddMenuItem("Use large icon").Click += delegate {
+                LandmarkSearch.Visible = true;
+                landmarkSearchIcon.Visible = false;
+            };
+
+            landmarkSearchIcon.Click += delegate {
+                LandmarkSearchWindow.ToggleWindow();
+            };
 
             GameService.Graphics.SpriteScreen.Resized += delegate { LandmarkSearch.Location = new Point(GameService.Graphics.WindowWidth / 4 * 1 - 30, 0); };
 
@@ -62,7 +79,7 @@ namespace Blish_HUD.Modules.PoiLookup {
             var floorInfo = BHGw2Api.Floor.FloorFromContinentAndId(1, 1);
 
             if (floorInfo == null) {
-                Console.WriteLine("PoiLookup: Could not load landmark information from API. Aborting.");
+                GameService.Debug.WriteWarningLine("PoiLookup: Could not load landmark information from API. Aborting.");
                 return;
             }
 
@@ -103,10 +120,6 @@ namespace Blish_HUD.Modules.PoiLookup {
             }
             
             return closestWp;
-        }
-
-        public override void Update(GameTime gameTime) {
-            LandmarkSearch.Visible = GameService.GameIntegration.IsInGame;
         }
 
     }


### PR DESCRIPTION
Switched to using corner icon by default instead of the much larger skillbox.

https://gfycat.com/warlikeimpassionedalbacoretuna

Icon choice is now available via a right-click context menu.

![image](https://user-images.githubusercontent.com/1950594/53687956-bc9e4600-3d09-11e9-93b6-aa9825fc034c.png)

![image](https://user-images.githubusercontent.com/1950594/53687960-c4f68100-3d09-11e9-9ef6-3bc59259d87b.png)