### PR TITLE
Static chat code service, changed IKeyboard

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -104,6 +104,7 @@
     <StartupObject>Blish_HUD.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="GameServices\Gw2ChatCodeService.cs" />
     <Compile Include="GameServices\Content\AsyncTexture2D.cs" />
     <Compile Include="Controls\BasicWindow.cs" />
     <Compile Include="Controls\Book.cs" />
@@ -254,7 +255,6 @@
     <Compile Include="_Enums\Gw2Profession.cs" />
     <Compile Include="_Enums\Gw2Race.cs" />
     <Compile Include="_Events\ValueChangedEventArgs[T].cs" />
-    <Compile Include="_Interfaces\IKeyboard.cs" />
     <Compile Include="Library\Glide\CustomLerpers\PointLerper.cs" />
     <Compile Include="GameServices\Modules\ManifestV1.cs" />
     <Compile Include="GameServices\Pathing\Behaviors\Copy.cs" />

--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -104,7 +104,7 @@
     <StartupObject>Blish_HUD.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="GameServices\Gw2ChatCodeService.cs" />
+    <Compile Include="Common\Gw2\ChatCode.cs" />
     <Compile Include="GameServices\Content\AsyncTexture2D.cs" />
     <Compile Include="Controls\BasicWindow.cs" />
     <Compile Include="Controls\Book.cs" />

--- a/Blish HUD/Common/Gw2/ChatCode.cs
+++ b/Blish HUD/Common/Gw2/ChatCode.cs
@@ -3,18 +3,11 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
-namespace Blish_HUD
+namespace Blish_HUD.Common.Gw2
 {
-    public class Gw2ChatCodeService : GameService
+    public static class ChatCode
     {
-        private static Logger Logger = Logger.GetLogger(typeof(Gw2ChatCodeService));
-        protected override void Initialize(){ /** NOOP **/ }
-
-        protected override void Load(){ /** NOOP **/ }
-
-        protected override void Unload(){ /** NOOP **/ }
-
-        protected override void Update(GameTime gameTime){ /** NOOP **/}
+        private static Logger Logger = Logger.GetLogger(typeof(ChatCode));
 
         /// <author>The original code was made in a JSFiddle by the GW2 Wikiuser Fam. Translation to C# by Andy</author>
         /// <seealso cref="https://jsfiddle.net/fffam/cg3njdu6/"/>
@@ -22,9 +15,9 @@ namespace Blish_HUD
         /// <summary>
         /// Decodes a Guild Wars 2 chat code.
         /// </summary>
-        /// <param name="fullcode">This needs to be the item code (i.e. from trading post or gw2spidy) not the wardrobe ID</param>
-        /// <returns>0 if invalid or item code</returns>
-        public static int DecodeChatCodeForItemOrSkin(string fullcode)
+        /// <param name="fullcode">This needs to be the item code or chat code (i.e. from trading post or gw2spidy) not the wardrobe ID</param>
+        /// <returns>Item ID or 0, if invalid.</returns>
+        public static int DecodeChatCode(string fullcode)
         {
             if (!Regex.IsMatch(fullcode, @"^\[\&")) {
                 return 0;
@@ -60,13 +53,13 @@ namespace Blish_HUD
         /// <summary>
         /// Generates a chat code with the given parameters.
         /// </summary>
-        /// <param name="itemId"></param>
-        /// <param name="quantity">This can be evidence of witchcraft. Careful when showing off in-game.</param>
-        /// <param name="upgrade1Id">An upgrade id if item has one upgrade slot.</param>
-        /// <param name="upgrade2Id">An upgrade id if item has two upgrade slots.</param>
-        /// <param name="skinId">A skin id if item is transmutable.</param>
+        /// <param name="itemId">The item identifier to generate a chat code for.</param>
+        /// <param name="quantity">Optional: Quantity of the item.</param>
+        /// <param name="upgrade1Id">Optional: An upgrade id if item has one upgrade slot.</param>
+        /// <param name="upgrade2Id">Optional: An upgrade id if item has two upgrade slots.</param>
+        /// <param name="skinId">Optional: A skin id if item is transmutable.</param>
         /// <returns>A Guild Wars 2 chat code</returns>
-        public static string GenerateChatCodeForItem(int itemId, int quantity, int upgrade1Id = 0, int upgrade2Id = 0, int skinId = 0)
+        public static string GenerateChatCode(int itemId, int quantity = 1, int upgrade1Id = 0, int upgrade2Id = 0, int skinId = 0)
         {
 
             // Figure out which header we need based on what components

--- a/Blish HUD/Controls/Extern/VirtualKeyShort.cs
+++ b/Blish HUD/Controls/Extern/VirtualKeyShort.cs
@@ -1,6 +1,6 @@
 namespace Blish_HUD.Controls.Extern
 {
-    internal enum VirtualKeyShort : short
+    public enum VirtualKeyShort : short
     {
         ///<summary>
         ///Left mouse button

--- a/Blish HUD/Controls/Intern/Keyboard.cs
+++ b/Blish HUD/Controls/Intern/Keyboard.cs
@@ -45,7 +45,7 @@ namespace Blish_HUD.Controls.Intern
                 ExtraKeyInfo lParam = new ExtraKeyInfo(){
                     scanCode = (char)PInvoke.MapVirtualKey(vkCode, MAPVK_VK_TO_VSC)
                 };
-                PInvoke.PostMessage(GameService.GameIntegration.Gw2Process.MainWindowHandle, WM_KEYDOWN, vkCode, lParam.GetInt());
+                PInvoke.PostMessage(GameService.GameIntegration.Gw2WindowHandle, WM_KEYDOWN, vkCode, lParam.GetInt());
             }
         }
 
@@ -85,7 +85,7 @@ namespace Blish_HUD.Controls.Intern
                     prevKeyState = 1,
                     transitionState = 1
                 };
-                PInvoke.PostMessage(GameService.GameIntegration.Gw2Process.MainWindowHandle, WM_KEYUP, vkCode, lParam.GetInt());
+                PInvoke.PostMessage(GameService.GameIntegration.Gw2WindowHandle, WM_KEYUP, vkCode, lParam.GetInt());
             }
         }
     }

--- a/Blish HUD/GameServices/GameIntegrationService.cs
+++ b/Blish HUD/GameServices/GameIntegrationService.cs
@@ -77,7 +77,7 @@ namespace Blish_HUD {
             }
         }
 
