### PR TITLE
Change to using PathableAttribute and PathableAttributeCollection instead of XmlElement and XmlAttribute.

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -239,6 +239,9 @@
     <Compile Include="Pathing\Behaviors\Title.cs" />
     <Compile Include="Pathing\Content\PathableResourceManager.cs" />
     <Compile Include="Pathing\Entities\Effects\MarkerEffect.cs" />
+    <Compile Include="Pathing\Entities\Effects\ScrollingTrailEffect.cs" />
+    <Compile Include="Pathing\PathableAttribute.cs" />
+    <Compile Include="Pathing\PathableAttributeCollection.cs" />
     <Compile Include="_Utils\DirectoryUtil.cs" />
     <Compile Include="_Utils\InvariantUtil.cs" />
     <Compile Include="_Utils\MouseInterceptor.cs" />

--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -239,7 +239,6 @@
     <Compile Include="Pathing\Behaviors\Title.cs" />
     <Compile Include="Pathing\Content\PathableResourceManager.cs" />
     <Compile Include="Pathing\Entities\Effects\MarkerEffect.cs" />
-    <Compile Include="Pathing\Entities\Effects\ScrollingTrailEffect.cs" />
     <Compile Include="Pathing\PathableAttribute.cs" />
     <Compile Include="Pathing\PathableAttributeCollection.cs" />
     <Compile Include="_Utils\DirectoryUtil.cs" />

