### PR TITLE
couple of control fixes.

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -245,6 +245,7 @@
     <Compile Include="GameServices\Pathing\PathableAttributeCollection.cs" />
     <Compile Include="_Utils\DirectoryUtil.cs" />
     <Compile Include="_Utils\InvariantUtil.cs" />
+    <Compile Include="_Utils\LoadingSpinnerUtil.cs" />
     <Compile Include="_Utils\MouseInterceptor.cs" />
     <Compile Include="_Utils\StringUtil.cs" />
     <Compile Include="_Utils\VectorUtil.cs" />

--- a/Blish HUD/Controls/Container.cs
+++ b/Blish HUD/Controls/Container.cs
@@ -22,7 +22,8 @@ namespace Blish_HUD.Controls {
 
         public event EventHandler<RegionChangedEventArgs> ContentResized;
 
-        protected readonly List<Control> _children;
+        protected List<Control> _children;
+
         [Newtonsoft.Json.JsonIgnore]
         public IReadOnlyCollection<Control> Children => _children.AsReadOnly();
 
@@ -124,6 +125,16 @@ namespace Blish_HUD.Controls {
             }
 
             return allDescendants;
+        }
+
+        public void ClearChildren() {
+            Control[] oldChildren = _children.ToArray();
+
+            _children = new List<Control>();
+
+            for (int i = 0; i < oldChildren.Length; i++) {
+                oldChildren[i].Parent = null;
+            }
         }
 
         public override Control TriggerMouseInput(MouseEventType mouseEventType, MouseState ms) {

--- a/Blish HUD/Controls/Container.cs
+++ b/Blish HUD/Controls/Container.cs
@@ -14,16 +14,15 @@ namespace Blish_HUD.Controls {
     /// <summary>
     /// A control that is capable of having child controls that are drawn when the container is drawn.
     /// Classes that inherit should be packaged controls that that manage their own controls internally.
-    /// For a Container with accessible children for non-packaged controls, use <see cref="AccessibleContainer"/>.
     /// </summary>
-    public abstract class Container:Control, IEnumerable<Control> {
+    public abstract class Container : Control, IEnumerable<Control> {
 
         public event EventHandler<ChildChangedEventArgs> ChildAdded;
         public event EventHandler<ChildChangedEventArgs> ChildRemoved;
 
         public event EventHandler<RegionChangedEventArgs> ContentResized;
 
-        protected List<Control> _children;
+        protected readonly List<Control> _children;
         [Newtonsoft.Json.JsonIgnore]
         public IReadOnlyCollection<Control> Children => _children.AsReadOnly();
 
@@ -49,8 +48,9 @@ namespace Blish_HUD.Controls {
             /* ContentRegion defaults to match our control size until one is manually set,
                so we do squeeze in OnPropertyChanged for it if the control hasn't had a
                ContentRegion specified and then resizes */
-            if (!_contentRegion.HasValue)
+            if (!_contentRegion.HasValue) {
                 OnPropertyChanged(nameof(this.ContentRegion));
+            }
         }
 
         public bool AddChild(Control child) {
@@ -90,7 +90,7 @@ namespace Blish_HUD.Controls {
             return true;
         }
 
-        private Rectangle? _contentRegion;
+        protected Rectangle? _contentRegion;
         public Rectangle ContentRegion {
             get => _contentRegion ?? new Rectangle(Point.Zero, this.Size);
             protected set {

--- a/Blish HUD/Controls/CornerIcon.cs
+++ b/Blish HUD/Controls/CornerIcon.cs
@@ -7,7 +7,7 @@ using Blish_HUD.Content;
 using Blish_HUD.Input;
 
 namespace Blish_HUD.Controls {
-    public class CornerIcon : Container {
+    public class CornerIcon : Control {
 
         private static int _leftOffset = 0;
         public static int LeftOffset {
@@ -20,21 +20,11 @@ namespace Blish_HUD.Controls {
             }
         }
 
+        private static ObservableCollection<CornerIcon> CornerIcons { get; }
+
         private const int   ICON_POSITION = 10;
         private const int   ICON_SIZE     = 32;
         private const float ICON_TRANS    = 0.4f;
-
-        private AsyncTexture2D _icon;
-        public AsyncTexture2D Icon {
-            get => _icon;
-            set => SetProperty(ref _icon, value);
-        }
-
-        private AsyncTexture2D _hoverIcon;
-        public AsyncTexture2D HoverIcon {
-            get => _hoverIcon;
-            set => SetProperty(ref _hoverIcon, value);
-        }
         
         private float _hoverTrans = ICON_TRANS;
         public float HoverTrans {
@@ -52,10 +42,34 @@ namespace Blish_HUD.Controls {
             }
         }
 
-        private static ObservableCollection<CornerIcon> CornerIcons { get; }
+        private AsyncTexture2D _icon;
+        /// <summary>
+        /// The icon shown when the <see cref="CornerIcon"/> is not currently being hovered over.
+        /// </summary>
+        public AsyncTexture2D Icon {
+            get => _icon;
+            set => SetProperty(ref _icon, value);
+        }
+
+        private AsyncTexture2D _hoverIcon;
+        /// <summary>
+        /// The icon shown when the <see cref="CornerIcon"/> is hovered over.
+        /// </summary>
+        public AsyncTexture2D HoverIcon {
+            get => _hoverIcon;
+            set => SetProperty(ref _hoverIcon, value);
+        }
+
+        private string _iconName;
+        /// <summary>
+        /// The name of the <see cref="CornerIcon"/> that is shown when moused over.
+        /// </summary>
+        public string IconName {
+            get => _iconName;
+            set => SetProperty(ref _iconName, value);
+        }
 
         private int? _priority;
-
         /// <summary>
         /// <see cref="CornerIcon"/>s are sorted by priority so that, from left to right, priority goes from the highest to lowest.
         /// </summary>
@@ -69,9 +83,17 @@ namespace Blish_HUD.Controls {
         }
 
         private string _loadingMessage;
+        /// <summary>
+        /// If defined, a loading spinner is shown below the <see cref="CornerIcon"/> and this text will be
+        /// shown in a tooltip when the loading spinner is moused over.
+        /// </summary>
         public string LoadingMessage {
             get => _loadingMessage;
-            set => SetProperty(ref _loadingMessage, value, true);
+            set {
+                if (SetProperty(ref _loadingMessage, value, true) && _mouseOver) {
+                    this.BasicTooltipText = _loadingMessage;
+                }
+            }
         }
 
         static CornerIcon() {
@@ -105,18 +127,20 @@ namespace Blish_HUD.Controls {
             }
         }
 
-        private readonly LoadingSpinner _iconLoader;
         public CornerIcon() {
-            this.Parent        = Graphics.SpriteScreen;
-            this.Size          = new Point(ICON_SIZE, ICON_SIZE);
-            this.ContentRegion = new Rectangle(0, ICON_SIZE, ICON_SIZE, ICON_SIZE);
-
-            _iconLoader = new LoadingSpinner() {
-                Parent = this,
-                Size   = this.ContentRegion.Size,
-            };
+            this.Parent = Graphics.SpriteScreen;
+            this.Size   = new Point(ICON_SIZE, ICON_SIZE);
 
             CornerIcons.Add(this);
+        }
+
+        public CornerIcon(AsyncTexture2D icon, string iconName) : this() {
+            _icon     = icon;
+            _iconName = iconName;
+        }
+
+        public CornerIcon(AsyncTexture2D icon, AsyncTexture2D hoverIcon, string iconName) : this(icon, iconName) {
+            _hoverIcon = hoverIcon;
         }
 
         /// <inheritdoc />
@@ -132,26 +156,41 @@ namespace Blish_HUD.Controls {
         }
 
         private Rectangle _layoutIconBounds;
-        /// <inheritdoc />
 
+        private bool _isLoading = false;
+
+        /// <inheritdoc />
         public override void RecalculateLayout() {
             _layoutIconBounds = new Rectangle(0, 0, ICON_SIZE, ICON_SIZE);
 
-            bool isLoading = !string.IsNullOrEmpty(_loadingMessage);
-            this.Size = new Point(ICON_SIZE, isLoading ? ICON_SIZE * 2 : ICON_SIZE);
-            _iconLoader.Visible = isLoading;
-            _iconLoader.BasicTooltipText = _loadingMessage;
+            _isLoading = !string.IsNullOrEmpty(_loadingMessage);
+            _size = new Point(ICON_SIZE, _isLoading ? ICON_SIZE * 2 : ICON_SIZE);
+        }
+
+        /// <inheritdoc />
+        protected override void OnMouseMoved(MouseEventArgs e) {
+            if (_isLoading && _mouseOver && !_layoutIconBounds.Contains(this.RelativeMousePosition)) {
+                this.BasicTooltipText = _loadingMessage;
+            } else {
+                this.BasicTooltipText = _iconName;
+            }
+
+            base.OnMouseMoved(e);
         }
 
         // TODO: Use a shader to replace "HoverIcon"
         /// <inheritdoc />
-        public override void PaintBeforeChildren(SpriteBatch spriteBatch, Rectangle bounds) {
+        protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
             if (_icon == null) return;
 
             if (this.MouseOver && this.RelativeMousePosition.Y <= _layoutIconBounds.Bottom) {
                 spriteBatch.DrawOnCtrl(this, _hoverIcon ?? _icon, _layoutIconBounds);
             } else {
                 spriteBatch.DrawOnCtrl(this, _icon, _layoutIconBounds, Color.White * _hoverTrans);
+            }
+
+            if (_isLoading) {
+                LoadingSpinnerUtil.DrawLoadingSpinner(this, spriteBatch, new Rectangle(0, ICON_SIZE, ICON_SIZE, ICON_SIZE));
             }
         }
 

--- a/Blish HUD/Controls/CornerIcon.cs
+++ b/Blish HUD/Controls/CornerIcon.cs
@@ -22,6 +22,8 @@ namespace Blish_HUD.Controls {
 
         private static ObservableCollection<CornerIcon> CornerIcons { get; }
 
+        private static readonly Rectangle _standardIconBounds;
+
         private const int   ICON_POSITION = 10;
         private const int   ICON_SIZE     = 32;
         private const float ICON_TRANS    = 0.4f;
@@ -99,6 +101,8 @@ namespace Blish_HUD.Controls {
         static CornerIcon() {
             CornerIcons = new ObservableCollection<CornerIcon>();
 
+            _standardIconBounds = new Rectangle(0, 0, ICON_SIZE, ICON_SIZE);
+
             CornerIcons.CollectionChanged += delegate { UpdateCornerIconPositions(); };
 
             GameService.Input.MouseMoved += (sender, e) => {
@@ -155,21 +159,17 @@ namespace Blish_HUD.Controls {
             base.OnClick(e);
         }
 
-        private Rectangle _layoutIconBounds;
-
         private bool _isLoading = false;
 
         /// <inheritdoc />
         public override void RecalculateLayout() {
-            _layoutIconBounds = new Rectangle(0, 0, ICON_SIZE, ICON_SIZE);
-
             _isLoading = !string.IsNullOrEmpty(_loadingMessage);
             _size = new Point(ICON_SIZE, _isLoading ? ICON_SIZE * 2 : ICON_SIZE);
         }
 
         /// <inheritdoc />
         protected override void OnMouseMoved(MouseEventArgs e) {
-            if (_isLoading && _mouseOver && !_layoutIconBounds.Contains(this.RelativeMousePosition)) {
+            if (_isLoading && _mouseOver && !(this.RelativeMousePosition.Y < _standardIconBounds.Bottom)) {
                 this.BasicTooltipText = _loadingMessage;
             } else {
                 this.BasicTooltipText = _iconName;
@@ -183,10 +183,10 @@ namespace Blish_HUD.Controls {
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
             if (_icon == null) return;
 
-            if (this.MouseOver && this.RelativeMousePosition.Y <= _layoutIconBounds.Bottom) {
-                spriteBatch.DrawOnCtrl(this, _hoverIcon ?? _icon, _layoutIconBounds);
+            if (this.MouseOver && this.RelativeMousePosition.Y <= _standardIconBounds.Bottom) {
+                spriteBatch.DrawOnCtrl(this, _hoverIcon ?? _icon, _standardIconBounds);
             } else {
-                spriteBatch.DrawOnCtrl(this, _icon, _layoutIconBounds, Color.White * _hoverTrans);
+                spriteBatch.DrawOnCtrl(this, _icon, _standardIconBounds, Color.White * _hoverTrans);
             }
 
             if (_isLoading) {

--- a/Blish HUD/Controls/LoadingSpinner.cs
+++ b/Blish HUD/Controls/LoadingSpinner.cs
@@ -4,30 +4,14 @@ using Microsoft.Xna.Framework.Graphics;
 namespace Blish_HUD.Controls {
     public class LoadingSpinner : Control {
 
-        private const string DRAWATLAS = "spinner-atlas";
         private const int DRAWLENGTH = 64;
-
-        private Rectangle _activeAtlasRegion = new Rectangle(0, 416, 256, 32);
-
-        public int Rotation { get; set; } = 0;
 
         public LoadingSpinner() {
             this.Size = new Point(DRAWLENGTH, DRAWLENGTH);
-
-            Animation.Tweener.Tween(this, new { Rotation = 64 }, 3).Repeat().Round();
-        }
-
-        public override void DoUpdate(GameTime gameTime) {
-            _activeAtlasRegion = new Rectangle(DRAWLENGTH * this.Rotation, 0, DRAWLENGTH, DRAWLENGTH);
-        }
-
-        protected override CaptureType CapturesInput() {
-            return CaptureType.Mouse;
         }
 
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
-            // TODO: Add this texture in with the rest of the UI elements in the ControlUI atlas
-            spriteBatch.DrawOnCtrl(this, Content.GetTexture(DRAWATLAS), bounds, _activeAtlasRegion);
+            LoadingSpinnerUtil.DrawLoadingSpinner(this, spriteBatch, bounds);
         }
 
     }

--- a/Blish HUD/Controls/Menu.cs
+++ b/Blish HUD/Controls/Menu.cs
@@ -100,10 +100,6 @@ namespace Blish_HUD.Controls {
 
             newChild.MenuItemHeight = this.MenuItemHeight;
 
-            // Ensure child items remains the same width as us
-            //Adhesive.Binding.CreateOneWayBinding(() => e.ChangedChild.Width,
-            //                                     () => this.Width, applyLeft: true);
-
             // We'll bind the top of the control to the bottom of the last control we added
             var lastItem = _children.LastOrDefault();
             if (lastItem != null) {
@@ -128,24 +124,24 @@ namespace Blish_HUD.Controls {
         }
 
         public override void UpdateContainer(GameTime gameTime) {
-            int totalItemHeight = _children.Where(c => c.Visible).Max(c => c.Bottom);
+            int totalItemHeight = 0;
+
+            for (int i = 0; i < _children.Count; i++) {
+                totalItemHeight = Math.Max(_children[i].Bottom, totalItemHeight);
+            }
 
             this.Height = totalItemHeight;
         }
 
         public override void PaintBeforeChildren(SpriteBatch spriteBatch, Rectangle bounds) {
             // Draw items dark every other one
-            int totalItemHeight = _children.Where(c => c.Visible).Max(c => c.Bottom);
-
-            for (int sec = 0; sec < totalItemHeight / MenuItemHeight; sec += 2) {
+            for (int sec = 0; sec < _size.Y / MenuItemHeight; sec += 2) {
                 spriteBatch.DrawOnCtrl(this,
                                        _textureMenuItemFade,
-                                       new Rectangle(
-                                                     0,
+                                       new Rectangle(0,
                                                      MenuItemHeight * sec - VerticalScrollOffset,
                                                      _size.X,
-                                                     MenuItemHeight
-                                                    ),
+                                                     MenuItemHeight),
                                        Color.Black * 0.7f);
             }
         }

--- a/Blish HUD/Controls/Menu.cs
+++ b/Blish HUD/Controls/Menu.cs
@@ -110,7 +110,7 @@ namespace Blish_HUD.Controls {
             ShouldShift = e.ResultingChildren.Any(mi => {
                                                       MenuItem cmi = (MenuItem) mi;
 
-                                                      return cmi.CanCheck || cmi.Icon != null || cmi.Children.Any() ;
+                                                      return cmi.CanCheck || cmi.Icon != null || cmi.Children.Any();
                                                   });
 
             base.OnChildAdded(e);

--- a/Blish HUD/Controls/TabbedWindow.cs
+++ b/Blish HUD/Controls/TabbedWindow.cs
@@ -10,13 +10,13 @@ namespace Blish_HUD.Controls {
 
     public class TabbedWindow : WindowBase {
 
-        private const int TAB_HEIGHT = 52;
-        private const int TAB_WIDTH = 104;
+        private const int TAB_HEIGHT    = 52;
+        private const int TAB_WIDTH     = 104;
         private const int TAB_ICON_SIZE = 32;
 
         private const int TAB_SECTION_WIDTH = 46;
 
-        private const int WINDOWCONTENT_WIDTH = 1024;
+        private const int WINDOWCONTENT_WIDTH  = 1024;
         private const int WINDOWCONTENT_HEIGHT = 700;
 
         #region Load Static
@@ -39,7 +39,7 @@ namespace Blish_HUD.Controls {
 
         public event EventHandler<EventArgs> TabChanged;
 
-        protected int _selectedTabIndex = -1;
+        protected int _selectedTabIndex = 0;
         public int SelectedTabIndex {
             get => _selectedTabIndex;
             set {
@@ -49,7 +49,7 @@ namespace Blish_HUD.Controls {
             }
         }
 
-        public WindowTab SelectedTab => Tabs[_selectedTabIndex];
+        public WindowTab SelectedTab => Tabs.Count > _selectedTabIndex ? Tabs[_selectedTabIndex] : null;
 
         private int _hoveredTabIndex = 0;
         private int HoveredTabIndex {
@@ -63,7 +63,7 @@ namespace Blish_HUD.Controls {
 
             this.ConstructWindow(tabWindowTexture, new Vector2(25, 33), new Rectangle(0, 0, 1100, 745), new Thickness(60, 75, 45, 25), 40);
 
-            ContentRegion = new Rectangle(TAB_WIDTH / 2, 48, WINDOWCONTENT_WIDTH, WINDOWCONTENT_HEIGHT);
+            _contentRegion = new Rectangle(TAB_WIDTH / 2, 48, WINDOWCONTENT_WIDTH, WINDOWCONTENT_HEIGHT);
         }
 
         protected virtual void OnTabChanged(EventArgs e) {
@@ -222,27 +222,30 @@ namespace Blish_HUD.Controls {
         public override void RecalculateLayout() {
             base.RecalculateLayout();
 
-            var firstTabBounds = TabBoundsFromIndex(0);
-            var selectedTabBounds = TabRegions[this.SelectedTab];
-            var lastTabBounds = TabBoundsFromIndex(TabRegions.Count - 1);
+            if (this.Tabs.Count == 0) return;
 
-            _layoutTopTabBarBounds = new Rectangle(0, 0, TAB_SECTION_WIDTH, firstTabBounds.Top);
+            var firstTabBounds    = TabBoundsFromIndex(0);
+            var selectedTabBounds = TabRegions[this.SelectedTab];
+            var lastTabBounds     = TabBoundsFromIndex(TabRegions.Count - 1);
+
+            _layoutTopTabBarBounds    = new Rectangle(0, 0,                    TAB_SECTION_WIDTH, firstTabBounds.Top);
             _layoutBottomTabBarBounds = new Rectangle(0, lastTabBounds.Bottom, TAB_SECTION_WIDTH, _size.Y - lastTabBounds.Bottom);
 
-            int topSplitHeight = selectedTabBounds.Top - ContentRegion.Top;
-            int bottomSplitHeight = ContentRegion.Bottom - selectedTabBounds.Bottom;
+            int topSplitHeight    = selectedTabBounds.Top - ContentRegion.Top;
+            int bottomSplitHeight = ContentRegion.Bottom  - selectedTabBounds.Bottom;
 
             _layoutTopSplitLineBounds = new Rectangle(ContentRegion.X - _textureSplitLine.Width + 1,
                                                       ContentRegion.Y,
                                                       _textureSplitLine.Width,
                                                       topSplitHeight);
-            _layoutTopSplitLineSourceBounds = new Rectangle(0, 0, _textureSplitLine.Width, topSplitHeight);
 
+            _layoutTopSplitLineSourceBounds = new Rectangle(0, 0, _textureSplitLine.Width, topSplitHeight);
 
             _layoutBottomSplitLineBounds = new Rectangle(ContentRegion.X - _textureSplitLine.Width + 1,
                                                          selectedTabBounds.Bottom,
                                                          _textureSplitLine.Width,
                                                          bottomSplitHeight);
+
             _layoutBottomSplitLineSourceBounds = new Rectangle(0, _textureSplitLine.Height - bottomSplitHeight, _textureSplitLine.Width, bottomSplitHeight);
         }
 

--- a/Blish HUD/Controls/WindowTab.cs
+++ b/Blish HUD/Controls/WindowTab.cs
@@ -3,7 +3,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Blish_HUD.Controls {
 
-    public struct WindowTab {
+    public class WindowTab {
         public string         Name     { get; set; }
         public AsyncTexture2D Icon     { get; set; }
         public int            Priority { get; set; }

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -21,6 +21,9 @@ namespace Blish_HUD {
         public CornerIcon BlishMenuIcon { get; protected set; }
         public ContextMenuStrip BlishContextMenu { get; protected set; }
 
+        private GameTime _currentGameTime;
+        public GameTime CurrentGameTime => _currentGameTime;
+
         private SettingEntry<Gw2Locale> _userLocale;
         private SettingEntry<bool> _stayInTray;
 
@@ -157,6 +160,8 @@ namespace Blish_HUD {
         }
 
         protected override void Update(GameTime gameTime) {
+            _currentGameTime = gameTime;
+
             HandleEnqueuedUpdates(gameTime);
 
             if (GameService.GameIntegration.IsInGame) {

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -75,13 +75,10 @@ namespace Blish_HUD {
         }
 
         protected override void Load() {
-            this.BlishMenuIcon = new CornerIcon() {
-                Icon             = Content.GetTexture("logo"),
-                HoverIcon        = Content.GetTexture("logo-big"),
-                Menu             = new ContextMenuStrip(),
-                BasicTooltipText = Properties.Strings.General_BlishHUD,
-                Priority         = int.MaxValue,
-                Parent           = Graphics.SpriteScreen,
+            this.BlishMenuIcon = new CornerIcon(Content.GetTexture("logo"), Content.GetTexture("logo-big"), Properties.Strings.General_BlishHUD) {
+                Menu     = new ContextMenuStrip(),
+                Priority = int.MaxValue,
+                Parent   = Graphics.SpriteScreen,
             };
 
             this.BlishContextMenu = this.BlishMenuIcon.Menu;

--- a/Blish HUD/_Utils/DrawUtil.cs
+++ b/Blish HUD/_Utils/DrawUtil.cs
@@ -44,6 +44,8 @@ namespace Blish_HUD {
 
         /// <remarks> Source: https://stackoverflow.com/a/15987581/595437 </remarks>
         public static string WrapText(BitmapFont spriteFont, string text, float maxLineWidth) {
+            if (string.IsNullOrEmpty(text)) return "";
+
             string[] words      = text.Split(' ');
             var      sb         = new StringBuilder();
             float    lineWidth  = 0f;

--- a/Blish HUD/_Utils/LoadingSpinnerUtil.cs
+++ b/Blish HUD/_Utils/LoadingSpinnerUtil.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Blish_HUD.Controls;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Blish_HUD {
+    public static class LoadingSpinnerUtil {
+
+        #region Load Static
+
+        private static readonly Texture2D _loadingSpinnerTexture;
+
+        static LoadingSpinnerUtil() {
+            _loadingSpinnerTexture = GameService.Content.GetTexture("spinner-atlas");
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Draws an animated loading spinner at the provided <param name="bounds">bounds</param>.
+        /// </summary>
+        /// <param name="control">The control the loading spinner will be drawn on.</param>
+        /// <param name="spriteBatch">The active spritebatch.</param>
+        /// <param name="bounds">The location to draw the loading spinner.</param>
+        public static void DrawLoadingSpinner(Control control, SpriteBatch spriteBatch, Rectangle bounds) {
+            spriteBatch.DrawOnCtrl(control,
+                                   _loadingSpinnerTexture,
+                                   bounds,
+                                   new Rectangle(((int)(GameService.Overlay.CurrentGameTime.TotalGameTime.TotalSeconds * (64f / 3f))) % 64 * 64, 0, 64, 64));
+        }
+
+    }
+}


### PR DESCRIPTION
- Minor fixes to `Container` control.
- Fixed error in `Menu` control that would throw exception if there were no `MenuItems` within it when calculating the height of the `Menu`.
- Fixed possible error in `TabbedWindow` control that could throw an exception if the window has no tabs before something tries to update or interact with the window.
- Fixed `StringUtil.WrapText()` from throwing an exception.
- Added `ClearChildren()` to `Container`s.
- Exposed `CurrentGameTime` through the `OverlayService`.
- Added new `LoadingSpinnerUtil.DrawLoadingSpinner()` and switched the `LoadingSpinner` to use the util.
- Changed `CornerIcon` to be a standard `Control` with `LoadingSpinner` rendered using `LoadingSpinnerUtil`.
- Updated `OverlayService` to define the `IconName` property on the `CornerIcon`.

The changes to the `CornerIcon` is a soft-breaking change as `BasicTooltipText` is no longer kept on `CornerIcon` (used to set the text shown when `CornerIcon` is hovered over).  `CornerIcon` now has `IconName` property which can be used to set this instead.  New constructors on the `CornerIcon` now allow for passing the `Icon`, `HoverIcon`, and also the `IconName`.