### PR TITLE
Fixed the ContextMenuStrip bug, a minor issue with PathableAttributeCollection, and removed the duplicate CornerIcon for Pathing.

### DIFF
--- a/Blish HUD/Controls/ContextMenuStrip.cs
+++ b/Blish HUD/Controls/ContextMenuStrip.cs
@@ -13,7 +13,7 @@ namespace Blish_HUD.Controls {
 
         private const int BORDER_PADDING = 2;
 
-        private const int ITEM_WIDTH          = 160;
+        private const int ITEM_WIDTH          = 135;
         private const int ITEM_HEIGHT         = 22;
         private const int ITEM_VERTICALMARGIN = 6;
 

--- a/Blish HUD/Controls/ContextMenuStrip.cs
+++ b/Blish HUD/Controls/ContextMenuStrip.cs
@@ -33,13 +33,14 @@ namespace Blish_HUD.Controls {
             this.Visible = false;
             this.Width = CONTROL_WIDTH;
             this.ZIndex = Screen.CONTEXTMENU_BASEINDEX;
-            this.Parent = GameService.Graphics.SpriteScreen;
 
-            Input.LeftMouseButtonPressed += MouseButtonPressed;
+            Input.LeftMouseButtonPressed  += MouseButtonPressed;
             Input.RightMouseButtonPressed += MouseButtonPressed;
         }
 
         protected override void OnShown(EventArgs e) {
+            this.Parent = GameService.Graphics.SpriteScreen;
+
             // If we have no children, don't display (and don't even call 'Shown' event)
             if (!_children.Any()) {
                 this.Visible = false;
@@ -47,6 +48,13 @@ namespace Blish_HUD.Controls {
             }
             
             base.OnShown(e);
+        }
+
+        /// <inheritdoc />
+        protected override void OnHidden(EventArgs e) {
+            this.Parent = null;
+
+            base.OnHidden(e);
         }
 
         public void Show(Point position) {
@@ -112,7 +120,6 @@ namespace Blish_HUD.Controls {
                 }
 
                 newChild.Height = ITEM_HEIGHT;
-                newChild.Left = BORDER_PADDING;
 
                 newChild.MouseEntered += ChildOnMouseEntered;
                 newChild.Resized      += ChildOnResized;
@@ -122,14 +129,6 @@ namespace Blish_HUD.Controls {
             }
 
             this.Invalidate();
-
-            int lastBottom = -4;
-            e.ResultingChildren.Where(c => c.Visible).ToList().ForEach(child => {
-                                            child.Top = lastBottom + ITEM_VERTICALMARGIN;
-                                            lastBottom = child.Bottom;
-            });
-
-            this.Height = lastBottom + BORDER_PADDING;
         }
 
         private void ChildOnMouseEntered(object sender, MouseEventArgs e) {
@@ -149,27 +148,34 @@ namespace Blish_HUD.Controls {
 
         public override void RecalculateLayout() {
             if (_children.Any()) {
-                int maxChildWidth = Math.Max(_children.Where(c => c.Visible).Max(c => c.Width), CONTROL_WIDTH);
+                int maxChildWidth = CONTROL_WIDTH;
 
-                this.Width = maxChildWidth + BORDER_PADDING * 2;
+                int lastChildBottom = BORDER_PADDING - ITEM_VERTICALMARGIN;
+
+                foreach (var menuItem in _children.Where(c => c.Visible)) {
+                    maxChildWidth = Math.Max(menuItem.Width, maxChildWidth);
+
+                    menuItem.Location = new Point(BORDER_PADDING, lastChildBottom + ITEM_VERTICALMARGIN);
+
+                    lastChildBottom = menuItem.Bottom;
+                }
+
+                _size = new Point(maxChildWidth   + BORDER_PADDING * 2,
+                                  lastChildBottom + BORDER_PADDING);
 
                 foreach (var childItem in this.Children) {
                     childItem.Width = maxChildWidth;
                 }
-            } else {
-                this.Width = CONTROL_WIDTH + BORDER_PADDING * 2;
             }
         }
 
         public override void PaintBeforeChildren(SpriteBatch spriteBatch, Rectangle bounds) {
             spriteBatch.DrawOnCtrl(this,
                                    ContentService.Textures.Pixel,
-                                   new Rectangle(
-                                                 BORDER_PADDING,
+                                   new Rectangle(BORDER_PADDING,
                                                  BORDER_PADDING,
                                                  _size.X - BORDER_PADDING * 2,
-                                                 _size.Y - BORDER_PADDING * 2
-                                                ),
+                                                 _size.Y - BORDER_PADDING * 2),
                                    Color.FromNonPremultiplied(33, 32, 33, 255));
 
             // Left line

--- a/Blish HUD/Controls/ContextMenuStripItem.cs
+++ b/Blish HUD/Controls/ContextMenuStripItem.cs
@@ -31,8 +31,6 @@ namespace Blish_HUD.Controls {
             this.CheckedChanged?.Invoke(this, e);
         }
 
-        private BitmapFont _font = GameService.Content.DefaultFont14;
-
         private string _text;
         public string Text {
             get => _text;
@@ -66,7 +64,7 @@ namespace Blish_HUD.Controls {
         }
 
         public override void RecalculateLayout() {
-            var textSize = _font.MeasureString(_text);
+            var textSize = GameService.Content.DefaultFont14.MeasureString(_text);
             int nWidth   = (int)textSize.Width + TEXT_LEFTPADDING + TEXT_LEFTPADDING;
 
             if (this.Parent != null) {

--- a/Blish HUD/GameServices/PathingService.cs
+++ b/Blish HUD/GameServices/PathingService.cs
@@ -36,27 +36,7 @@ namespace Blish_HUD {
         }
 
         protected override void Load() {
-           BuildCornerIcon();
-        }
-
-        public CornerIcon Icon;
-        public ContextMenuStrip IconContextMenu;
-
-        private Panel BuildCornerIcon() {
-            Icon = new CornerIcon() {
-                BasicTooltipText = "Pathing",
-                Icon             = Content.GetTexture("marker-pathing-icon"),
-                Parent           = Graphics.SpriteScreen,
-                Priority         = Int32.MaxValue - 1,
-            };
-
-            IconContextMenu = new ContextMenuStrip();
-
-            Icon.Click += delegate {
-                IconContextMenu.Show(Icon);
-            };
-
-            return null;
+           /* NOOP */
         }
 
         private void ProcessPathableState(IPathable<Entity> pathable) {

--- a/Blish HUD/Pathing/PathableAttributeCollection.cs
+++ b/Blish HUD/Pathing/PathableAttributeCollection.cs
@@ -19,7 +19,7 @@ namespace Blish_HUD.Pathing {
         /// </summary>
         /// <param name="attributeCollection"></param>
         public PathableAttributeCollection(IEnumerable<PathableAttribute> attributeCollection) : base(StringComparer.OrdinalIgnoreCase) {
-            this.AddRange(attributeCollection);
+            this.AddRange(attributeCollection.GroupBy(a => a.Name).Select(g => g.Last()));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed the `ContextMenuStrip` (#77):
- Fixed the default width of the control to match the in-game default width.
- Removed a font reference that wasn't really being used.
- Ensured that the ContextMenuStrip's height and width were recalculated when items were added or removed.
- Previously the `ContextMenuStrip` was parented to the `SpriteScreen` and just left with it not visible. This was hurting performance when a large number of menus were added.  These are now automatically added to the `SpriteScreen` when shown and automatically unparented when hidden.

Fixed bug with `PathableAttributeCollection`:
- Some modules define the same attribute more than once in a single XML element.
- We checked for this when adding to an existing collection, but not when we instanced it.
- These changes now ensure that only the last attribute defined is kept, if there are duplicates provided when the collection is first instanced.

Removed the duplicate `CornerIcon` from the `PathingService` (#2):
- Ownership of this icon has now been moved to the Markers and Paths module.