### PR TITLE
Resolved several valid sonar complaints and enabled AsyncTexture2D on Markers.  Also implemented `Equals` on AsyncTexture2D.

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -201,6 +201,10 @@
     <Compile Include="GameServices\Gw2ApiService.cs" />
     <Compile Include="GameServices\ArcDpsService.cs" />
     <Compile Include="Content\IDataReader.cs" />
+    <Compile Include="GameServices\Input\KeyboardEventType.cs" />
+    <Compile Include="GameServices\Input\KeyboardMessage.cs" />
+    <Compile Include="GameServices\Input\MouseEventArgs.cs" />
+    <Compile Include="GameServices\Input\MouseEventType.cs" />
     <Compile Include="GameServices\PersistentStore\Store.cs" />
     <Compile Include="GameServices\PersistentStore\StoreValue.cs" />
     <Compile Include="GameServices\PersistentStore\StoreValue[T].cs" />

--- a/Blish HUD/Content/AsyncTexture2D.cs
+++ b/Blish HUD/Content/AsyncTexture2D.cs
@@ -5,25 +5,53 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Octokit;
 
 namespace Blish_HUD.Content {
+    /// <summary>
+    /// A thread-safe wrapper on Texture2D that allows you to swap the <see cref="Texture2D"/> backing for a texture already assigned to a property.
+    /// </summary>
     public sealed class AsyncTexture2D : IDisposable {
 
         private Texture2D _stagedTexture2D;
         private Texture2D _activeTexture2D;
 
+        /// <summary>
+        /// <c>true</c>, if the <see cref="AsyncTexture2D"/>'s <see cref="Texture"/> is set.
+        /// </summary>
+        public bool HasTexture => _activeTexture2D != null;
+
+        /// <summary>
+        /// The active <see cref="Texture2D"/> of the <see cref="AsyncTexture2D"/>.
+        /// </summary>
+        public Texture2D Texture {
+            get {
+                if (!this.HasTexture) {
+                    throw new InvalidOperationException($"{nameof(AsyncTexture2D)} object must have a Texture.");
+                }
+
+                return _activeTexture2D;
+            }
+        }
+
+        /// <summary>
+        /// Create an <see cref="AsyncTexture2D"/> where the current <see cref="Texture"/> is a single transparent pixel.
+        /// </summary>
         public AsyncTexture2D() {
             _activeTexture2D = ContentService.Textures.TransparentPixel;
         }
 
+        /// <summary>
+        /// Create an <see cref="AsyncTexture2D"/> where the current <see cref="Texture"/> is the <see cref="Texture2D"/> passed as <param name="defaultTexture"/>.
+        /// </summary>
         public AsyncTexture2D(Texture2D defaultTexture) {
             _activeTexture2D = defaultTexture;
         }
 
-        public Texture2D GetTexture() {
-            return _activeTexture2D;
-        }
-
+        /// <summary>
+        /// Replaces the <see cref="Texture"/> of the <see cref="AsyncTexture2D"/> with the texture provided in <param name="newTexture"/> on the next game cycle loop.
+        /// </summary>
+        /// <param name="newTexture">The new texture to assign.</param>
         public void SwapTexture(Texture2D newTexture) {
             _stagedTexture2D = newTexture;
 
@@ -35,10 +63,17 @@ namespace Blish_HUD.Content {
             _stagedTexture2D = null;
         }
 
-        ///// <inheritdoc />
-        //public override bool Equals(object obj) {
-        //    return Equals(_activeTexture2D, obj);
-        //}
+        /// <inheritdoc />
+        public override bool Equals(object obj) {
+            if (!HasTexture) return obj == null;
+            if (obj == null) return false;
+
+            if (obj is Texture2D tobj) {
+                return _activeTexture2D.Equals(tobj);
+            }
+
+            return this == obj;
+        }
 
         /// <inheritdoc />
         public override int GetHashCode() {

--- a/Blish HUD/Controls/BackButton.cs
+++ b/Blish HUD/Controls/BackButton.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using Blish_HUD.Input;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Blish_HUD.Controls {

--- a/Blish HUD/Controls/Checkbox.cs
+++ b/Blish HUD/Controls/Checkbox.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 

--- a/Blish HUD/Controls/Container.cs
+++ b/Blish HUD/Controls/Container.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;

--- a/Blish HUD/Controls/ContextMenuStrip.cs
+++ b/Blish HUD/Controls/ContextMenuStrip.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 

--- a/Blish HUD/Controls/ContextMenuStripItem.cs
+++ b/Blish HUD/Controls/ContextMenuStripItem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.BitmapFonts;

--- a/Blish HUD/Controls/Control.cs
+++ b/Blish HUD/Controls/Control.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Blish_HUD.Controls.Effects;
+using Blish_HUD.Input;
 using Newtonsoft.Json;
 
 namespace Blish_HUD.Controls {

--- a/Blish HUD/Controls/CornerIcon.cs
+++ b/Blish HUD/Controls/CornerIcon.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Blish_HUD.Content;
+using Blish_HUD.Input;
 
 namespace Blish_HUD.Controls {
     public class CornerIcon : Container {

--- a/Blish HUD/Controls/CounterBox.cs
+++ b/Blish HUD/Controls/CounterBox.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using Blish_HUD.Input;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 namespace Blish_HUD.Controls
 {

--- a/Blish HUD/Controls/DetailsButton.cs
+++ b/Blish HUD/Controls/DetailsButton.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Blish_HUD.Controls.Effects;
 using Blish_HUD;
 using Blish_HUD.Content;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 

--- a/Blish HUD/Controls/Dropdown.cs
+++ b/Blish HUD/Controls/Dropdown.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.TextureAtlases;

--- a/Blish HUD/Controls/Effects/ScrollingHighlightEffect.cs
+++ b/Blish HUD/Controls/Effects/ScrollingHighlightEffect.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using Blish_HUD.Input;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Blish_HUD.Controls.Effects {

--- a/Blish HUD/Controls/GlowButton.cs
+++ b/Blish HUD/Controls/GlowButton.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Blish_HUD.Content;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 

--- a/Blish HUD/Controls/HealthPoolButton.cs
+++ b/Blish HUD/Controls/HealthPoolButton.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 namespace Blish_HUD.Controls {

--- a/Blish HUD/Controls/HotkeyAssigner.cs
+++ b/Blish HUD/Controls/HotkeyAssigner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Blish_HUD;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 

--- a/Blish HUD/Controls/HotkeyAssignmentWindow.cs
+++ b/Blish HUD/Controls/HotkeyAssignmentWindow.cs
@@ -1,4 +1,5 @@
 ﻿using Blish_HUD;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 

--- a/Blish HUD/Controls/Image.cs
+++ b/Blish HUD/Controls/Image.cs
@@ -19,7 +19,7 @@ namespace Blish_HUD.Controls {
 
         private Rectangle? _sourceRectangle;
         public Rectangle SourceRectangle {
-            get => _sourceRectangle ?? _texture.GetTexture().Bounds;
+            get => _sourceRectangle ?? _texture.Texture.Bounds;
             set => SetProperty(ref _sourceRectangle, value);
         }
 
@@ -33,7 +33,7 @@ namespace Blish_HUD.Controls {
 
         public Image(AsyncTexture2D texture) {
             this.Texture = texture;
-            this.Size = texture.GetTexture().Bounds.Size;
+            this.Size = texture.Texture.Bounds.Size;
         }
 
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {

--- a/Blish HUD/Controls/Intern/Keyboard.cs
+++ b/Blish HUD/Controls/Intern/Keyboard.cs
@@ -57,7 +57,7 @@ namespace Blish_HUD.Controls.Intern
             {
                 var nInputs = new[]
                 {
-                    new Input
+                    new Extern.Input
                     {
                         type = InputType.KEYBOARD,
                         U = new InputUnion
@@ -70,7 +70,7 @@ namespace Blish_HUD.Controls.Intern
                         }
                     }
                 };
-                PInvoke.SendInput((uint)nInputs.Length, nInputs, Input.Size);
+                PInvoke.SendInput((uint)nInputs.Length, nInputs, Extern.Input.Size);
             }
             else
             {
@@ -88,7 +88,7 @@ namespace Blish_HUD.Controls.Intern
             {
                 var nInputs = new[]
                 {
-                    new Input
+                    new Extern.Input
                     {
                         type = InputType.KEYBOARD,
                         U = new InputUnion
@@ -102,7 +102,7 @@ namespace Blish_HUD.Controls.Intern
                         }
                     }
                 };
-                PInvoke.SendInput((uint)nInputs.Length, nInputs, Input.Size);
+                PInvoke.SendInput((uint)nInputs.Length, nInputs, Extern.Input.Size);
             }
             else
             {

--- a/Blish HUD/Controls/MenuItem.cs
+++ b/Blish HUD/Controls/MenuItem.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Blish_HUD.Content;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.TextureAtlases;
@@ -253,16 +254,13 @@ namespace Blish_HUD.Controls {
         }
 
         protected override void OnClick(MouseEventArgs e) {
-            if (_canCheck
-             && this.MouseOverIconBox) { /* Mouse was clicked inside of the checkbox */
+            if (_canCheck && this.MouseOverIconBox) { /* Mouse was clicked inside of the checkbox */
 
                 Checked = !Checked;
-            } else if (_overSection
-                    && _children.Any()) { /* Mouse was clicked inside of the mainbody of the MenuItem */
+            } else if (_overSection && _children.Any()) { /* Mouse was clicked inside of the mainbody of the MenuItem */
 
                 ToggleAccordionState();
-            } else if (_overSection
-                    && _canCheck) { /* Mouse was clicked inside of the mainbody of the MenuItem,
+            } else if (_overSection && _canCheck) { /* Mouse was clicked inside of the mainbody of the MenuItem,
                                            but we have no children, so we toggle checkbox */
 
                 Checked = !Checked;

--- a/Blish HUD/Controls/MultilineTextBox.cs
+++ b/Blish HUD/Controls/MultilineTextBox.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using Blish_HUD.Input;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Blish_HUD.Controls {

--- a/Blish HUD/Controls/Panel.cs
+++ b/Blish HUD/Controls/Panel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Newtonsoft.Json;

--- a/Blish HUD/Controls/Resources/Checkable.cs
+++ b/Blish HUD/Controls/Resources/Checkable.cs
@@ -4,12 +4,10 @@ using MonoGame.Extended.TextureAtlases;
 namespace Blish_HUD.Controls.Resources {
     public static class Checkable {
 
-        public static readonly List<TextureRegion2D> TextureRegionsCheckbox;
+        public static readonly IReadOnlyList<TextureRegion2D> TextureRegionsCheckbox;
 
         static Checkable() {
-            TextureRegionsCheckbox = new List<TextureRegion2D>();
-
-            TextureRegionsCheckbox.AddRange(new[] {
+            TextureRegionsCheckbox = new List<TextureRegion2D>(new[] {
                                                 Control.TextureAtlasControl.GetRegion("checkbox/cb-unchecked"),
                                                 Control.TextureAtlasControl.GetRegion("checkbox/cb-unchecked-active"),
                                                 Control.TextureAtlasControl.GetRegion("checkbox/cb-unchecked-disabled"),

--- a/Blish HUD/Controls/Scrollbar.cs
+++ b/Blish HUD/Controls/Scrollbar.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Blish_HUD.Input;
 using Glide;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;

--- a/Blish HUD/Controls/SkillBox.cs
+++ b/Blish HUD/Controls/SkillBox.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Blish_HUD.Content;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.TextureAtlases;

--- a/Blish HUD/Controls/StandardButton.cs
+++ b/Blish HUD/Controls/StandardButton.cs
@@ -1,5 +1,6 @@
 ﻿using Blish_HUD;
 using Blish_HUD.Content;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
@@ -116,7 +117,7 @@ namespace Blish_HUD.Controls {
                     textLeft += ICON_SIZE / 2;
                 }
 
-                var iconSize = _resizeIcon ? new Point(ICON_SIZE) : _icon.GetTexture().Bounds.Size;
+                var iconSize = _resizeIcon ? new Point(ICON_SIZE) : _icon.Texture.Bounds.Size;
 
                 _layoutIconBounds = new Rectangle(textLeft - iconSize.X - ICON_TEXT_OFFSET, _size.Y / 2 - iconSize.Y / 2, iconSize.X, iconSize.Y);
             }

--- a/Blish HUD/Controls/TabbedWindow.cs
+++ b/Blish HUD/Controls/TabbedWindow.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Blish_HUD.Content;
+using Blish_HUD.Input;
 
 namespace Blish_HUD.Controls {
 

--- a/Blish HUD/Controls/Textbox.cs
+++ b/Blish HUD/Controls/Textbox.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Drawing;
 using System.Windows.Forms;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.BitmapFonts;
 using Color = Microsoft.Xna.Framework.Color;
+using MouseEventArgs = Blish_HUD.Input.MouseEventArgs;
 using Point = Microsoft.Xna.Framework.Point;
 using Rectangle = Microsoft.Xna.Framework.Rectangle;
 

--- a/Blish HUD/Controls/Tooltip.cs
+++ b/Blish HUD/Controls/Tooltip.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 

--- a/Blish HUD/Controls/TrackBar.cs
+++ b/Blish HUD/Controls/TrackBar.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.TextureAtlases;

--- a/Blish HUD/Controls/WindowBase.cs
+++ b/Blish HUD/Controls/WindowBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 

--- a/Blish HUD/Entities/Primitives/Billboard.cs
+++ b/Blish HUD/Entities/Primitives/Billboard.cs
@@ -51,8 +51,8 @@ namespace Blish_HUD.Entities.Primitives {
         public AsyncTexture2D Texture {
             get => _texture;
             set {
-                if (SetProperty(ref _texture, value) && _autoResizeBillboard && _texture.GetTexture() != null)
-                    this.Size = _texture.GetTexture().Bounds.Size.ToVector2().ToWorldCoord();
+                if (SetProperty(ref _texture, value) && _autoResizeBillboard && _texture.HasTexture)
+                    this.Size = _texture.Texture.Bounds.Size.ToVector2().ToWorldCoord();
             }
         }
 
@@ -107,7 +107,7 @@ namespace Blish_HUD.Entities.Primitives {
                                                             GameService.Camera.Forward);
 
             _billboardEffect.Alpha = this.Opacity;
-            _billboardEffect.Texture = this.Texture.GetTexture();
+            _billboardEffect.Texture = this.Texture.Texture;
 
             foreach (var pass in _billboardEffect.CurrentTechnique.Passes) {
                 pass.Apply();

--- a/Blish HUD/GameServices/Input/KeyboardEventType.cs
+++ b/Blish HUD/GameServices/Input/KeyboardEventType.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blish_HUD.Input {
+    public enum KeyboardEventType {
+        KeyDown = 0x0100,
+        KeyUp   = 0x0101
+    }
+}

--- a/Blish HUD/GameServices/Input/KeyboardMessage.cs
+++ b/Blish HUD/GameServices/Input/KeyboardMessage.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Blish_HUD.Input;
+using Microsoft.Xna.Framework.Input;
+
+namespace Blish_HUD.Input {
+    public struct KeyboardMessage {
+
+        public int               uMsg;
+        public KeyboardEventType EventType;
+        public Keys              Key;
+
+        public KeyboardMessage(int _uMsg, IntPtr _wParam, int _lParam) {
+            uMsg      = _uMsg;
+            EventType = (KeyboardEventType)_wParam;
+            Key       = (Keys)_lParam;
+        }
+
+    }
+}

--- a/Blish HUD/GameServices/Input/MouseEventArgs.cs
+++ b/Blish HUD/GameServices/Input/MouseEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+
+namespace Blish_HUD.Input {
+    public class MouseEventArgs : EventArgs {
+        public MouseState MouseState { get; }
+
+        /// <summary>
+        /// The relative mouse position when the event was fired.
+        /// </summary>
+        public Point MousePosition { get; }
+
+        public MouseEventArgs(MouseState ms) {
+            this.MouseState = ms;
+        }
+    }
+}

--- a/Blish HUD/GameServices/Input/MouseEventType.cs
+++ b/Blish HUD/GameServices/Input/MouseEventType.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blish_HUD.Input {
+    public enum MouseEventType {
+        LeftMouseButtonPressed,
+        LeftMouseButtonReleased,
+        MouseMoved,
+        RightMouseButtonPressed,
+        RightMouseButtonReleased,
+        MouseWheelScrolled
+    }
+}

--- a/Blish HUD/GameServices/InputService.cs
+++ b/Blish HUD/GameServices/InputService.cs
@@ -7,49 +7,9 @@ using System.Linq;
 using System.Threading;
 using ButtonState = Microsoft.Xna.Framework.Input.ButtonState;
 using Blish_HUD.Controls;
+using Blish_HUD.Input;
 using Control = Blish_HUD.Controls.Control;
 using Keys = Microsoft.Xna.Framework.Input.Keys;
-
-public class MouseEventArgs : EventArgs {
-    public MouseState MouseState { get; }
-
-    /// <summary>
-    /// The relative mouse position when the event was fired.
-    /// </summary>
-    public Point MousePosition { get; }
-
-    public MouseEventArgs(MouseState ms) {
-        this.MouseState = ms;
-    }
-}
-
-public enum MouseEventType {
-    LeftMouseButtonPressed,
-    LeftMouseButtonReleased,
-    MouseMoved,
-    RightMouseButtonPressed,
-    RightMouseButtonReleased,
-    MouseWheelScrolled
-}
-
-public enum KeyboardEventType {
-    KeyDown = 0x0100,
-    KeyUp = 0x0101
-}
-
-public struct KeyboardMessage {
-
-    public int    uMsg;
-    public KeyboardEventType EventType;
-    public Keys Key;
-
-    public KeyboardMessage(int _uMsg, IntPtr _wParam, int _lParam) {
-        uMsg   = _uMsg;
-        EventType = (KeyboardEventType)_wParam;
-        Key = (Keys)_lParam;
-    }
-
-}
 
 namespace Blish_HUD {
     public class InputService:GameService {

--- a/Blish HUD/Pathing/Entities/Marker.cs
+++ b/Blish HUD/Pathing/Entities/Marker.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using Blish_HUD.Content;
 using Blish_HUD.Entities;
 using Blish_HUD.Entities.Primitives;
+using Blish_HUD.Input;
 using Blish_HUD.Pathing.Entities.Effects;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -31,7 +33,7 @@ namespace Blish_HUD.Pathing.Entities {
         private bool                        _autoResize = true;
         private Vector2                     _size       = Vector2.One;
         private float                       _scale      = 1f;
-        private Texture2D                   _texture;
+        private AsyncTexture2D              _texture;
         private BillboardVerticalConstraint _verticalConstraint = BillboardVerticalConstraint.CameraPosition;
         private float                       _fadeNear           = -1;
         private float                       _fadeFar            = -1;
@@ -79,17 +81,17 @@ namespace Blish_HUD.Pathing.Entities {
             set => SetProperty(ref _fadeFar, value);
         }
 
-        public Texture2D Texture {
+        public AsyncTexture2D Texture {
             get => _texture;
             set {
                 if (SetProperty(ref _texture, value) && _texture != null) {
-                    this.VerticalConstraint = _texture.Height == _texture.Width
+                    this.VerticalConstraint = _texture.Texture.Height == _texture.Texture.Width
                                                   ? BillboardVerticalConstraint.CameraPosition
                                                   : BillboardVerticalConstraint.PlayerPosition;
 
                     if (_autoResize) {
-                        this.Size = new Vector2(WorldUtil.GameToWorldCoord(_texture.Width),
-                                                WorldUtil.GameToWorldCoord(_texture.Height));
+                        this.Size = new Vector2(WorldUtil.GameToWorldCoord(_texture.Texture.Width),
+                                                WorldUtil.GameToWorldCoord(_texture.Texture.Height));
                     }
                 }
             }

--- a/Blish HUD/_Utils/MouseInterceptor.cs
+++ b/Blish HUD/_Utils/MouseInterceptor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using MouseEventArgs = Blish_HUD.Input.MouseEventArgs;
 
 namespace Blish_HUD {
 

--- a/Blish HUD/_Utils/WinAPI/KeyboardHook.cs
+++ b/Blish HUD/_Utils/WinAPI/KeyboardHook.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Blish_HUD.Input;
 
 namespace Blish_HUD.WinAPI {
     internal class KeyboardHook {


### PR DESCRIPTION
Resolves the following SonarCloud issues:

https://sonarcloud.io/project/issues?branch=dev&id=blish-hud_Blish-HUD&open=AWvSLOxR7BGPHuO3rJh-&resolved=false&types=BUG

https://sonarcloud.io/project/issues?branch=dev&id=blish-hud_Blish-HUD&open=AWvSLOrm7BGPHuO3rJgs&resolved=false&types=BUG

https://sonarcloud.io/project/issues?branch=dev&id=blish-hud_Blish-HUD&open=AWvSLOfV7BGPHuO3rJdX&resolved=false&types=BUG

https://sonarcloud.io/project/issues?branch=dev&id=blish-hud_Blish-HUD&open=AWvSLOfV7BGPHuO3rJdd&resolved=false&types=BUG

https://sonarcloud.io/project/issues?branch=dev&id=blish-hud_Blish-HUD&open=AWvSLOfV7BGPHuO3rJda&resolved=false&types=BUG

https://sonarcloud.io/project/issues?branch=dev&id=blish-hud_Blish-HUD&open=AWvSLOfU7BGPHuO3rJdW&resolved=false&types=BUG

The changes to move the Input types into a proper namespace is a change that breaks any module with a custom control.  Here is the PR for the Community-Module-Pack: https://github.com/blish-hud/Community-Module-Pack/pull/3