### PR TITLE
Bug fix for mouse hook intercepting clips for other applications and windows getting below the overlay.

### DIFF
--- a/Blish HUD/GameServices/InputService.cs
+++ b/Blish HUD/GameServices/InputService.cs
@@ -97,7 +97,7 @@ namespace Blish_HUD {
         }
 
         private void HandleMouse() {
-            if (!GameIntegration.Gw2IsRunning || (this.FocusedControl == null && !GameIntegration.Gw2HasFocus)) {
+            if (!GameIntegration.Gw2IsRunning || !GameIntegration.Gw2HasFocus) {
                 this.HudFocused = false;
                 return;
             }


### PR DESCRIPTION
Removed `FocusedControl` from the `HudFocus` check in `HandleMouse` since it is not related to the mouse.  This should resolve #81.

Also fixed an issue that would allow you to move windows between the game and Blish HUD and potentially requiring multiple clicks to get the outside application to show above Blish HUD.  This should resolve #128. 