### PR TITLE
Fix default trail width.

### DIFF
--- a/Blish HUD/Pathing/Entities/ScrollingTrail.cs
+++ b/Blish HUD/Pathing/Entities/ScrollingTrail.cs
@@ -7,8 +7,7 @@ using Texture2D = Microsoft.Xna.Framework.Graphics.Texture2D;
 namespace Blish_HUD.Pathing.Entities {
     public class ScrollingTrail : Trail, ITrail {
 
-
-        public const float TRAIL_WIDTH = 40 * 0.0254f;
+        public const float TRAIL_WIDTH = 20 * 0.0254f;
 
         private float _animationSpeed = 1;
 


### PR DESCRIPTION
TacO has a trail width of 40.  I mistakenly was setting ours to 40 on either side of the center line (doubling the width).

Fixes #92 