### PR TITLE
Modified control invalidation for better control updates

### DIFF
--- a/Blish HUD/Controls/Checkbox.cs
+++ b/Blish HUD/Controls/Checkbox.cs
@@ -9,7 +9,7 @@ namespace Blish_HUD.Controls {
     // TODO: Checkbox needs to shrink on mousedown (animation)
     public class Checkbox : LabelBase, ICheckable {
 
-        public const int CHECKBOX_SIZE = 32;
+        private const int CHECKBOX_SIZE = 32;
 
         public event EventHandler<CheckChangedEvent> CheckedChanged;
 
@@ -36,7 +36,7 @@ namespace Blish_HUD.Controls {
         }
 
         public Checkbox() : base() {
-            this.Height = CHECKBOX_SIZE / 2;
+            _size = new Point(64, CHECKBOX_SIZE / 2);
 
             _autoSizeWidth     = true;
             _textColor         = Color.White;
@@ -46,7 +46,7 @@ namespace Blish_HUD.Controls {
         public override void RecalculateLayout() {
             base.RecalculateLayout();
 
-            this.Size = new Point(CHECKBOX_SIZE / 3 * 2 + LabelRegion.X, _size.Y);
+            _size = new Point(CHECKBOX_SIZE / 3 * 2 + LabelRegion.X, _size.Y);
         }
 
         protected override void OnLeftMouseButtonPressed(MouseEventArgs e) {

--- a/Blish HUD/Controls/InteractionIndicator.cs
+++ b/Blish HUD/Controls/InteractionIndicator.cs
@@ -48,17 +48,15 @@ namespace Blish_HUD.Controls {
             _showShadow = true;
             _strokeText = true;
             _font = Content.GetFont(ContentService.FontFace.Menomonia, ContentService.FontSize.Size18, ContentService.FontStyle.Regular);
-            this.Size = new Point((int)(CONTROL_WIDTH * Graphics.GetScaleRatio(GraphicsService.UiScale.Large)), (int)(CONTROL_HEIGHT * Graphics.GetScaleRatio(GraphicsService.UiScale.Large)));
-            this.Location = new Point((int)(Graphics.WindowWidth * LEFT_OFFSET), (int)(Graphics.WindowHeight * TOP_OFFSET) - CONTROL_HEIGHT * _verticalIndex);
-            this.Opacity = 0f;
-            this.Visible = false;
+            _size = new Point((int)(CONTROL_WIDTH * Graphics.GetScaleRatio(GraphicsService.UiScale.Large)), (int)(CONTROL_HEIGHT * Graphics.GetScaleRatio(GraphicsService.UiScale.Large)));
+            _location = new Point((int)(Graphics.WindowWidth * LEFT_OFFSET), (int)(Graphics.WindowHeight * TOP_OFFSET) - CONTROL_HEIGHT * _verticalIndex);
+            _opacity = 0f;
+            _visible = false;
             this.Parent = Graphics.SpriteScreen;
 
             Graphics.SpriteScreen.Resized += delegate {
-                this.Location = new Point(
-                                          (int) (Graphics.WindowWidth * LEFT_OFFSET * Graphics.GetScaleRatio(GraphicsService.UiScale.Large)), 
-                                          (int) (Graphics.WindowHeight * TOP_OFFSET * Graphics.GetScaleRatio(GraphicsService.UiScale.Large)) - CONTROL_HEIGHT * _verticalIndex
-                                          );
+                this.Location = new Point((int) (Graphics.WindowWidth * LEFT_OFFSET * Graphics.GetScaleRatio(GraphicsService.UiScale.Large)), 
+                                          (int) (Graphics.WindowHeight * TOP_OFFSET * Graphics.GetScaleRatio(GraphicsService.UiScale.Large)) - CONTROL_HEIGHT * _verticalIndex);
             };
         }
 

--- a/Blish HUD/Controls/Label.cs
+++ b/Blish HUD/Controls/Label.cs
@@ -105,7 +105,6 @@ namespace Blish_HUD.Controls {
             _cacheLabel = false;
         }
 
-
         public override void RecalculateLayout() {
             base.RecalculateLayout();
 

--- a/Blish HUD/Controls/LabelBase.cs
+++ b/Blish HUD/Controls/LabelBase.cs
@@ -83,7 +83,9 @@ namespace Blish_HUD.Controls {
         protected Size2 GetTextDimensions(string text = null) {
             text = text ?? _text;
 
-            if (!_autoSizeWidth && _wrapText) text = Blish_HUD.DrawUtil.WrapText(_font, text, LabelRegion.X > 0 ? LabelRegion.X : _size.X);
+            if (!_autoSizeWidth && _wrapText) {
+                text = DrawUtil.WrapText(_font, text, LabelRegion.X > 0 ? LabelRegion.X : _size.X);
+            }
 
             return _font.MeasureString(text ?? _text);
         }
@@ -91,15 +93,17 @@ namespace Blish_HUD.Controls {
         protected void DrawText(SpriteBatch spriteBatch, Rectangle bounds, string text = null) {
             text = text ?? _text;
 
-            if (_font == null || string.IsNullOrEmpty(text)) { return; }
+            if (_font == null || string.IsNullOrEmpty(text)) return;
 
-            if (_showShadow && !_strokeText)
+            if (_showShadow && !_strokeText) {
                 spriteBatch.DrawStringOnCtrl(this, text, _font, bounds.OffsetBy(1, 1), _shadowColor, false, _horizontalAlignment, _verticalAlignment);
+            }
             
-            if (_cacheLabel && _labelRender != null)
+            if (_cacheLabel && _labelRender != null) {
                 spriteBatch.DrawOnCtrl(this, _labelRender.CachedRender, bounds);
-            else
+            } else {
                 spriteBatch.DrawStringOnCtrl(this, text, _font, bounds, _textColor, _wrapText, _strokeText, 1, _horizontalAlignment, _verticalAlignment);
+            }
         }
 
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {


### PR DESCRIPTION
Added support for SuspendLayout and ResumeLayout on controls. Modified invalidation behavior for controls so that they can recalculate without needing a full update cycle to occur.

Also fixed a bug that prevented controls from changing in size if they were first set to 0 for either their Width or their Height.