### PR TITLE
Contexts + CdnInfoContext & Gw2ClientContext

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -201,6 +201,12 @@
     <Compile Include="GameServices\ArcDps\SocketAsyncEventArgsPool.cs" />
     <Compile Include="GameServices\ArcDps\SocketListener\SocketListener.cs" />
     <Compile Include="GameServices\Content\RenderServiceTextureSize.cs" />
+    <Compile Include="GameServices\ContextsService.cs" />
+    <Compile Include="GameServices\Contexts\CdnInfoContext.cs" />
+    <Compile Include="GameServices\Contexts\Gw2ClientContext.cs" />
+    <Compile Include="GameServices\Contexts\Context.cs" />
+    <Compile Include="GameServices\Contexts\ContextResult[T].cs" />
+    <Compile Include="GameServices\Contexts\ContextAvailability.cs" />
     <Compile Include="GameServices\Debug\Logger.cs" />
     <Compile Include="GameServices\Gw2ApiService.cs" />
     <Compile Include="GameServices\ArcDpsService.cs" />

--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -203,6 +203,7 @@
     <Compile Include="GameServices\Content\RenderServiceTextureSize.cs" />
     <Compile Include="GameServices\ContextsService.cs" />
     <Compile Include="GameServices\Contexts\CdnInfoContext.cs" />
+    <Compile Include="GameServices\Contexts\ContextState.cs" />
     <Compile Include="GameServices\Contexts\Gw2ClientContext.cs" />
     <Compile Include="GameServices\Contexts\Context.cs" />
     <Compile Include="GameServices\Contexts\ContextResult[T].cs" />

