### PR TITLE
Minor control fixes

### DIFF
--- a/Blish HUD/Controls/LabelBase.cs
+++ b/Blish HUD/Controls/LabelBase.cs
@@ -96,7 +96,7 @@ namespace Blish_HUD.Controls {
             if (_font == null || string.IsNullOrEmpty(text)) return;
 
             if (_showShadow && !_strokeText) {
-                spriteBatch.DrawStringOnCtrl(this, text, _font, bounds.OffsetBy(1, 1), _shadowColor, false, _horizontalAlignment, _verticalAlignment);
+                spriteBatch.DrawStringOnCtrl(this, text, _font, bounds.OffsetBy(1, 1), _shadowColor, _wrapText, _horizontalAlignment, _verticalAlignment);
             }
             
             if (_cacheLabel && _labelRender != null) {

--- a/Blish HUD/Controls/Panel.cs
+++ b/Blish HUD/Controls/Panel.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 
 namespace Blish_HUD.Controls {
 
-    /// <summary>7
+    /// <summary>
     /// Used to group collections of controls. Can have an accented border and title, if enabled.
     /// </summary>
     public class Panel : Container, IAccordion {
@@ -56,7 +56,7 @@ namespace Blish_HUD.Controls {
         public bool CanScroll {
             get => _canScroll;
             set {
-                if (!SetProperty(ref _canScroll, value)) return;
+                if (!SetProperty(ref _canScroll, value, true)) return;
 
                 UpdateScrollbar();
             }

--- a/Blish HUD/Controls/ViewContainer.cs
+++ b/Blish HUD/Controls/ViewContainer.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Blish_HUD.Graphics.UI;
+using Glide;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Blish_HUD.Controls {
     public class ViewContainer : Panel {
+
+        private const float FADE_DURATION = 0.35f;
 
         private Panel _buildPanel;
         private IView _currentView;
@@ -16,9 +19,10 @@ namespace Blish_HUD.Controls {
 
         public ViewState ViewState => _viewState;
 
+        private Tween _fadeInAnimation;
+
         public void Show(IView newView) {
-            _currentView?.DoUnload();
-            _buildPanel?.Dispose();
+            this.Clear();
 
             _viewState = ViewState.Loading;
 
@@ -29,7 +33,25 @@ namespace Blish_HUD.Controls {
             newView.Loaded += BuildView;
             newView.DoLoad(progressIndicator).ContinueWith(BuildView);
 
+            _fadeInAnimation?.CancelAndComplete();
+            _opacity         = 0f;
+            _fadeInAnimation = GameService.Animation.Tweener.Tween(this, new { Opacity = 1f }, FADE_DURATION);
+
             base.Show();
+        }
+
+        /// <summary>
+        /// Clear the view from this container.
+        /// </summary>
+        public void Clear() {
+            _currentView?.DoUnload();
+
+            // Reset panel defaults
+            this.BackgroundColor   = Color.Transparent;
+            this.BackgroundTexture = null;
+            this.ClipsBounds       = true;
+
+            this.ClearChildren();
         }
 
         private void BuildView(object sender, EventArgs e) {
@@ -40,20 +62,24 @@ namespace Blish_HUD.Controls {
 
         private void BuildView(Task<bool> loadResult) {
             if (loadResult.Result) {
-                _buildPanel = new Panel() {
-                    Size = this.ContentRegion.Size
-                };
-
                 _currentView.DoBuild(_buildPanel);
-                _buildPanel.Parent = this;
             }
         }
 
         /// <inheritdoc />
         public override void PaintBeforeChildren(SpriteBatch spriteBatch, Rectangle bounds) {
+            base.PaintBeforeChildren(spriteBatch, bounds);
+
             if (_viewState == ViewState.Loading) {
-                spriteBatch.DrawStringOnCtrl(this, _loadingMessage ?? "", Content.DefaultFont14, bounds, Color.White, false, true, 1, HorizontalAlignment.Center);
+                spriteBatch.DrawStringOnCtrl(this, _loadingMessage ?? "", Content.DefaultFont14, this.ContentRegion, Color.White, false, true, 1, HorizontalAlignment.Center);
             }
+        }
+
+        /// <inheritdoc />
+        protected override void DisposeControl() {
+            this.Clear();
+
+            base.DisposeControl();
         }
 
     }


### PR DESCRIPTION
- Fixed LabelBase shadows not wrapping.
- Removed typo from Panel summary and now toggling `CanScroll` invalidates the panel.
- Properly center loading message in `ViewContainer`.
- Introduced standard panel fade when switching views.
- `Clear()` method added to `ViewContainer` to clear the active view.