### PR TITLE
Changed RasterizerState to CullNone

### DIFF
--- a/Blish HUD/Entities/World.cs
+++ b/Blish HUD/Entities/World.cs
@@ -37,7 +37,7 @@ namespace Blish_HUD.Entities {
             graphicsDevice.BlendState        = BlendState.AlphaBlend;
             graphicsDevice.DepthStencilState = DepthStencilState.DepthRead;
             graphicsDevice.SamplerStates[0]  = SamplerState.LinearWrap;
-            graphicsDevice.RasterizerState   = RasterizerState.CullCounterClockwise;
+            graphicsDevice.RasterizerState   = RasterizerState.CullNone;
 
             foreach (var entity in _sortedEntities.Where(entity => entity.Visible)) {
                 entity.DoDraw(graphicsDevice);


### PR DESCRIPTION
Changed RasterizerState to CullNone to allow viewing trails from under or behind. Fixes #79 