--- a/Blish HUD/GameServices/PersistentStoreService.cs
+++ b/Blish HUD/GameServices/PersistentStoreService.cs
@@ -78,12 +78,15 @@ namespace Blish_HUD {
         }
 
         public void Save() {
-            string rawStore = JsonConvert.SerializeObject(_stores, Formatting.None, _jsonSettings);
-
             try {
+                string rawStore = JsonConvert.SerializeObject(_stores, Formatting.None, _jsonSettings);
+
                 using (var settingsWriter = new StreamWriter(_persistentStorePath, false)) {
                     settingsWriter.Write(rawStore);
                 }
+            } catch (InvalidOperationException e) {
+                // Likely that the collection was modified while we were attempting to serialize the stores
+                Logger.Warn(e, "Failed to save persistent store.");
             } catch (Exception e) {
                 Logger.Warn(e, "Failed to write persistent store to file!");
             }

--- a/Blish HUD/Pathing/Behaviors/Bounce.cs
+++ b/Blish HUD/Pathing/Behaviors/Bounce.cs
@@ -128,7 +128,7 @@ namespace Blish_HUD.Pathing.Behaviors {
                                                             .Ease(Ease.BounceOut);
         }
 
-        public void LoadWithAttributes(IEnumerable<XmlAttribute> attributes) {
+        public void LoadWithAttributes(IEnumerable<PathableAttribute> attributes) {
             float fOut;
 
             foreach (var attr in attributes) {

--- a/Blish HUD/Pathing/Behaviors/Copy.cs
+++ b/Blish HUD/Pathing/Behaviors/Copy.cs
@@ -25,7 +25,7 @@ namespace Blish_HUD.Pathing.Behaviors {
             };
         }
 
-        public void LoadWithAttributes(IEnumerable<XmlAttribute> attributes) {
+        public void LoadWithAttributes(IEnumerable<PathableAttribute> attributes) {
             foreach (var attr in attributes) {
                 switch (attr.Name.ToLower()) {
                     case "copy":

--- a/Blish HUD/Pathing/Behaviors/ILoadableBehavior.cs
+++ b/Blish HUD/Pathing/Behaviors/ILoadableBehavior.cs
@@ -4,7 +4,7 @@ using System.Xml;
 namespace Blish_HUD.Pathing.Behaviors {
     public interface ILoadableBehavior {
 
-        void LoadWithAttributes(IEnumerable<XmlAttribute> attributes);
+        void LoadWithAttributes(IEnumerable<PathableAttribute> attributes);
 
         void Load();
 

--- a/Blish HUD/Pathing/Behaviors/Mesh.cs
+++ b/Blish HUD/Pathing/Behaviors/Mesh.cs
@@ -35,7 +35,7 @@ namespace Blish_HUD.Pathing.Behaviors {
         private string _meshName = string.Empty;
 
         /// <inheritdoc />
-        public void LoadWithAttributes(IEnumerable<XmlAttribute> attributes) {
+        public void LoadWithAttributes(IEnumerable<PathableAttribute> attributes) {
             foreach (var attr in attributes) {
                 switch (attr.Name.ToLower()) {
                     case "mesh":

--- a/Blish HUD/Pathing/Behaviors/Notification.cs
+++ b/Blish HUD/Pathing/Behaviors/Notification.cs
@@ -64,7 +64,7 @@ namespace Blish_HUD.Pathing.Behaviors {
         }
 
         /// <inheritdoc />
-        public void LoadWithAttributes(IEnumerable<XmlAttribute> attributes) {
+        public void LoadWithAttributes(IEnumerable<PathableAttribute> attributes) {
             foreach (var attr in attributes) {
                 switch (attr.Name.ToLower()) {
                     case "notification":

--- a/Blish HUD/Pathing/Behaviors/Rotate.cs
+++ b/Blish HUD/Pathing/Behaviors/Rotate.cs
@@ -32,7 +32,7 @@ namespace Blish_HUD.Pathing.Behaviors {
 
         public Rotate(TPathable managedPathable) : base(managedPathable) { }
 
-        public void LoadWithAttributes(IEnumerable<XmlAttribute> attributes) {
+        public void LoadWithAttributes(IEnumerable<PathableAttribute> attributes) {
             float rotateX = 0f;
             float rotateY = 0f;
             float rotateZ = 0f;

--- a/Blish HUD/Pathing/Behaviors/Title.cs
+++ b/Blish HUD/Pathing/Behaviors/Title.cs
@@ -27,7 +27,7 @@ namespace Blish_HUD.Pathing.Behaviors {
 
         public Title(TPathable managedPathable) : base(managedPathable) { }
 
-        public void LoadWithAttributes(IEnumerable<XmlAttribute> attributes) {
+        public void LoadWithAttributes(IEnumerable<PathableAttribute> attributes) {
             bool colorSet = false;
 
             foreach (var attr in attributes) {

--- a/Blish HUD/Pathing/Format/LoadedMarkerPathable.cs
+++ b/Blish HUD/Pathing/Format/LoadedMarkerPathable.cs
@@ -11,13 +11,13 @@ namespace Blish_HUD.Pathing.Format {
 
     public class LoadedPathableAttributeDescription {
 
-        public Func<XmlAttribute, bool> LoadAttributeFunc { get; }
+        public Func<PathableAttribute, bool> LoadAttributeFunc { get; }
 
         public bool Required { get; }
 
         public bool Loaded { get; set; }
 
-        public LoadedPathableAttributeDescription(Func<XmlAttribute, bool> loadAttributeFunc, bool required) {
+        public LoadedPathableAttributeDescription(Func<PathableAttribute, bool> loadAttributeFunc, bool required) {
             this.LoadAttributeFunc = loadAttributeFunc;
             this.Required = required;
             this.Loaded = false;
@@ -78,7 +78,7 @@ namespace Blish_HUD.Pathing.Format {
             base.PrepareAttributes();
 
             // IMarker:MinimumSize
-            RegisterAttribute("minSize", delegate (XmlAttribute attribute) {
+            RegisterAttribute("minSize", delegate (PathableAttribute attribute) {
                 if (!InvariantUtil.TryParseFloat(attribute.Value, out float fOut)) return false;
 
                 this.MinimumSize = fOut;
@@ -86,7 +86,7 @@ namespace Blish_HUD.Pathing.Format {
             });
 
             // IMarker:MaximumSize
-            RegisterAttribute("maxSize", delegate (XmlAttribute attribute) {
+            RegisterAttribute("maxSize", delegate (PathableAttribute attribute) {
                 if (!InvariantUtil.TryParseFloat(attribute.Value, out float fOut)) return false;
 
                 this.MaximumSize = fOut;
@@ -94,7 +94,7 @@ namespace Blish_HUD.Pathing.Format {
             });
 
             // IMarker:Icon
-            RegisterAttribute("iconFile", delegate (XmlAttribute attribute) {
+            RegisterAttribute("iconFile", delegate (PathableAttribute attribute) {
                 if (!string.IsNullOrEmpty(attribute.Value)) {
                     this.IconReferencePath = attribute.Value.Trim();
 

--- a/Blish HUD/Pathing/Format/LoadedTrailPathable.cs
+++ b/Blish HUD/Pathing/Format/LoadedTrailPathable.cs
@@ -41,7 +41,7 @@ namespace Blish_HUD.Pathing.Format {
             base.PrepareAttributes();
 
             // ITrail:Texture
-            RegisterAttribute("texture", delegate(XmlAttribute attribute) {
+            RegisterAttribute("texture", delegate(PathableAttribute attribute) {
                                   if (!string.IsNullOrEmpty(attribute.Value)) {
                                       this.TextureReferencePath = attribute.Value.Trim();
 

--- a/Blish HUD/Pathing/PathableAttribute.cs
+++ b/Blish HUD/Pathing/PathableAttribute.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blish_HUD.Pathing {
+    /// <summary>
+    /// Represents a content-type agnostic name/value pairing.
+    /// </summary>
+    public struct PathableAttribute {
+
+        private readonly string _name;
+        private readonly string _value;
+
+        /// <summary>
+        /// The name of the attribute.
+        /// </summary>
+        public string Name => _name;
+
+        /// <summary>
+        /// The value of the attribute.
+        /// </summary>
+        public string Value => _value;
+
+        public PathableAttribute(string name, string value) {
+            _name  = name;
+            _value = value;
+        }
+
+        /// <inheritdoc />
+        public override string ToString() {
+            return $"{_name}={_value}";
+        }
+
+    }
+}

--- a/Blish HUD/Pathing/PathableAttributeCollection.cs
+++ b/Blish HUD/Pathing/PathableAttributeCollection.cs
@@ -10,7 +10,7 @@ namespace Blish_HUD.Pathing {
     /// <summary>
     /// A collection of <see cref="PathableAttribute"/>.
     /// </summary>
-    public class PathableAttributeCollection : KeyedCollection<string, PathableAttribute> {
+    public sealed class PathableAttributeCollection : KeyedCollection<string, PathableAttribute> {
 
         public PathableAttributeCollection() : base(StringComparer.OrdinalIgnoreCase) { /* NOOP */ }
 
@@ -22,12 +22,27 @@ namespace Blish_HUD.Pathing {
             this.AddRange(attributeCollection);
         }
 
-        public void SetOrUpdateAttributes(PathableAttributeCollection attributes) {
-            foreach (var newAttribute in attributes) {
-                if (this.Contains(newAttribute.Name)) {
-                    this.Remove(newAttribute.Name);
-                }
-                this.Add(newAttribute);
+        /// <summary>
+        /// If an attribute with the provided <param name="attribute"></param>s
+        /// name already exists, it is replaced with the provided attribute.
+        /// Otherwise, the attribute is added to the collection.
+        /// </summary>
+        /// <param name="attribute">The attribute to update or insert into the collection.</param>
+        public void AddOrUpdateAttribute(PathableAttribute attribute) {
+            if (this.Contains(attribute.Name)) {
+                this.Remove(attribute.Name);
+            }
+            this.Add(attribute);
+        }
+
+        /// <summary>
+        /// Calls <see cref="AddOrUpdateAttribute"/> on each of the provided attributes
+        /// in <param name="attributes"></param>.
+        /// </summary>
+        /// <param name="attributes">The <see cref="PathableAttribute"/>s to add to the collection.</param>
+        public void AddOrUpdateAttributes(IEnumerable<PathableAttribute> attributes) {
+            foreach (var attribute in attributes) {
+                AddOrUpdateAttribute(attribute);
             }
         }
 

--- a/Blish HUD/Pathing/PathableAttributeCollection.cs
+++ b/Blish HUD/Pathing/PathableAttributeCollection.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Scripting.Utils;
+
+namespace Blish_HUD.Pathing {
+    /// <summary>
+    /// A collection of <see cref="PathableAttribute"/>.
+    /// </summary>
+    public class PathableAttributeCollection : KeyedCollection<string, PathableAttribute> {
+
+        public PathableAttributeCollection() : base(StringComparer.OrdinalIgnoreCase) { /* NOOP */ }
+
+        /// <summary>
+        /// Create a <see cref="PathableAttributeCollection"/> from an existing <see cref="IEnumerable{PathableAttribute}"/>.
+        /// </summary>
+        /// <param name="attributeCollection"></param>
+        public PathableAttributeCollection(IEnumerable<PathableAttribute> attributeCollection) : base(StringComparer.OrdinalIgnoreCase) {
+            this.AddRange(attributeCollection);
+        }
+
+        public void SetOrUpdateAttributes(PathableAttributeCollection attributes) {
+            foreach (var newAttribute in attributes) {
+                if (this.Contains(newAttribute.Name)) {
+                    this.Remove(newAttribute.Name);
+                }
+                this.Add(newAttribute);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override string GetKeyForItem(PathableAttribute item) => item.Name;
+
+        /// <inheritdoc />
+        public override string ToString() {
+            return string.Join(", ", this);
+        }
+
+    }
+}


### PR DESCRIPTION
This takes care of #74 

This is a breaking change for the Markers & Paths module (PR which has solution: https://github.com/blish-hud/Community-Module-Pack/pull/11).