### PR TITLE
Additional control fixes and optimizations

### DIFF
--- a/Blish HUD/Controls/Menu.cs
+++ b/Blish HUD/Controls/Menu.cs
@@ -100,6 +100,8 @@ namespace Blish_HUD.Controls {
 
             newChild.MenuItemHeight = this.MenuItemHeight;
 
+            e.ChangedChild.Width = this.Width;
+
             // We'll bind the top of the control to the bottom of the last control we added
             var lastItem = _children.LastOrDefault();
             if (lastItem != null) {

--- a/Blish HUD/Controls/TabbedWindow.cs
+++ b/Blish HUD/Controls/TabbedWindow.cs
@@ -169,8 +169,13 @@ namespace Blish_HUD.Controls {
                     _tabRegions[_tabs[i]] = TabBoundsFromIndex(i);
                 }
 
+                // Update tab index without making tab switch noise
                 if (_selectedTabIndex == -1) {
-                    this.SelectedTabIndex = _tabs.IndexOf(prevTab);
+                    _subtitle         = prevTab.Name;
+                    _selectedTabIndex = _tabs.IndexOf(prevTab);
+                    this.ActivePanel  = panel;
+                } else {
+                    _selectedTabIndex = _tabs.IndexOf(prevTab);
                 }
 
                 Invalidate();
@@ -272,7 +277,7 @@ namespace Blish_HUD.Controls {
                 if (active) {
                     spriteBatch.DrawOnCtrl(this, _textureDefaultBackround,
                                            tabBounds,
-                                           tabBounds.OffsetBy(_windowBackgroundOrigin.ToPoint()).Add(0, -35, 0, 0).Add(tabBounds.Width / 3, 0, -tabBounds.Width / 3, 0),
+                                           tabBounds.OffsetBy(_windowBackgroundOrigin.ToPoint()).OffsetBy(-5, -13).Add(0, -35, 0, 0).Add(tabBounds.Width / 3, 0, -tabBounds.Width / 3, 0),
                                      Color.White);
 
                     spriteBatch.DrawOnCtrl(this, _textureTabActive, tabBounds);

--- a/Blish HUD/Controls/TabbedWindow.cs
+++ b/Blish HUD/Controls/TabbedWindow.cs
@@ -39,7 +39,7 @@ namespace Blish_HUD.Controls {
 
         public event EventHandler<EventArgs> TabChanged;
 
-        protected int _selectedTabIndex = 0;
+        protected int _selectedTabIndex = -1;
         public int SelectedTabIndex {
             get => _selectedTabIndex;
             set {
@@ -49,13 +49,20 @@ namespace Blish_HUD.Controls {
             }
         }
 
-        public WindowTab SelectedTab => Tabs.Count > _selectedTabIndex ? Tabs[_selectedTabIndex] : null;
+        public WindowTab SelectedTab => _tabs.Count > _selectedTabIndex ? _tabs[_selectedTabIndex] : null;
 
         private int _hoveredTabIndex = 0;
         private int HoveredTabIndex {
             get => _hoveredTabIndex;
             set => SetProperty(ref _hoveredTabIndex, value);
         }
+
+        private readonly Dictionary<WindowTab, Rectangle> _tabRegions = new Dictionary<WindowTab, Rectangle>();
+        private readonly Dictionary<WindowTab, Panel>     _panels     = new Dictionary<WindowTab, Panel>();
+        private          List<WindowTab>                  _tabs       = new List<WindowTab>();
+
+        // TODO: Remove public access to _panels - only kept currently as it is used by KillProof.me module (need more robust "Navigate()" call for panel history)
+        public Dictionary<WindowTab, Panel> Panels => _panels;
 
         public TabbedWindow() {
             var tabWindowTexture = _textureDefaultBackround;
@@ -73,7 +80,7 @@ namespace Blish_HUD.Controls {
 
             this.Subtitle = SelectedTab.Name;
 
-            Navigate(Panels[this.SelectedTab], false);
+            Navigate(_panels[this.SelectedTab], false);
 
             this.TabChanged?.Invoke(this, e);
         }
@@ -92,10 +99,10 @@ namespace Blish_HUD.Controls {
             bool newSet = false;
 
             if (RelativeMousePosition.X < StandardTabBounds.Right && RelativeMousePosition.Y > StandardTabBounds.Y) {
-                var tabList = TabRegions.ToList();
-                for (int tabIndex = 0; tabIndex < Tabs.Count; tabIndex++) {
-                    var tab = Tabs[tabIndex];
-                    if (TabRegions[tab].Contains(RelativeMousePosition)) {
+                var tabList = _tabRegions.ToList();
+                for (int tabIndex = 0; tabIndex < _tabs.Count; tabIndex++) {
+                    var tab = _tabs[tabIndex];
+                    if (_tabRegions[tab].Contains(RelativeMousePosition)) {
                         HoveredTabIndex       = tabIndex;
                         newSet                = true;
                         this.BasicTooltipText = tab.Name;
@@ -116,10 +123,10 @@ namespace Blish_HUD.Controls {
 
         protected override void OnLeftMouseButtonPressed(MouseEventArgs e) {
             if (RelativeMousePosition.X < StandardTabBounds.Right && RelativeMousePosition.Y > StandardTabBounds.Y) {
-                var tabList = Tabs.ToList();
-                for (int tabIndex = 0; tabIndex < Tabs.Count; tabIndex++) {
+                var tabList = _tabs.ToList();
+                for (int tabIndex = 0; tabIndex < _tabs.Count; tabIndex++) {
                     var tab = tabList[tabIndex];
-                    if (TabRegions[tab].Contains(RelativeMousePosition)) {
+                    if (_tabRegions[tab].Contains(RelativeMousePosition)) {
                         SelectedTabIndex = tabIndex;
 
                         break;
@@ -132,10 +139,6 @@ namespace Blish_HUD.Controls {
         }
 
         #region Tab Handling
-
-        public Dictionary<WindowTab, Rectangle> TabRegions = new Dictionary<WindowTab, Rectangle>();
-        public Dictionary<WindowTab, Panel> Panels = new Dictionary<WindowTab, Panel>();
-        public List<WindowTab> Tabs = new List<WindowTab>();
 
         public WindowTab AddTab(string name, AsyncTexture2D icon, Panel panel, int priority) {
             var tab = new WindowTab(name, icon, priority);
@@ -150,28 +153,25 @@ namespace Blish_HUD.Controls {
         }
 
         public void AddTab(WindowTab tab, Panel panel) {
-            if (!Tabs.Contains(tab)) {
-                var prevTab = Tabs.Count > 0 ? Tabs[this.SelectedTabIndex] : tab;
+            if (!_tabs.Contains(tab)) {
+                var prevTab = _tabs.Count > 0 ? _tabs[this.SelectedTabIndex] : tab;
 
                 panel.Visible = false;
-                panel.Parent = this;
+                panel.Parent  = this;
 
-                Tabs.Add(tab);
-                TabRegions.Add(tab, TabBoundsFromIndex(TabRegions.Count));
-                Panels.Add(tab, panel);
+                _tabs.Add(tab);
+                _tabRegions.Add(tab, TabBoundsFromIndex(_tabRegions.Count));
+                _panels.Add(tab, panel);
 
-                Tabs = Tabs.OrderBy(t => t.Priority).ToList();
+                _tabs = _tabs.OrderBy(t => t.Priority).ToList();
 
-                var i = 0;
-                foreach (var etab in Tabs.ToList()) {
-                    TabRegions[etab] = TabBoundsFromIndex(i);
-                    i++;
+                for (int i = 0; i < _tabs.Count; i++) {
+                    _tabRegions[_tabs[i]] = TabBoundsFromIndex(i);
                 }
 
-                if (_selectedTabIndex > -1)
-                    _selectedTabIndex = Tabs.IndexOf(prevTab);
-                else
-                    SelectedTabIndex = Tabs.IndexOf(prevTab);
+                if (_selectedTabIndex == -1) {
+                    this.SelectedTabIndex = _tabs.IndexOf(prevTab);
+                }
 
                 Invalidate();
             }
@@ -179,23 +179,23 @@ namespace Blish_HUD.Controls {
 
         public void RemoveTab(WindowTab tab) {
             // TODO: If the last tab is for some reason removed, this will crash the application
-            var prevTab = Tabs.Count > 0 ? Tabs[this.SelectedTabIndex] : Tabs[0];
+            var prevTab = _tabs.Count > 0 ? _tabs[this.SelectedTabIndex] : _tabs[0];
 
-            if (Tabs.Contains(tab)) {
-                Tabs.Remove(tab);
-                TabRegions.Remove(tab);
-                Panels.Remove(tab);
+            if (_tabs.Contains(tab)) {
+                _tabs.Remove(tab);
+                _tabRegions.Remove(tab);
+                _panels.Remove(tab);
             }
 
-            Tabs = Tabs.OrderBy(t => t.Priority).ToList();
+            _tabs = _tabs.OrderBy(t => t.Priority).ToList();
 
-            for (var tabIndex = 0; tabIndex < TabRegions.Count; tabIndex++) {
-                var curTab = Tabs[tabIndex];
-                TabRegions[curTab] = TabBoundsFromIndex(tabIndex);
+            for (var tabIndex = 0; tabIndex < _tabRegions.Count; tabIndex++) {
+                var curTab = _tabs[tabIndex];
+                _tabRegions[curTab] = TabBoundsFromIndex(tabIndex);
             }
 
-            if (Tabs.Contains(prevTab)) {
-                _selectedTabIndex = Tabs.IndexOf(prevTab);
+            if (_tabs.Contains(prevTab)) {
+                _selectedTabIndex = _tabs.IndexOf(prevTab);
             }
 
             Invalidate();
@@ -222,11 +222,11 @@ namespace Blish_HUD.Controls {
         public override void RecalculateLayout() {
             base.RecalculateLayout();
 
-            if (this.Tabs.Count == 0) return;
+            if (_tabs.Count == 0) return;
 
             var firstTabBounds    = TabBoundsFromIndex(0);
-            var selectedTabBounds = TabRegions[this.SelectedTab];
-            var lastTabBounds     = TabBoundsFromIndex(TabRegions.Count - 1);
+            var selectedTabBounds = _tabRegions[this.SelectedTab];
+            var lastTabBounds     = TabBoundsFromIndex(_tabRegions.Count - 1);
 
             _layoutTopTabBarBounds    = new Rectangle(0, 0,                    TAB_SECTION_WIDTH, firstTabBounds.Top);
             _layoutBottomTabBarBounds = new Rectangle(0, lastTabBounds.Bottom, TAB_SECTION_WIDTH, _size.Y - lastTabBounds.Bottom);
@@ -262,11 +262,11 @@ namespace Blish_HUD.Controls {
 
             // Draw tabs
             int i = 0;
-            foreach (var tab in Tabs) {
+            foreach (var tab in _tabs) {
                 bool active = (i == this.SelectedTabIndex);
                 bool hovered = (i == this.HoveredTabIndex);
 
-                var tabBounds = TabRegions[tab];
+                var tabBounds = _tabRegions[tab];
                 var subBounds = new Rectangle(tabBounds.X + tabBounds.Width / 2, tabBounds.Y, TAB_WIDTH / 2, tabBounds.Height);
 
                 if (active) {

--- a/Blish HUD/Controls/Textbox.cs
+++ b/Blish HUD/Controls/Textbox.cs
@@ -91,24 +91,25 @@ namespace Blish_HUD.Controls {
             _lastInvalidate = DateTime.MinValue.TimeOfDay;
 
             _mttb = new System.Windows.Forms.TextBox() {
-                Parent = BlishHud.Form,
-                Size = new Size(20, 20),
-                Location = new System.Drawing.Point(-500),
-                AutoCompleteMode = AutoCompleteMode.Append,
-                AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource,
-                AutoCompleteCustomSource = new System.Windows.Forms.AutoCompleteStringCollection(),
-                ShortcutsEnabled = true,
-                TabStop = false
+                Parent                   = BlishHud.Form,
+                Size                     = new Size(20, 20),
+                Location                 = new System.Drawing.Point(-500),
+                AutoCompleteMode         = AutoCompleteMode.Append,
+                AutoCompleteSource       = AutoCompleteSource.CustomSource,
+                AutoCompleteCustomSource = new AutoCompleteStringCollection(),
+                ShortcutsEnabled         = true,
+                TabStop                  = false
             };
 
             _sharedInterceptor.LeftMouseButtonReleased += delegate {
-                if (_sharedInterceptor.ActiveControl == this) 
+                if (_sharedInterceptor.ActiveControl == this) {
                     Textbox_LeftMouseButtonReleased(null, null);
+                }
             };
-            
+
             _mttb.TextChanged += InternalTextBox_TextChanged;
-            _mttb.KeyDown += InternalTextBox_KeyDown;
-            _mttb.KeyUp += InternalTextBox_KeyUp;
+            _mttb.KeyDown     += InternalTextBox_KeyDown;
+            _mttb.KeyUp       += InternalTextBox_KeyUp;
 
             this.Size = Standard.Size;
 
@@ -117,14 +118,21 @@ namespace Blish_HUD.Controls {
         }
 
         protected override void OnMouseEntered(MouseEventArgs e) {
+            bool restoreFocus = _mttb.Focused;
+
             _sharedInterceptor.Show(this);
+
+            if (restoreFocus) {
+                Textbox_LeftMouseButtonReleased(null, null);
+            }
 
             base.OnMouseEntered(e);
         }
 
         protected override void OnMouseLeft(MouseEventArgs e) {
-            if (_sharedInterceptor.ActiveControl == this)
+            if (_sharedInterceptor.ActiveControl == this) {
                 _sharedInterceptor.Hide();
+            }
 
             base.OnMouseLeft(e);
         }
@@ -132,13 +140,14 @@ namespace Blish_HUD.Controls {
         public override void TriggerKeyboardInput(KeyboardMessage e) {
         }
 
-        protected override CaptureType CapturesInput() { return CaptureType.Mouse | CaptureType.ForceNone; }
+        protected override CaptureType CapturesInput() { return CaptureType.Mouse; }
 
         private void InternalTextBox_KeyDown(object sender, System.Windows.Forms.KeyEventArgs e) {
             /* Supress up and down keys because they move the cursor left and
                right for some silly reason */
-            if (e.KeyCode == Keys.Up || e.KeyCode == Keys.Down)
+            if (e.KeyCode == Keys.Up || e.KeyCode == Keys.Down) {
                 e.SuppressKeyPress = true;
+            }
             
             this.KeyDown?.Invoke(this, (Microsoft.Xna.Framework.Input.Keys)e.KeyCode);
 
@@ -166,6 +175,7 @@ namespace Blish_HUD.Controls {
         private void Input_MouseButtonPressed(object sender, MouseEventArgs e) {
             if (_mttb.Focused && !this.MouseOver) {
                 _sharedUnfocusLabel.Select();
+                GameService.GameIntegration.FocusGw2();
                 Invalidate();
             }
         }
@@ -210,8 +220,9 @@ namespace Blish_HUD.Controls {
 
         public override void DoUpdate(GameTime gameTime) {
             // Keep MouseInterceptor on top of us
-            if (_sharedInterceptor.Visible && _sharedInterceptor.ActiveControl == this)
+            if (_sharedInterceptor.Visible && _sharedInterceptor.ActiveControl == this) {
                 _sharedInterceptor.Show(this);
+            }
 
             // Determines if the blinking caret is currently visible
             this.CaretVisible = _mttb.Focused && (Math.Round(gameTime.TotalGameTime.TotalSeconds) % 2 == 1 || gameTime.TotalGameTime.Subtract(_lastInvalidate).TotalSeconds < 0.75);

--- a/Blish HUD/Controls/WindowBase.cs
+++ b/Blish HUD/Controls/WindowBase.cs
@@ -112,7 +112,6 @@ namespace Blish_HUD.Controls {
             }
         }
 
-
         private readonly Glide.Tween _animFade;
 
         protected bool  Dragging  = false;


### PR DESCRIPTION
These changes include the following:

- Optimized both the update and paint calls within `Container`s to allow them to loop through children faster.
- Fixed #107 a bug where `MenuItem`'s could end up the wrong width inside of their `Menu` parent if the `MenuItem` was added to the `Menu` after the `Menu` already had a parent set.
- Fixed bug in `TabbedWindow` that would prevent it from showing the first tab after the previous set of changes until it was deselected and then reselected.  (Introduced by #99)
- Cleaned up some `TabbedWindow` internal members.
- Made the seam between tabs and the window background much less noticeable.
- Fixed #101 a `TextBox` bug that prevented you from typing into a `TextBox` if the `TextBox` was clicked on after it was already focused or if the mouse was hover over the `TextBox` after it had already been focused.