### PR TITLE
Fix #124 hide from taskbar

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -105,6 +105,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Common\Gw2\ChatCode.cs" />
+    <Compile Include="Controls\Intern\Mouse.cs" />
     <Compile Include="Controls\ViewContainer.cs" />
     <Compile Include="Controls\_Types\ViewState.cs" />
     <Compile Include="GameServices\Content\AsyncTexture2D.cs" />

--- a/Blish HUD/BlishHud.cs
+++ b/Blish HUD/BlishHud.cs
@@ -62,10 +62,12 @@ namespace Blish_HUD {
         /// </summary>
         protected override void Initialize() {
             FormHandle = this.Window.Handle;
-            Form = System.Windows.Forms.Control.FromHandle(FormHandle).FindForm();
+            Form       = System.Windows.Forms.Control.FromHandle(FormHandle).FindForm();
+
+            Form.HandleCreated += delegate { Console.WriteLine("HANDLE CREATED!"); };
 
             this.Window.IsBorderless = true;
-            this.Window.AllowAltF4 = false;
+            this.Window.AllowAltF4   = false;
 
 #if DEBUG
             ActiveGraphicsDeviceManager.SynchronizeWithVerticalRetrace = false;
@@ -74,8 +76,9 @@ namespace Blish_HUD {
 #endif
 
             // Initialize all game services
-            foreach (var service in GameService.All)
+            foreach (var service in GameService.All) {
                 service.DoInitialize(this);
+            }
 
             base.Initialize();
         }
@@ -95,8 +98,9 @@ namespace Blish_HUD {
         /// </summary>
         protected override void UnloadContent() {
             // Let all of the game services have a chance to unload
-            foreach (var service in GameService.All)
+            foreach (var service in GameService.All) {
                 service.DoUnload();
+            }
         }
 
         protected override void BeginRun() {

--- a/Blish HUD/BlishHud.cs
+++ b/Blish HUD/BlishHud.cs
@@ -64,8 +64,6 @@ namespace Blish_HUD {
             FormHandle = this.Window.Handle;
             Form       = System.Windows.Forms.Control.FromHandle(FormHandle).FindForm();
 
-            Form.HandleCreated += delegate { Console.WriteLine("HANDLE CREATED!"); };
-
             this.Window.IsBorderless = true;
             this.Window.AllowAltF4   = false;
 

--- a/Blish HUD/GameServices/GameIntegrationService.cs
+++ b/Blish HUD/GameServices/GameIntegrationService.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Security.AccessControl;
 using System.Windows.Forms;
@@ -88,7 +87,7 @@ namespace Blish_HUD {
                 _gw2Process = value;
 
                 if (value == null || _gw2Process.MainWindowHandle == IntPtr.Zero) {
-                    BlishHud.Form.Invoke((MethodInvoker) (() => { BlishHud.Form.Hide(); }));
+                    BlishHud.Form.Invoke((MethodInvoker) (() => { BlishHud.Form.Visible = false; }));
 
                     _gw2Process = null;
                 } else {
@@ -103,6 +102,8 @@ namespace Blish_HUD {
             }
         }
 
+        private System.Windows.Forms.Form _formWrapper;
+
         private SettingCollection _gameIntegrationSettings;
 
         private SettingEntry<string> _gw2ExecutablePath;
@@ -110,6 +111,11 @@ namespace Blish_HUD {
         public string Gw2ExecutablePath => _gw2ExecutablePath.Value;
 
         protected override void Initialize() {
+            _formWrapper = new Form();
+            BlishHud.Form.Hide();
+            BlishHud.Form.Show(_formWrapper);
+            BlishHud.Form.Visible = false;
+
             _gameIntegrationSettings = Settings.RegisterRootSettingCollection(GAMEINTEGRATION_SETTINGS);
 
             DefineSettings(_gameIntegrationSettings);
@@ -226,7 +232,9 @@ namespace Blish_HUD {
                     OnGw2Exit(null, EventArgs.Empty);
                 }
 
-                BlishHud.Form.Invoke((MethodInvoker) (() => { BlishHud.Form.Show(); }));
+                BlishHud.Form.Invoke((MethodInvoker) (() => {
+                    BlishHud.Form.Visible = true;
+                }));
             }
         }
 
@@ -285,7 +293,6 @@ namespace Blish_HUD {
                     case WindowUtil.OverlayUpdateResponse.Errored:
                         this.Gw2Process = null;
                         break;
-
                 }
             } else {
                 _lastGw2Check += gameTime.ElapsedGameTime.TotalSeconds;

--- a/Blish HUD/GameServices/GameIntegrationService.cs
+++ b/Blish HUD/GameServices/GameIntegrationService.cs
@@ -26,7 +26,7 @@ namespace Blish_HUD {
         // check to see if GW2 is running
         private const int GW2_EXE_CHECKRATE = 15;
 
-        private const string GW2_REGISTRY_KEY = @"SOFTWARE\ArenaNet\Guild Wars 2";
+        private const string GW2_REGISTRY_KEY     = @"SOFTWARE\ArenaNet\Guild Wars 2";
         private const string GW2_REGISTRY_PATH_SV = "Path";
 
         private const string GW2_64_BIT_PROCESSNAME = "Gw2-64";
@@ -35,7 +35,7 @@ namespace Blish_HUD {
         private const string GW2_32_BIT_PROCESSNAME = "Gw2";
 
         private const string GW2_PATCHWINDOW_NAME = "ArenaNet";
-        private const string GW2_GAMEWINDOW_NAME = "ArenaNet_Dx_Window_Class";
+        private const string GW2_GAMEWINDOW_NAME  = "ArenaNet_Dx_Window_Class";
 
         private const string GAMEINTEGRATION_SETTINGS = "GameIntegrationConfiguration";
 

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -30,9 +30,12 @@ namespace Blish_HUD {
         internal SettingCollection       _applicationSettings;
         private  SettingEntry<Gw2Locale> _userLocale;
         private  SettingEntry<bool>      _stayInTray;
+        private  SettingEntry<bool>      _showInTaskbar;
 
-        public Gw2Locale UserLocale => _userLocale.Value;
-        public bool      StayInTray => _stayInTray.Value;
+        public Gw2Locale UserLocale    => _userLocale.Value;
+        public bool      StayInTray    => _stayInTray.Value;
+        public bool      ShowInTaskbar => _showInTaskbar.Value;
+
 
         private bool                        _checkedClient;
         private Gw2ClientContext.ClientType _clientType;
@@ -51,11 +54,24 @@ namespace Blish_HUD {
             _applicationSettings = Settings.RegisterRootSettingCollection(APPLICATION_SETTINGS);
 
             DefineSettings(_applicationSettings);
+
+            ApplySettings();
         }
 
         private void DefineSettings(SettingCollection settings) {
-            _userLocale = settings.DefineSetting("AppCulture", GetGw2LocaleFromCurrentUICulture(), "Application & API Language", "Determines the language used when displaying Blish HUD text and when requests are made to the GW2 web API.");
-            _stayInTray = settings.DefineSetting("StayInTray", true, "Minimize to tray when Guild Wars 2 Closes", "If true, Blish HUD will automatically minimize when GW2 closes and will continue running until GW2 is launched again.\nYou can also use the Blish HUD icon in the tray to launch Guild Wars 2.");
+            _userLocale    = settings.DefineSetting("AppCulture",    GetGw2LocaleFromCurrentUICulture(), "Application & API Language",                "Determines the language used when displaying Blish HUD text and when requests are made to the GW2 web API.");
+            _stayInTray    = settings.DefineSetting("StayInTray",    true,                               "Minimize to tray when Guild Wars 2 Closes", "If true, Blish HUD will automatically minimize when GW2 closes and will continue running until GW2 is launched again.\nYou can also use the Blish HUD icon in the tray to launch Guild Wars 2.");
+            _showInTaskbar = settings.DefineSetting("ShowInTaskbar", false,                              "Show in Taskbar",                           "When enabled, Blish HUD will be shown in the taskbar.");
+
+            _showInTaskbar.SettingChanged += OverlaySettingChanged;
+        }
+
+        private void ApplySettings() {
+            WindowUtil.SetShowInTaskbar(BlishHud.FormHandle, _showInTaskbar.Value);
+        }
+
+        private void OverlaySettingChanged(object sender, ValueChangedEventArgs<bool> e) {
+            ApplySettings();
         }
 
         private Gw2Locale GetGw2LocaleFromCurrentUICulture() {
@@ -101,8 +117,9 @@ namespace Blish_HUD {
             // Center the window so that you don't have to drag it over every single time (which is really annoying)
             // TODO: Save window positions to settings so that they remember where they were last
             Graphics.SpriteScreen.Resized += delegate {
-                if (!this.BlishHudWindow.Visible)
+                if (!this.BlishHudWindow.Visible) {
                     this.BlishHudWindow.Location = new Point(Graphics.WindowWidth / 2 - this.BlishHudWindow.Width / 2, Graphics.WindowHeight / 2 - this.BlishHudWindow.Height / 2);
+                }
             };
 
             this.BlishHudWindow.AddTab(Properties.Strings.Service_DirectorService_Tab_Home, Content.GetTexture("255369"), BuildHomePanel(this.BlishHudWindow), int.MinValue);

--- a/Blish HUD/GameServices/Settings/UI/OverlaySettingsUIBuilder.cs
+++ b/Blish HUD/GameServices/Settings/UI/OverlaySettingsUIBuilder.cs
@@ -15,7 +15,7 @@ namespace Blish_HUD.Settings.UI {
                 Width       = settingPanels.ContentRegion.Width - 8,
                 Title       = "Application Settings",
                 CanCollapse = true,
-                Height      = 128,
+                Height      = 168,
                 Parent      = settingPanels,
             };
 

--- a/Blish HUD/_Utils/WindowUtil.cs
+++ b/Blish HUD/_Utils/WindowUtil.cs
@@ -15,10 +15,14 @@ namespace Blish_HUD {
         private static readonly Logger Logger = Logger.GetLogger(typeof(WindowUtil));
 
         private const uint WS_EX_TRANSPARENT = 0x00000020;
+        private const uint WS_EX_APPWINDOW   = 0x00040000;
         private const uint WS_EX_LAYERED     = 0x00080000;
 
         private const int GWL_STYLE   = -16;
         private const int GWL_EXSTYLE = -20;
+
+        private const int SW_HIDE = 0;
+        private const int SW_SHOW = 5;
 
         private const uint CS_VREDRAW = 0x0001;
         private const uint CS_HREDRAW = 0x0002;
@@ -42,6 +46,9 @@ namespace Blish_HUD {
 
         [DllImport("user32.dll", SetLastError = true)]
         private static extern bool GetClientRect(IntPtr hWnd, ref RECT lpRect);
+
+        [DllImport("user32.dll")]
+        static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
 
         [DllImport("user32.dll")]
         private static extern IntPtr GetForegroundWindow();
@@ -89,12 +96,23 @@ namespace Blish_HUD {
 
         private static int SetWindowLong(IntPtr hWnd, int nIndex, uint dwNewLong) => IntPtr.Size != 8 ? SetWindowLong32(hWnd, nIndex, dwNewLong) : (int) SetWindowLongPtr64(hWnd, nIndex, new UIntPtr(dwNewLong));
 
+        internal static void SetShowInTaskbar(IntPtr winHandle, bool showInTaskbar) {
+            if (showInTaskbar) {
+                ShowWindow(winHandle, SW_HIDE);
+                SetWindowLong(winHandle, GWL_EXSTYLE, (uint)GetWindowLong(winHandle, GWL_EXSTYLE) | WS_EX_APPWINDOW);
+                ShowWindow(winHandle, SW_SHOW);
+            } else {
+                SetWindowLong(winHandle, GWL_EXSTYLE, (uint)GetWindowLong(winHandle, GWL_EXSTYLE) & ~WS_EX_APPWINDOW);
+            }
+        }
+
         internal static void SetupOverlay(IntPtr winHandle) {
             SetWindowLong(winHandle, GWL_STYLE, CS_HREDRAW | CS_VREDRAW);
 
             SetWindowLong(winHandle, GWL_EXSTYLE, (uint)GetWindowLong(winHandle, GWL_EXSTYLE) | WS_EX_LAYERED | WS_EX_TRANSPARENT);
+            SetWindowLong(winHandle, GWL_EXSTYLE, (uint)GetWindowLong(winHandle, GWL_EXSTYLE) | WS_EX_LAYERED | WS_EX_TRANSPARENT);
 
-            SetLayeredWindowAttributes(winHandle, 0, 0, 1);
+            SetLayeredWindowAttributes(winHandle, 0, 0,   1);
             SetLayeredWindowAttributes(winHandle, 0, 255, 2);
         }
 


### PR DESCRIPTION
Added new option to hide Blish HUD from the Taskbar.  This option defaults to off (hidden).

+Minor cleanup of BlishHud class.