--- a/Blish HUD/GameServices/Contexts/CdnInfoContext.cs
+++ b/Blish HUD/GameServices/Contexts/CdnInfoContext.cs
@@ -27,7 +27,7 @@ namespace Blish_HUD.Contexts {
 
                 bool parsedSuccessfully = true;
 
-                if (cdnVars.Length == 5) {
+                if (cdnVars.Length == 5 || (parsedSuccessfully = false)) {
                     parsedSuccessfully &= int.TryParse(cdnVars[0], out _buildId);
                     parsedSuccessfully &= int.TryParse(cdnVars[1], out _exeFileId);
                     parsedSuccessfully &= int.TryParse(cdnVars[2], out _exeFileSize);

--- a/Blish HUD/GameServices/Contexts/CdnInfoContext.cs
+++ b/Blish HUD/GameServices/Contexts/CdnInfoContext.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Threading.Tasks;
+using Flurl.Http;
+
+namespace Blish_HUD.Contexts {
+
+    public class CdnInfoContext : Context {
+
+        private static readonly Logger Logger = Logger.GetLogger(typeof(CdnInfoContext));
+        
+        public struct CdnInfo {
+
+            private readonly int _buildId;
+            private readonly int _exeFileId;
+            private readonly int _exeFileSize;
+            private readonly int _manifestFileId;
+            private readonly int _manifestFileSize;
+
+            public int BuildId          => _buildId;
+            public int ExeFileId        => _exeFileId;
+            public int ExeFileSize      => _exeFileSize;
+            public int ManifestFileId   => _manifestFileId;
+            public int ManifestFileSize => _manifestFileSize;
+
+            public CdnInfo(string rawCdnResponse) : this() {
+                string[] cdnVars = rawCdnResponse.Split(' ');
+
+                bool parsedSuccessfully = true;
+
+                if (cdnVars.Length == 5) {
+                    parsedSuccessfully &= int.TryParse(cdnVars[0], out _buildId);
+                    parsedSuccessfully &= int.TryParse(cdnVars[1], out _exeFileId);
+                    parsedSuccessfully &= int.TryParse(cdnVars[2], out _exeFileSize);
+                    parsedSuccessfully &= int.TryParse(cdnVars[3], out _manifestFileId);
+                    parsedSuccessfully &= int.TryParse(cdnVars[4], out _manifestFileSize);
+                }
+
+                if (!parsedSuccessfully) {
+                    _buildId = -1;
+                    Logger.Warn("Failed to parse CDN response {rawCdnResponse}.", rawCdnResponse);
+                }
+            }
+
+            public CdnInfo(int buildId, int exeFileId, int exeFileSize, int manifestFileId, int manifestFileSize) {
+                _buildId          = buildId;
+                _exeFileId        = exeFileId;
+                _exeFileSize      = exeFileSize;
+                _manifestFileId   = manifestFileId;
+                _manifestFileSize = manifestFileSize;
+            }
+
+        }
+
+        private const int TOTAL_CDN_ENDPOINTS = 2;
+
+        private const string GW2_ASSETCDN_URL    = "http://assetcdn.101.arenanetworks.com/latest/101";
+        private const string GW2_CN_ASSETCDN_URL = "http://assetcdn.111.cgw2.com/latest/111";
+
+        private CdnInfo _standardCdnInfo;
+        private CdnInfo _chineseCdnInfo;
+
+        private int _loadCount = 0;
+
+        #region Context Loading
+
+        protected override void Load() {
+            GetCdnInfoFromCdnUrl(GW2_ASSETCDN_URL).ContinueWith((cdnInfo) => SetCdnInfo(ref _standardCdnInfo, cdnInfo.Result));
+            GetCdnInfoFromCdnUrl(GW2_CN_ASSETCDN_URL).ContinueWith((cdnInfo) => SetCdnInfo(ref _chineseCdnInfo, cdnInfo.Result));
+        }
+
+        private void SetCdnInfo(ref CdnInfo cdnInfo, string result) {
+            if (string.IsNullOrEmpty(result)) return;
+
+            cdnInfo = new CdnInfo(result);
+
+            if (++_loadCount >= TOTAL_CDN_ENDPOINTS) {
+                ConfirmReady();
+            }
+        }
+
+        private async Task<string> GetCdnInfoFromCdnUrl(string cdnUrl) {
+            try {
+                return await cdnUrl.GetStringAsync();
+            } catch (Exception ex) {
+                Logger.Warn(ex, "Failed to get CDN information from {cdnUrl}.", cdnUrl);
+            }
+
+            return null;
+        }
+
+        #endregion
+
+        private ContextAvailability TryGetCdnInfo(ref CdnInfo cdnInfo, out ContextResult<CdnInfo> contextResult) {
+            if (!this.Ready) return NotReady(out contextResult);
+
+            if (cdnInfo.BuildId > 0) {
+                contextResult = new ContextResult<CdnInfo>(cdnInfo, true);
+                return ContextAvailability.Available;
+            }
+
+            if (cdnInfo.BuildId < 0) {
+                contextResult = new ContextResult<CdnInfo>(cdnInfo, true);
+                return ContextAvailability.Failed;
+            }
+
+            contextResult = new ContextResult<CdnInfo>(cdnInfo, false);
+            return ContextAvailability.Unavailable;
+        }
+
+        /// <summary>
+        /// If <see cref="ContextAvailability.Available"/>, returns
+        /// <see cref="CdnInfo"/> provided by the standard asset CDN.
+        /// </summary>
+        public ContextAvailability TryGetStandardCdnInfo(out ContextResult<CdnInfo> contextResult) {
+            return TryGetCdnInfo(ref _standardCdnInfo, out contextResult);
+        }
+
+        /// <summary>
+        /// If <see cref="ContextAvailability.Available"/>, returns
+        /// <see cref="CdnInfo"/> provided by the Chinese asset CDN.
+        /// </summary>
+        public ContextAvailability TryGetChineseCdnInfo(out ContextResult<CdnInfo> contextResult) {
+            return TryGetCdnInfo(ref _chineseCdnInfo, out contextResult);
+        }
+
+    }
+
+}

--- a/Blish HUD/GameServices/Contexts/Context.cs
+++ b/Blish HUD/GameServices/Contexts/Context.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+
+namespace Blish_HUD.Contexts {
+    /// <summary>
+    /// Provides context about something
+    /// </summary>
+    public abstract class Context {
+
+        /// <summary>
+        /// Fired when the context has finished loading.
+        /// </summary>
+
+        public event EventHandler<EventArgs> Readied;
+
+        private void OnReadied(EventArgs e) {
+            this.Readied?.Invoke(this, e);
+        }
+
+        public bool Ready { get; private set; }
+
+        public void DoLoad() {
+            this.Load();
+        }
+
+        public void DoUpdate(GameTime gameTime) {
+            Update(gameTime);
+        }
+
+        public void DoUnload() {
+            this.Unload();
+        }
+
+        protected void ConfirmReady() {
+            this.Ready = true;
+            OnReadied(EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// If the <see cref="Context"/> is not <see cref="Context.Ready"/> and a function is called
+        /// on the <see cref="Context"/> that relies on something to be loaded, this short-circuit can
+        /// be called to return <see cref="ContextAvailability.Unavailable"/> and out the default result
+        /// with the status set to "Not ready!"
+        /// </summary>
+        protected ContextAvailability NotReady<T>(out ContextResult<T> contextResult) {
+            contextResult = new ContextResult<T>(default, "Not ready!");
+
+            return ContextAvailability.Unavailable;
+        }
+
+        protected virtual void Load() { /* NOOP */ }
+
+        protected virtual void Update(GameTime gameTime) { /* NOOP */ }
+
+        protected virtual void Unload() { /* NOOP */ }
+
+
+    }
+
+}

--- a/Blish HUD/GameServices/Contexts/Context.cs
+++ b/Blish HUD/GameServices/Contexts/Context.cs
@@ -10,7 +10,6 @@ namespace Blish_HUD.Contexts {
         /// <summary>
         /// Fired when the context has finished loading.
         /// </summary>
-
         public event EventHandler<EventArgs> Readied;
 
         private void OnReadied(EventArgs e) {

--- a/Blish HUD/GameServices/Contexts/Context.cs
+++ b/Blish HUD/GameServices/Contexts/Context.cs
@@ -8,7 +8,7 @@ namespace Blish_HUD.Contexts {
     public abstract class Context {
 
         /// <summary>
-        /// Fired when the context has finished loading.
+        /// Occurs when the context has finished loading.
         /// </summary>
         public event EventHandler<EventArgs> Readied;
 
@@ -19,32 +19,37 @@ namespace Blish_HUD.Contexts {
         public bool Ready { get; private set; }
 
         public void DoLoad() {
+            this.Ready = false;
+
             this.Load();
         }
 
         public void DoUpdate(GameTime gameTime) {
-            Update(gameTime);
+            this.Update(gameTime);
         }
 
         public void DoUnload() {
+            this.Ready = false;
+
             this.Unload();
         }
 
         protected void ConfirmReady() {
             this.Ready = true;
-            OnReadied(EventArgs.Empty);
+
+            this.OnReadied(EventArgs.Empty);
         }
 
         /// <summary>
         /// If the <see cref="Context"/> is not <see cref="Context.Ready"/> and a function is called
         /// on the <see cref="Context"/> that relies on something to be loaded, this short-circuit can
-        /// be called to return <see cref="ContextAvailability.Unavailable"/> and out the default result
+        /// be called to return <see cref="ContextAvailability.NotReady"/> and out the default result
         /// with the status set to "Not ready!"
         /// </summary>
         protected ContextAvailability NotReady<T>(out ContextResult<T> contextResult) {
             contextResult = new ContextResult<T>(default, "Not ready!");
 
-            return ContextAvailability.Unavailable;
+            return ContextAvailability.NotReady;
         }
 
         protected virtual void Load() { /* NOOP */ }
@@ -52,7 +57,6 @@ namespace Blish_HUD.Contexts {
         protected virtual void Update(GameTime gameTime) { /* NOOP */ }
 
         protected virtual void Unload() { /* NOOP */ }
-
 
     }
 

--- a/Blish HUD/GameServices/Contexts/Context.cs
+++ b/Blish HUD/GameServices/Contexts/Context.cs
@@ -4,26 +4,6 @@ using Microsoft.Xna.Framework;
 namespace Blish_HUD.Contexts {
 
     /// <summary>
-    /// The current state of the <see cref="Context"/>.
-    /// </summary>
-    public enum ContextState {
-        /// <summary>
-        /// The <see cref="Context"/> is currently loading.
-        /// </summary>
-        Loading,
-
-        /// <summary>
-        /// The <see cref="Context"/> has loaded.
-        /// </summary>
-        Ready,
-
-        /// <summary>
-        /// The <see cref="Context"/> has been unregistered and should no longer be used or referenced.
-        /// </summary>
-        Expired
-    }
-
-    /// <summary>
     /// Provides context about something.
     /// </summary>
     public abstract class Context {
@@ -37,15 +17,15 @@ namespace Blish_HUD.Contexts {
             this.StateChanged?.Invoke(this, e);
         }
 
-        private ContextState _state = ContextState.Loading;
+        private ContextState _state = ContextState.None;
 
         /// <summary>
-        /// The current load state of the <see cref="Context"/>.
+        /// Gets the current load state of the <see cref="Context"/>.
         /// </summary>
         public ContextState State {
             get => _state;
-            set {
-                if (_state == value) return;
+            private set {
+                if (_state == value || _state == ContextState.Expired) return;
 
                 _state = value;
 
@@ -54,6 +34,8 @@ namespace Blish_HUD.Contexts {
         }
 
         public void DoLoad() {
+            if (this.State == ContextState.Expired) return;
+
             this.State = ContextState.Loading;
 
             this.Load();
@@ -65,6 +47,9 @@ namespace Blish_HUD.Contexts {
             this.Unload();
         }
 
+        /// <summary>
+        /// Called to confirm that the context is now <see cref="ContextState.Ready"/>.
+        /// </summary>
         protected void ConfirmReady() {
             this.State = ContextState.Ready;
         }

--- a/Blish HUD/GameServices/Contexts/Context.cs
+++ b/Blish HUD/GameServices/Contexts/Context.cs
@@ -2,59 +2,86 @@
 using Microsoft.Xna.Framework;
 
 namespace Blish_HUD.Contexts {
+
     /// <summary>
-    /// Provides context about something
+    /// The current state of the <see cref="Context"/>.
+    /// </summary>
+    public enum ContextState {
+        /// <summary>
+        /// The <see cref="Context"/> is currently loading.
+        /// </summary>
+        Loading,
+
+        /// <summary>
+        /// The <see cref="Context"/> has loaded.
+        /// </summary>
+        Ready,
+
+        /// <summary>
+        /// The <see cref="Context"/> has been unregistered and should no longer be used or referenced.
+        /// </summary>
+        Expired
+    }
+
+    /// <summary>
+    /// Provides context about something.
     /// </summary>
     public abstract class Context {
 
         /// <summary>
-        /// Occurs when the context has finished loading.
+        /// Occurs when <see cref="State"/> changes.
         /// </summary>
-        public event EventHandler<EventArgs> Readied;
+        public event EventHandler<EventArgs> StateChanged;
 
-        private void OnReadied(EventArgs e) {
-            this.Readied?.Invoke(this, e);
+        protected void OnStateChanged(EventArgs e) {
+            this.StateChanged?.Invoke(this, e);
         }
 
-        public bool Ready { get; private set; }
+        private ContextState _state = ContextState.Loading;
+
+        /// <summary>
+        /// The current load state of the <see cref="Context"/>.
+        /// </summary>
+        public ContextState State {
+            get => _state;
+            set {
+                if (_state == value) return;
+
+                _state = value;
+
+                OnStateChanged(EventArgs.Empty);
+            }
+        }
 
         public void DoLoad() {
-            this.Ready = false;
+            this.State = ContextState.Loading;
 
             this.Load();
         }
 
-        public void DoUpdate(GameTime gameTime) {
-            this.Update(gameTime);
-        }
-
         public void DoUnload() {
-            this.Ready = false;
+            this.State = ContextState.Expired;
 
             this.Unload();
         }
 
         protected void ConfirmReady() {
-            this.Ready = true;
-
-            this.OnReadied(EventArgs.Empty);
+            this.State = ContextState.Ready;
         }
 
         /// <summary>
-        /// If the <see cref="Context"/> is not <see cref="Context.Ready"/> and a function is called
+        /// If the <see cref="State"/> is not <see cref="ContextState.Ready"/> and a function is called
         /// on the <see cref="Context"/> that relies on something to be loaded, this short-circuit can
         /// be called to return <see cref="ContextAvailability.NotReady"/> and out the default result
-        /// with the status set to "Not ready!"
+        /// with the status set to "not ready".
         /// </summary>
         protected ContextAvailability NotReady<T>(out ContextResult<T> contextResult) {
-            contextResult = new ContextResult<T>(default, "Not ready!");
+            contextResult = new ContextResult<T>(default, Properties.Strings.Context_StateNotReady);
 
             return ContextAvailability.NotReady;
         }
 
         protected virtual void Load() { /* NOOP */ }
-
-        protected virtual void Update(GameTime gameTime) { /* NOOP */ }
 
         protected virtual void Unload() { /* NOOP */ }
 

--- a/Blish HUD/GameServices/Contexts/ContextAvailability.cs
+++ b/Blish HUD/GameServices/Contexts/ContextAvailability.cs
@@ -5,9 +5,16 @@
     public enum ContextAvailability {
         /// <summary>
         /// The value provided by this context is not available.
-        /// <see cref="ContextResult{T}.Status"/> should detail why it is not available.
+        /// <see cref="ContextResult{T}.Status"/> should detail why it
+        /// is not available (e.g. missing dependency).
         /// </summary>
         Unavailable,
+
+        /// <summary>
+        /// The value provided by this context is not ready or the
+        /// context has been unloaded.
+        /// </summary>
+        NotReady,
 
         /// <summary>
         /// The value provided by this context is available.

--- a/Blish HUD/GameServices/Contexts/ContextAvailability.cs
+++ b/Blish HUD/GameServices/Contexts/ContextAvailability.cs
@@ -1,0 +1,23 @@
+﻿namespace Blish_HUD.Contexts {
+    /// <summary>
+    /// Describes the availability of a <see cref="Context"/>'s endpoint after it is called.
+    /// </summary>
+    public enum ContextAvailability {
+        /// <summary>
+        /// The value provided by this context is not available.
+        /// <see cref="ContextResult{T}.Status"/> should detail why it is not available.
+        /// </summary>
+        Unavailable,
+
+        /// <summary>
+        /// The value provided by this context is available.
+        /// </summary>
+        Available,
+
+        /// <summary>
+        /// The value provided by this context is not available because something failed.
+        /// <see cref="ContextResult{T}.Status"/> should detail what failed.
+        /// </summary>
+        Failed
+    }
+}

--- a/Blish HUD/GameServices/Contexts/ContextAvailability.cs
+++ b/Blish HUD/GameServices/Contexts/ContextAvailability.cs
@@ -12,7 +12,7 @@
 
         /// <summary>
         /// The value provided by this context is not ready or the
-        /// context has been unloaded.
+        /// <see cref="Context.State"/> is not <see cref="ContextState.Ready"/>.
         /// </summary>
         NotReady,
 

--- a/Blish HUD/GameServices/Contexts/ContextResult[T].cs
+++ b/Blish HUD/GameServices/Contexts/ContextResult[T].cs
@@ -1,10 +1,12 @@
-﻿namespace Blish_HUD.Contexts {
+﻿using Blish_HUD.Properties;
+
+namespace Blish_HUD.Contexts {
 
     /// <summary>
     /// The result when querying a <see cref="Context"/>.
     /// </summary>
     /// <typeparam name="T">The type the call returns.</typeparam>
-    public class ContextResult<T> {
+    public struct ContextResult<T> {
 
         /// <summary>
         /// The value requested from the <see cref="Context"/>.
@@ -17,14 +19,30 @@
         /// </summary>
         public string Status { get; }
 
+        /// <summary>
+        /// Creates an instance of <see cref="ContextResult{T}"/>
+        /// which contains the return <c>T</c> <see cref="Value"/>
+        /// of a context's call and a <c>string</c> <see cref="Status"/>
+        /// describing the result of getting the call.
+        /// </summary>
+        /// <param name="value">The result to send back to the caller.</param>
+        /// <param name="status">The summary status of the result.  This value should be UI ready.</param>
         public ContextResult(T value, string status) {
             this.Value  = value;
             this.Status = status;
         }
 
-        public ContextResult(T value, bool succeeded) {
+        /// <summary>
+        /// Creates an instance of <see cref="ContextResult{T}"/>
+        /// which contains the return <c>T</c> <see cref="Value"/>
+        /// of a context's call and defines the <see cref="Status"/>
+        /// as "Succeeded".  This call is a shortcut for a successfull
+        /// calls.
+        /// </summary>
+        /// <param name="value">The result to send back to the caller.</param>
+        public ContextResult(T value) {
             this.Value  = value;
-            this.Status = succeeded ? "Succeeded!" : "Failed!";
+            this.Status = Strings.Context_ResultSuccess;
         }
 
         public static implicit operator T(ContextResult<T> contextResult) {

--- a/Blish HUD/GameServices/Contexts/ContextResult[T].cs
+++ b/Blish HUD/GameServices/Contexts/ContextResult[T].cs
@@ -1,0 +1,36 @@
+﻿namespace Blish_HUD.Contexts {
+
+    /// <summary>
+    /// The result when querying a <see cref="Context"/>.
+    /// </summary>
+    /// <typeparam name="T">The type the call returns.</typeparam>
+    public class ContextResult<T> {
+
+        /// <summary>
+        /// The value requested from the <see cref="Context"/>.
+        /// </summary>
+        public T Value { get; }
+
+        /// <summary>
+        /// A message indicating the result of the context request.
+        /// This string is suitable to display in the UI.
+        /// </summary>
+        public string Status { get; }
+
+        public ContextResult(T value, string status) {
+            this.Value  = value;
+            this.Status = status;
+        }
+
+        public ContextResult(T value, bool succeeded) {
+            this.Value  = value;
+            this.Status = succeeded ? "Succeeded!" : "Failed!";
+        }
+
+        public static implicit operator T(ContextResult<T> contextResult) {
+            return contextResult.Value;
+        }
+
+    }
+
+}

--- a/Blish HUD/GameServices/Contexts/ContextState.cs
+++ b/Blish HUD/GameServices/Contexts/ContextState.cs
@@ -1,0 +1,28 @@
+﻿namespace Blish_HUD.Contexts {
+
+    /// <summary>
+    /// The current state of the <see cref="Context"/>.
+    /// </summary>
+    public enum ContextState {
+        /// <summary>
+        /// The <see cref="Context"/> has not loaded yet.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The <see cref="Context"/> is currently loading.
+        /// </summary>
+        Loading,
+
+        /// <summary>
+        /// The <see cref="Context"/> has loaded.
+        /// </summary>
+        Ready,
+
+        /// <summary>
+        /// The <see cref="Context"/> has been unregistered and should no longer be used or referenced.
+        /// </summary>
+        Expired
+    }
+
+}

--- a/Blish HUD/GameServices/Contexts/Gw2ClientContext.cs
+++ b/Blish HUD/GameServices/Contexts/Gw2ClientContext.cs
@@ -2,7 +2,7 @@
 
     public class Gw2ClientContext : Context {
 
-        private static Logger Logger = Logger.GetLogger(typeof(Gw2ClientContext));
+        private static readonly Logger Logger = Logger.GetLogger(typeof(Gw2ClientContext));
 
         /// <summary>
         /// The type of the client currently running.
@@ -34,7 +34,7 @@
         private bool IsStandardClientType(int currentBuildId, out ContextAvailability contextAvailability) {
             contextAvailability = GameService.Contexts.GetContext<CdnInfoContext>().TryGetStandardCdnInfo(out var standardCdnContextResult);
 
-            Logger.Info("{contextName} ({contextAvailability}) reported the Standard client build ID to be {standardBuildId}.", nameof(CdnInfoContext), contextAvailability, standardCdnContextResult.Value.BuildId);
+            Logger.Debug("{contextName} ({contextAvailability}) reported the Standard client build ID to be {standardBuildId}.", nameof(CdnInfoContext), contextAvailability, standardCdnContextResult.Value.BuildId);
 
             if (contextAvailability != ContextAvailability.Available)
                 return false;
@@ -45,7 +45,7 @@
         private bool IsChineseClientType(int currentBuildId, out ContextAvailability contextAvailability) {
             contextAvailability = GameService.Contexts.GetContext<CdnInfoContext>().TryGetChineseCdnInfo(out var chineseCdnContextResult);
 
-            Logger.Info("{contextName} ({contextAvailability}) reported the Chinese client build ID to be {chineseBuildId}.", nameof(CdnInfoContext), contextAvailability, chineseCdnContextResult.Value.BuildId);
+            Logger.Debug("{contextName} ({contextAvailability}) reported the Chinese client build ID to be {chineseBuildId}.", nameof(CdnInfoContext), contextAvailability, chineseCdnContextResult.Value.BuildId);
 
             if (contextAvailability != ContextAvailability.Available)
                 return false;
@@ -71,12 +71,12 @@
             }
 
             if (IsStandardClientType(currentBuildId, out var standardCdnStatus)) {
-                contextResult = new ContextResult<ClientType>(ClientType.Standard, true);
+                contextResult = new ContextResult<ClientType>(ClientType.Standard);
                 return ContextAvailability.Available;
             }
 
             if (IsChineseClientType(currentBuildId, out var chineseCdnStatus)) {
-                contextResult = new ContextResult<ClientType>(ClientType.Chinese, true);
+                contextResult = new ContextResult<ClientType>(ClientType.Chinese);
                 return ContextAvailability.Available;
             }
 

--- a/Blish HUD/GameServices/Contexts/Gw2ClientContext.cs
+++ b/Blish HUD/GameServices/Contexts/Gw2ClientContext.cs
@@ -32,29 +32,19 @@
         private bool IsStandardClientType(int currentBuildId, out ContextAvailability contextAvailability) {
             contextAvailability = GameService.Contexts.GetContext<CdnInfoContext>().TryGetStandardCdnInfo(out var standardCdnContextResult);
 
-            if (contextAvailability == ContextAvailability.Available) {
-                int standardBuildId = standardCdnContextResult.Value.BuildId;
+            if (contextAvailability != ContextAvailability.Available)
+                return false;
 
-                if (currentBuildId == standardBuildId) {
-                    return true;
-                }
-            }
-
-            return false;
+            return currentBuildId == standardCdnContextResult.Value.BuildId;
         }
 
         private bool IsChineseClientType(int currentBuildId, out ContextAvailability contextAvailability) {
             contextAvailability = GameService.Contexts.GetContext<CdnInfoContext>().TryGetChineseCdnInfo(out var chineseCdnContextResult);
 
-            if (contextAvailability == ContextAvailability.Available) {
-                int chineseBuildId = chineseCdnContextResult.Value.BuildId;
+            if (contextAvailability != ContextAvailability.Available)
+                return false;
 
-                if (currentBuildId == chineseBuildId) {
-                    return true;
-                }
-            }
-
-            return false;
+            return currentBuildId == chineseCdnContextResult.Value.BuildId;
         }
 
         #endregion

--- a/Blish HUD/GameServices/Contexts/Gw2ClientContext.cs
+++ b/Blish HUD/GameServices/Contexts/Gw2ClientContext.cs
@@ -2,6 +2,8 @@
 
     public class Gw2ClientContext : Context {
 
+        private static Logger Logger = Logger.GetLogger(typeof(Gw2ClientContext));
+
         /// <summary>
         /// The type of the client currently running.
         /// </summary>
@@ -32,6 +34,8 @@
         private bool IsStandardClientType(int currentBuildId, out ContextAvailability contextAvailability) {
             contextAvailability = GameService.Contexts.GetContext<CdnInfoContext>().TryGetStandardCdnInfo(out var standardCdnContextResult);
 
+            Logger.Info("{contextName} ({contextAvailability}) reported the Standard client build ID to be {standardBuildId}.", nameof(CdnInfoContext), contextAvailability, standardCdnContextResult.Value.BuildId);
+
             if (contextAvailability != ContextAvailability.Available)
                 return false;
 
@@ -40,6 +44,8 @@
 
         private bool IsChineseClientType(int currentBuildId, out ContextAvailability contextAvailability) {
             contextAvailability = GameService.Contexts.GetContext<CdnInfoContext>().TryGetChineseCdnInfo(out var chineseCdnContextResult);
+
+            Logger.Info("{contextName} ({contextAvailability}) reported the Chinese client build ID to be {chineseBuildId}.", nameof(CdnInfoContext), contextAvailability, chineseCdnContextResult.Value.BuildId);
 
             if (contextAvailability != ContextAvailability.Available)
                 return false;
@@ -74,7 +80,7 @@
                 return ContextAvailability.Available;
             }
 
-            contextResult = new ContextResult<ClientType>(ClientType.Unknown, "The build ID reported by the Mumble Link API did not match the standard or the Chinese client build IDs provided by the CDN.");
+            contextResult = new ContextResult<ClientType>(ClientType.Unknown, $"The build ID reported by the Mumble Link API ({currentBuildId}) could not be matched against a CDN provided build ID.");
             return ContextAvailability.Failed;
         }
 

--- a/Blish HUD/GameServices/Contexts/Gw2ClientContext.cs
+++ b/Blish HUD/GameServices/Contexts/Gw2ClientContext.cs
@@ -1,0 +1,92 @@
+﻿namespace Blish_HUD.Contexts {
+
+    public class Gw2ClientContext : Context {
+
+        /// <summary>
+        /// The type of the client currently running.
+        /// </summary>
+        public enum ClientType {
+            /// <summary>
+            /// The client type could not be determined.
+            /// </summary>
+            Unknown,
+
+            /// <summary>
+            /// The client is the standard US/EU varient of the client.
+            /// </summary>
+            Standard,
+
+            /// <summary>
+            /// The client is the Chinese varient of the client.
+            /// </summary>
+            Chinese
+        }
+
+        /// <inheritdoc />
+        protected override void Load() {
+            this.ConfirmReady();
+        }
+
+        #region Specific Checks
+
+        private bool IsStandardClientType(int currentBuildId, out ContextAvailability contextAvailability) {
+            contextAvailability = GameService.Contexts.GetContext<CdnInfoContext>().TryGetStandardCdnInfo(out var standardCdnContextResult);
+
+            if (contextAvailability == ContextAvailability.Available) {
+                int standardBuildId = standardCdnContextResult.Value.BuildId;
+
+                if (currentBuildId == standardBuildId) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool IsChineseClientType(int currentBuildId, out ContextAvailability contextAvailability) {
+            contextAvailability = GameService.Contexts.GetContext<CdnInfoContext>().TryGetChineseCdnInfo(out var chineseCdnContextResult);
+
+            if (contextAvailability == ContextAvailability.Available) {
+                int chineseBuildId = chineseCdnContextResult.Value.BuildId;
+
+                if (currentBuildId == chineseBuildId) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// [DEPENDS ON: CdnInfoContext, Mumble Link API]
+        /// If <see cref="ContextAvailability.Available"/>, returns if the client is the
+        /// <see cref="ClientType.Standard"/> client or the <see cref="ClientType.Chinese"/> client.
+        /// </summary>
+        public ContextAvailability TryGetClientType(out ContextResult<ClientType> contextResult) {
+            int currentBuildId;
+
+            if (GameService.Gw2Mumble.Available) {
+                currentBuildId = GameService.Gw2Mumble.BuildId;
+            } else {
+                contextResult = new ContextResult<ClientType>(ClientType.Unknown, "The Guild Wars 2 Mumble Link API was not available.");
+                return ContextAvailability.Unavailable;
+            }
+
+            if (IsStandardClientType(currentBuildId, out var standardCdnStatus)) {
+                contextResult = new ContextResult<ClientType>(ClientType.Standard, true);
+                return ContextAvailability.Available;
+            }
+
+            if (IsChineseClientType(currentBuildId, out var chineseCdnStatus)) {
+                contextResult = new ContextResult<ClientType>(ClientType.Chinese, true);
+                return ContextAvailability.Available;
+            }
+
+            contextResult = new ContextResult<ClientType>(ClientType.Unknown, "The build ID reported by the Mumble Link API did not match the standard or the Chinese client build IDs provided by the CDN.");
+            return ContextAvailability.Failed;
+        }
+
+    }
+}

--- a/Blish HUD/GameServices/ContextsService.cs
+++ b/Blish HUD/GameServices/ContextsService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Blish_HUD.Contexts;
 using Microsoft.Xna.Framework;
 
@@ -10,20 +11,28 @@ namespace Blish_HUD {
 
         /// <inheritdoc />
         protected override void Initialize() {
-            
-        }
-
-        /// <inheritdoc />
-        protected override void Load() {
             // Temporary register
             RegisterContext(new Gw2ClientContext());
             RegisterContext(new CdnInfoContext());
         }
 
+        /// <inheritdoc />
+        protected override void Load() { /* NOOP */ }
+
         public void RegisterContext(Context context) {
             context.DoLoad();
 
             _registeredContexts.Add(context.GetType(), context);
+        }
+
+        public void UnregisterContext<TContext>() {
+            if (_registeredContexts.ContainsKey(typeof(TContext))) {
+                var context = _registeredContexts[typeof(TContext)];
+
+                _registeredContexts.Remove(typeof(TContext));
+
+                context.DoUnload();
+            }
         }
 
         public TContext GetContext<TContext>() where TContext : class {
@@ -33,13 +42,13 @@ namespace Blish_HUD {
         }
 
         /// <inheritdoc />
-        protected override void Unload() {
-            
-        }
+        protected override void Unload() { /* NOOP */ }
 
         /// <inheritdoc />
         protected override void Update(GameTime gameTime) {
-            
+            foreach (var context in _registeredContexts.Values) {
+                context.DoUpdate(gameTime);
+            }
         }
 
     }

--- a/Blish HUD/GameServices/ContextsService.cs
+++ b/Blish HUD/GameServices/ContextsService.cs
@@ -3,20 +3,32 @@ using System.Collections.Generic;
 using System.Linq;
 using Blish_HUD.Contexts;
 using Microsoft.Xna.Framework;
+using SharpDX.WIC;
 
 namespace Blish_HUD {
     public class ContextsService : GameService {
 
-        private class ContextHandle<TContext> {
+        /// <summary>
+        /// Returned by the <see cref="ContextsService"/> when registering
+        /// a new <see cref="Context"/>.  This handle can be used to later
+        /// unregister the <see cref="Context"/> by calling <see cref="Expire"/>
+        /// on the handle.
+        /// </summary>
+        public class ContextHandle<TContext> where TContext : Context {
 
-            private readonly TContext _contextReference;
+            private bool _hasExpired;
 
-            public ContextHandle(TContext context) {
-                _contextReference = context;
-            }
-
+            /// <summary>
+            /// Unloads and invalidates the <see cref="Context"/> marking it
+            /// as <see cref="ContextState.Expired"/>.  The <see cref="Context"/>
+            /// is then unregistered from the <see cref="ContextsService"/>.
+            /// </summary>
             public void Expire() {
-                GameService.Contexts.DeregisterContext<TContext>();
+                if (_hasExpired) return;
+
+                _hasExpired = true;
+
+                GameService.Contexts.UnregisterContext<TContext>();
             }
 
         }
@@ -25,7 +37,7 @@ namespace Blish_HUD {
 
         /// <inheritdoc />
         protected override void Initialize() {
-            // Temporary register
+            // Built-in contexts
             RegisterContext(new Gw2ClientContext());
             RegisterContext(new CdnInfoContext());
         }
@@ -33,13 +45,21 @@ namespace Blish_HUD {
         /// <inheritdoc />
         protected override void Load() { /* NOOP */ }
 
-        public void RegisterContext(Context context) {
+        /// <summary>
+        /// Registers and then loads an instance of a <see cref="Context"/>.
+        /// </summary>
+        /// <typeparam name="TContext">The type of <see cref="Context"/> that will be registered.</typeparam>
+        /// <param name="context">An instance of a <see cref="Context"/>.</param>
+        /// <returns>A <see cref="ContextHandle{TContext}"/> which can be used to later unregister the <see cref="Context"/>.</returns>
+        public ContextHandle<TContext> RegisterContext<TContext>(TContext context) where TContext : Context {
             context.DoLoad();
 
             _registeredContexts.Add(context.GetType(), context);
+
+            return new ContextHandle<TContext>();
         }
 
-        private void DeregisterContext<TContext>() {
+        private void UnregisterContext<TContext>() {
             if (_registeredContexts.ContainsKey(typeof(TContext))) {
                 var context = _registeredContexts[typeof(TContext)];
 
@@ -49,7 +69,16 @@ namespace Blish_HUD {
             }
         }
 
-        public TContext GetContext<TContext>() where TContext : class {
+        /// <summary>
+        /// Gets a registered <see cref="Context"/> by type.
+        /// </summary>
+        /// <typeparam name="TContext">The type of the <see cref="Context"/> to retrieve.</typeparam>
+        /// <returns>
+        /// The registered <see cref="Context"/> of type <c>TContext</c> or
+        /// <c>null</c> if not <see cref="Context"/> of that type is
+        /// currently registered.
+        /// </returns>
+        public TContext GetContext<TContext>() where TContext : Context {
             if (!_registeredContexts.ContainsKey(typeof(TContext))) return null;
 
             return _registeredContexts[typeof(TContext)] as TContext;

--- a/Blish HUD/GameServices/ContextsService.cs
+++ b/Blish HUD/GameServices/ContextsService.cs
@@ -7,6 +7,20 @@ using Microsoft.Xna.Framework;
 namespace Blish_HUD {
     public class ContextsService : GameService {
 
+        private class ContextHandle<TContext> {
+
+            private readonly TContext _contextReference;
+
+            public ContextHandle(TContext context) {
+                _contextReference = context;
+            }
+
+            public void Expire() {
+                GameService.Contexts.DeregisterContext<TContext>();
+            }
+
+        }
+
         private readonly Dictionary<Type, Context> _registeredContexts = new Dictionary<Type, Context>();
 
         /// <inheritdoc />
@@ -25,7 +39,7 @@ namespace Blish_HUD {
             _registeredContexts.Add(context.GetType(), context);
         }
 
-        public void UnregisterContext<TContext>() {
+        private void DeregisterContext<TContext>() {
             if (_registeredContexts.ContainsKey(typeof(TContext))) {
                 var context = _registeredContexts[typeof(TContext)];
 
@@ -45,11 +59,7 @@ namespace Blish_HUD {
         protected override void Unload() { /* NOOP */ }
 
         /// <inheritdoc />
-        protected override void Update(GameTime gameTime) {
-            foreach (var context in _registeredContexts.Values) {
-                context.DoUpdate(gameTime);
-            }
-        }
+        protected override void Update(GameTime gameTime) { /* NOOP */ }
 
     }
 }

--- a/Blish HUD/GameServices/ContextsService.cs
+++ b/Blish HUD/GameServices/ContextsService.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using Blish_HUD.Contexts;
+using Microsoft.Xna.Framework;
+
+namespace Blish_HUD {
+    public class ContextsService : GameService {
+
+        private readonly Dictionary<Type, Context> _registeredContexts = new Dictionary<Type, Context>();
+
+        /// <inheritdoc />
+        protected override void Initialize() {
+            
+        }
+
+        /// <inheritdoc />
+        protected override void Load() {
+            // Temporary register
+            RegisterContext(new Gw2ClientContext());
+            RegisterContext(new CdnInfoContext());
+        }
+
+        public void RegisterContext(Context context) {
+            context.DoLoad();
+
+            _registeredContexts.Add(context.GetType(), context);
+        }
+
+        public TContext GetContext<TContext>() where TContext : class {
+            if (!_registeredContexts.ContainsKey(typeof(TContext))) return null;
+
+            return _registeredContexts[typeof(TContext)] as TContext;
+        }
+
+        /// <inheritdoc />
+        protected override void Unload() {
+            
+        }
+
+        /// <inheritdoc />
+        protected override void Update(GameTime gameTime) {
+            
+        }
+
+    }
+}

--- a/Blish HUD/GameServices/GameService.cs
+++ b/Blish HUD/GameServices/GameService.cs
@@ -65,6 +65,7 @@ namespace Blish_HUD {
         public static readonly ModuleService          Module;
         public static readonly PersistentStoreService Store;
         public static readonly ArcDpsService          ArcDps;
+        public static readonly ContextsService        Contexts;
 
         #endregion
 
@@ -87,6 +88,7 @@ namespace Blish_HUD {
             Pathing         = new PathingService();
             Module          = new ModuleService();
             ArcDps          = new ArcDpsService();
+            Contexts        = new ContextsService();
 
             _allServices = new GameService[] {
                 Debug,
@@ -105,7 +107,8 @@ namespace Blish_HUD {
                 Hotkeys,
                 Pathing,
                 Module,
-                ArcDps
+                ArcDps,
+                Contexts
             };
 
         }

--- a/Blish HUD/GameServices/Gw2MumbleService.cs
+++ b/Blish HUD/GameServices/Gw2MumbleService.cs
@@ -11,6 +11,12 @@ namespace Blish_HUD {
 
         private static readonly Logger Logger = Logger.GetLogger(typeof(Gw2MumbleService));
 
+        public event EventHandler<EventArgs> BuildIdChanged;
+
+        private void OnBuildIdChanged(EventArgs e) {
+            BuildIdChanged?.Invoke(this, e);
+        }
+
         public bool Available => gw2Link != null && this.MumbleBacking != null;
 
         private Avatar _mumbleBacking;
@@ -20,7 +26,17 @@ namespace Blish_HUD {
 
         public long UiTick { get; private set; } = -1;
 
-        public int BuildId { get; private set; } = -1;
+        private int _buildId = -1;
+        public int BuildId {
+            get => _buildId;
+            private set {
+                if (_buildId == value) return;
+
+                _buildId = value;
+
+                OnBuildIdChanged(EventArgs.Empty);
+            }
+        }
 
         private MumbleLinkFile gw2Link;
 

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -114,7 +114,7 @@ namespace Blish_HUD {
             GameService.GameIntegration.Gw2Closed += GameIntegrationOnGw2Closed;
             GameService.Gw2Mumble.BuildIdChanged  += Gw2MumbleOnBuildIdChanged;
 
-            GameService.Contexts.GetContext<CdnInfoContext>().Readied += CdnInfoContextOnReadied;
+            GameService.Contexts.GetContext<CdnInfoContext>().StateChanged += CdnInfoContextOnStateChanged;
         }
 
         private void Gw2MumbleOnBuildIdChanged(object sender, EventArgs e) {
@@ -123,8 +123,8 @@ namespace Blish_HUD {
             }
         }
 
-        private void CdnInfoContextOnReadied(object sender, EventArgs e) {
-            if (!_checkedClient) {
+        private void CdnInfoContextOnStateChanged(object sender, EventArgs e) {
+            if (!_checkedClient && ((Context) sender).State == ContextState.Ready) {
                 DetectClientType();
             }
         }

--- a/Blish HUD/Properties/Strings.Designer.cs
+++ b/Blish HUD/Properties/Strings.Designer.cs
@@ -71,6 +71,16 @@ namespace Blish_HUD.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Not ready.
+        /// </summary>
+        public static string Context_StateNotReady {
+            get {
+                Contract.Ensures(Contract.Result<string>() != null);
+                return ResourceManager.GetString("Context_StateNotReady", resourceCulture) ?? string.Empty;
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Blish HUD.
         /// </summary>
         public static string General_BlishHUD {
@@ -111,6 +121,10 @@ namespace Blish_HUD.Properties {
     [global::System.Runtime.CompilerServices.CompilerGenerated]
     public enum StringResourceKey
     {
+        /// <summary>
+        ///   Looks up a localized string similar to Not ready.
+        /// </summary>
+        Context_StateNotReady,
         /// <summary>
         ///   Looks up a localized string similar to Blish HUD.
         /// </summary>

--- a/Blish HUD/Properties/Strings.Designer.cs
+++ b/Blish HUD/Properties/Strings.Designer.cs
@@ -71,6 +71,16 @@ namespace Blish_HUD.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Succeeded.
+        /// </summary>
+        public static string Context_ResultSuccess {
+            get {
+                Contract.Ensures(Contract.Result<string>() != null);
+                return ResourceManager.GetString("Context_ResultSuccess", resourceCulture) ?? string.Empty;
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Not ready.
         /// </summary>
         public static string Context_StateNotReady {
@@ -121,6 +131,10 @@ namespace Blish_HUD.Properties {
     [global::System.Runtime.CompilerServices.CompilerGenerated]
     public enum StringResourceKey
     {
+        /// <summary>
+        ///   Looks up a localized string similar to Succeeded.
+        /// </summary>
+        Context_ResultSuccess,
         /// <summary>
         ///   Looks up a localized string similar to Not ready.
         /// </summary>

--- a/Blish HUD/Properties/Strings.resx
+++ b/Blish HUD/Properties/Strings.resx
@@ -127,4 +127,7 @@
   <data name="General_Close" xml:space="preserve">
     <value>Close</value>
   </data>
+  <data name="Context_StateNotReady" xml:space="preserve">
+    <value>Not ready</value>
+  </data>
 </root>

--- a/Blish HUD/Properties/Strings.resx
+++ b/Blish HUD/Properties/Strings.resx
@@ -130,4 +130,7 @@
   <data name="Context_StateNotReady" xml:space="preserve">
     <value>Not ready</value>
   </data>
+  <data name="Context_ResultSuccess" xml:space="preserve">
+    <value>Succeeded</value>
+  </data>
 </root>


### PR DESCRIPTION
Added base structure for new `ContextsService`.  Also added two contexts `CdnInfoContext` and `Gw2ClientContext` which demonstrate detecting the Client version of the application using the Mumble Link service to detect the current build ID and then the asset CDNs to check which client we are using based on that current build ID.

This provides some of the potential implementation currently being discussed in #62. 

Additionally, if accepted, this contains contexts that would allow us to more easily solve #50.