### PR TITLE
Avoid wiping settings file on version changes

### DIFF
--- a/Blish HUD/GameServices/Settings/SettingCollection.cs
+++ b/Blish HUD/GameServices/Settings/SettingCollection.cs
@@ -22,8 +22,7 @@ namespace Blish_HUD.Settings {
                 if (value.Loaded) {
                     entryArray = new JArray();
 
-                    foreach (var entry in value._entries.Where(e => !e.IsNull)) {
-                        var entryObject = JObject.FromObject(entry, serializer);
+                    foreach (var entryObject in value._entries.Where(e => !e.IsNull).Select(entry => JObject.FromObject(entry, serializer))) {
                         entryArray.Add(entryObject);
                     }
                 }
@@ -112,7 +111,7 @@ namespace Blish_HUD.Settings {
         private void Load() {
             if (_entryTokens == null) return;
 
-            _entries = JsonConvert.DeserializeObject<List<SettingEntry>>(_entryTokens.ToString(), GameService.Settings.JsonReaderSettings);
+            _entries = JsonConvert.DeserializeObject<List<SettingEntry>>(_entryTokens.ToString(), GameService.Settings.JsonReaderSettings).Where((se) => se != null).ToList();
 
             _entryTokens = null;
         }

--- a/Blish HUD/GameServices/Settings/SettingEntry[T].cs
+++ b/Blish HUD/GameServices/Settings/SettingEntry[T].cs
@@ -18,7 +18,7 @@ namespace Blish_HUD.Settings {
 
         private T _value;
 
-        [JsonProperty, JsonRequired]
+        [JsonProperty(SETTINGVALUE_KEY), JsonRequired]
         public T Value {
             get => _value;
             set {


### PR DESCRIPTION
As classes continue to be moved around, the `FullName` of these types no longer match up with what is written in the `settings.json` file.  Currently, if a settings name or namespace has changed (or no longer exists), the settings will be wiped as the `SettingsService` attempts to load the Type associated with the setting and an exception is thrown.

This fix detects if the type is missing, writes a warning to the log, and moves onward gracefully (losing just the setting) preventing the settings file from being fully wiped.

Additionally, consts were introduced for the setting type, name/key, and value fields, just to ensure consistency and improve readability of the code.