-        private IntPtr Gw2WindowHandle { get; set; }
+        public IntPtr Gw2WindowHandle { get; private set; }
 
         private Process _gw2Process;
         public Process Gw2Process {

--- a/Blish HUD/GameServices/Gw2ChatCodeService.cs
+++ b/Blish HUD/GameServices/Gw2ChatCodeService.cs
@@ -1,0 +1,101 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Blish_HUD
+{
+    public class Gw2ChatCodeService : GameService
+    {
+        private static Logger Logger = Logger.GetLogger(typeof(Gw2ChatCodeService));
+        protected override void Initialize(){ /** NOOP **/ }
+
+        protected override void Load(){ /** NOOP **/ }
+
+        protected override void Unload(){ /** NOOP **/ }
+
+        protected override void Update(GameTime gameTime){ /** NOOP **/}
+
+        /// <author>The original code was made in a JSFiddle by the GW2 Wikiuser Fam. Translation to C# by Andy</author>
+        /// <seealso cref="https://jsfiddle.net/fffam/cg3njdu6/"/>
+        /// <seealso cref="https://wiki.guildwars2.com/wiki/Talk:Chat_link_format#Quick_app_for_generating_item_codes"/>
+        /// <summary>
+        /// Decodes a Guild Wars 2 chat code.
+        /// </summary>
+        /// <param name="fullcode">This needs to be the item code (i.e. from trading post or gw2spidy) not the wardrobe ID</param>
+        /// <returns>0 if invalid or item code</returns>
+        public static int DecodeChatCodeForItemOrSkin(string fullcode)
+        {
+            if (!Regex.IsMatch(fullcode, @"^\[\&")) {
+                return 0;
+            }
+            var code = Regex.Replace(fullcode, @"^\[\&+|\]+$", "");
+            var binary = Convert.FromBase64String(code);
+            var octets = new char[binary.Length];
+            for (var i = 0; i < binary.Length; i++)
+            {
+                octets[i] = (char)binary[i];
+            }
+            if (octets != null) {
+                if (octets[0] == 2) {
+                     return (octets[2] * 1)
+                            +(octets[3] << 8)
+                            +(octets[4] != null ? (octets[4] << 16) : 0);
+
+                } else if (octets[0] == 11 ) {
+
+                    return (octets[1] * 1)
+                            +(octets[2] << 8)
+                            +(octets[3] != null ? (octets[4] << 16) : 0);            
+                } else {
+                    Logger.Warn(fullcode + " must be a valid chat code");   
+                }
+            }
+            return 0;
+        }
+
+        /// <author>The original code was made in a JSFiddle by the GW2 Wikiuser Fam. Translation to C# by Andy</author>
+        /// <seealso cref="https://jsfiddle.net/fffam/cg3njdu6/"/>
+        /// <seealso cref="https://wiki.guildwars2.com/wiki/Talk:Chat_link_format#Quick_app_for_generating_item_codes"/>
+        /// <summary>
+        /// Generates a chat code with the given parameters.
+        /// </summary>
+        /// <param name="itemId"></param>
+        /// <param name="quantity">This can be evidence of witchcraft. Careful when showing off in-game.</param>
+        /// <param name="upgrade1Id">An upgrade id if item has one upgrade slot.</param>
+        /// <param name="upgrade2Id">An upgrade id if item has two upgrade slots.</param>
+        /// <param name="skinId">A skin id if item is transmutable.</param>
+        /// <returns>A Guild Wars 2 chat code</returns>
+        public static string GenerateChatCodeForItem(int itemId, int quantity, int upgrade1Id = 0, int upgrade2Id = 0, int skinId = 0)
+        {
+
+            // Figure out which header we need based on what components
+            //0x00 – Default item
+            //0x40 – 1 upgrade component
+            //0x60 – 2 upgrade components
+            //0x80 – Skinned
+            //0xC0 – Skinned + 1 upgrade component
+            //0xE0 – Skinned + 2 upgrade components
+            var separator = 16 * ((skinId > 0 ? 8 : 0) + (upgrade1Id > 0 ? 4 : 0) + (upgrade2Id > 0 ? 2 : 0));
+
+            // Arrange the IDs in order
+            var ids = new int[] { 2, quantity % 256, itemId, separator, skinId, upgrade1Id, upgrade2Id };
+
+            // Byte length for each part
+            var lengths = new int[] { 1, 1, 3, 1, skinId > 0 ? 4 : 0, upgrade1Id > 0 ? 4 : 0, upgrade2Id > 0 ? 4 : 0 };
+
+            // Build
+            var bytes = new List<byte>();
+            for (int i = 0; i < ids.Length; i++)
+            {
+                for (int j = 0; j < lengths[i]; j++)
+                {
+                    bytes.Add((byte)(ids[i] >> (8 * j) & 0xff));
+                }
+            }
+            // Get code
+            var output = Convert.ToBase64String(bytes.ToArray());
+            return "[&" + output + "]";
+        }
+    }
+}

--- a/Blish HUD/_Interfaces/IKeyboard.cs
+++ b/Blish HUD/_Interfaces/IKeyboard.cs
@@ -1,9 +1,0 @@
-﻿using Blish_HUD.Controls.Intern;
-namespace Blish_HUD
-{
-    public interface IKeyboard
-    {
-        void Press(GuildWarsControls key);
-        void Release(GuildWarsControls key);
-    }
-}


### PR DESCRIPTION
- provided static chat code functions which modules can use to customize chat code copy-to-clipboard buttons.
- changed Keyboard and removed IKeyboard
- Keyboard is now static.

(also see PR for Musician -> https://github.com/blish-hud/Community-Module-Pack/pull/20)