### PR TITLE
Optional ForGameWindowOnly added to Keyboard.

### DIFF
--- a/Blish HUD/Controls/Intern/Keyboard.cs
+++ b/Blish HUD/Controls/Intern/Keyboard.cs
@@ -18,10 +18,10 @@ namespace Blish_HUD.Controls.Intern
         /// Presses a key.
         /// </summary>
         /// <param name="key">Virtual Key Short</param>
-        /// <param name="ForGameWindowOnly">Key is sent as window message. Set to false if key message (or a combination of such) is not correctly interpreted by the game.</param>
-        public static void Press(VirtualKeyShort key, bool ForGameWindowOnly = true)
+        /// <param name="sendToSystem">Set if key message (or a combination of such) cannot be correctly interpreted by the game client.</param>
+        public static void Press(VirtualKeyShort key, bool sendToSystem = false)
         {
-            if (!GameService.GameIntegration.Gw2IsRunning || !ForGameWindowOnly)
+            if (!GameService.GameIntegration.Gw2IsRunning || sendToSystem)
             {
                 var nInputs = new[]
                 {
@@ -54,10 +54,10 @@ namespace Blish_HUD.Controls.Intern
         /// Releases a key.
         /// </summary>
         /// <param name="key">Virtual Key Short</param>
-        /// <param name="ForGameWindowOnly">Key is sent as window message. Set to false if key message (or a combination of such) is not correctly interpreted by the game.</param>
-        public static void Release(VirtualKeyShort key, bool ForGameWindowOnly = true)
+        /// <param name="sendToSystem">Set if key message (or a combination of such) cannot be correctly interpreted by the game client.</param>
+        public static void Release(VirtualKeyShort key, bool sendToSystem = false)
         {
-            if (!GameService.GameIntegration.Gw2IsRunning || !ForGameWindowOnly)
+            if (!GameService.GameIntegration.Gw2IsRunning || sendToSystem)
             {
                 var nInputs = new[]
                 {

--- a/Blish HUD/Controls/Intern/Keyboard.cs
+++ b/Blish HUD/Controls/Intern/Keyboard.cs
@@ -18,9 +18,10 @@ namespace Blish_HUD.Controls.Intern
         /// Presses a key.
         /// </summary>
         /// <param name="key">Virtual Key Short</param>
-        public static void Press(VirtualKeyShort key)
+        /// <param name="ForGameWindowOnly">Key is sent as window message. Set to false if key message (or a combination of such) is not correctly interpreted by the game.</param>
+        public static void Press(VirtualKeyShort key, bool ForGameWindowOnly = true)
         {
-            if (!GameService.GameIntegration.Gw2IsRunning)
+            if (!GameService.GameIntegration.Gw2IsRunning || !ForGameWindowOnly)
             {
                 var nInputs = new[]
                 {
@@ -53,9 +54,10 @@ namespace Blish_HUD.Controls.Intern
         /// Releases a key.
         /// </summary>
         /// <param name="key">Virtual Key Short</param>
-        public static void Release(VirtualKeyShort key)
+        /// <param name="ForGameWindowOnly">Key is sent as window message. Set to false if key message (or a combination of such) is not correctly interpreted by the game.</param>
+        public static void Release(VirtualKeyShort key, bool ForGameWindowOnly = true)
         {
-            if (!GameService.GameIntegration.Gw2IsRunning)
+            if (!GameService.GameIntegration.Gw2IsRunning || !ForGameWindowOnly)
             {
                 var nInputs = new[]
                 {


### PR DESCRIPTION
Small change.

I removed that Hardware bool when I cleaned this but I just remembered why it was there.

Some keys aren't correctly interpreted when they are sent as window messages, like LCONTROL, LSHIFT etc.  
This is an optional bool on the Press() Release() functions. Default is true. ie is sent to gw2 window as message.