### PR TITLE
Added support for launch parameters.

### DIFF
--- a/Blish HUD/ApplicationSettings.cs
+++ b/Blish HUD/ApplicationSettings.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using EntryPoint;
+
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+
+namespace Blish_HUD {
+    [Help("Optional launch arguments that modify overlay behavior.")]
+    public class ApplicationSettings : BaseCliArguments {
+
+        private static ApplicationSettings _instance;
+
+        internal static ApplicationSettings Instance => _instance;
+
+        public ApplicationSettings() : base("Blish HUD") {
+            _instance = this;
+        }
+
+        #region Game Integration
+
+        [
+            OptionParameter("process", 'p'),
+            Help("The name of the process to overlay (without '.exe').")
+        ]
+        public string ProcessName { get; private set; }
+
+        [
+            OptionParameter("window", 'w'),
+            Help("The name of the window to overlay.")
+        ]
+        public string WindowName { get; private set; }
+
+        #endregion
+
+        #region Utility
+
+        [
+            OptionParameter("settings", 's'),
+            Help("The path where Blish HUD will save settings and other files.")
+        ]
+        public string UserSettingsPath { get; private set; }
+
+        [
+            OptionParameter("ref", 'r'),
+            Help("The path to the ref.dat file.")
+        ]
+        public string RefPath { get; private set; }
+
+        #endregion
+
+    }
+}

--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -91,6 +91,7 @@
     <StartupObject>Blish_HUD.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ApplicationSettings.cs" />
     <Compile Include="Common\Gw2\ChatCode.cs" />
     <Compile Include="Common\Gw2\KeyBindings.cs" />
     <Compile Include="Controls\Intern\Mouse.cs" />
@@ -507,6 +508,9 @@
     </PackageReference>
     <PackageReference Include="DynamicLanguageRuntime">
       <Version>1.2.2</Version>
+    </PackageReference>
+    <PackageReference Include="EntryPoint">
+      <Version>1.3.0</Version>
     </PackageReference>
     <PackageReference Include="Flurl.Http">
       <Version>2.4.2</Version>

--- a/Blish HUD/GameServices/ContentService.cs
+++ b/Blish HUD/GameServices/ContentService.cs
@@ -132,12 +132,14 @@ namespace Blish_HUD {
         }
 
         private static Texture2D TextureFromFileSystem(string filepath) {
-            if (!File.Exists(REF_FILE)) {
-                Logger.Warn("{refFileName} is missing!  Lots of assets will be missing!", REF_FILE);
+            string refPath = ApplicationSettings.Instance.RefPath ?? REF_FILE;
+
+            if (!File.Exists(refPath)) {
+                Logger.Warn("{refFileName} is missing!  Lots of assets will be missing!", refPath);
                 return null;
             }
             
-            using (var refFs = new FileStream(REF_FILE, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+            using (var refFs = new FileStream(refPath, FileMode.Open, FileAccess.Read, FileShare.Read)) {
                 using (var refArchive = new ZipArchive(refFs, ZipArchiveMode.Read)) {
                     var refEntry = refArchive.GetEntry(filepath);
 

--- a/Blish HUD/GameServices/GameIntegrationService.cs
+++ b/Blish HUD/GameServices/GameIntegrationService.cs
@@ -98,8 +98,8 @@ namespace Blish_HUD {
                     }
                 }
 
-                // GW2 is running if the "_gw2Process" isn't null and the name of the process
-                // is the game window name (so we know we are passed the login screen)
+                // GW2 is running if the "_gw2Process" isn't null and the class name of process' 
+                // window is the game window name (so we know we are passed the login screen)
                 this.Gw2IsRunning = _gw2Process != null
                                  && WindowUtil.GetClassNameOfWindow(this.Gw2Process.MainWindowHandle) == (ApplicationSettings.Instance.WindowName
                                                                                                        ?? GW2_GAMEWINDOW_NAME);

--- a/Blish HUD/GameServices/GameIntegrationService.cs
+++ b/Blish HUD/GameServices/GameIntegrationService.cs
@@ -98,7 +98,11 @@ namespace Blish_HUD {
                     }
                 }
 
-                this.Gw2IsRunning = _gw2Process != null && WindowUtil.GetClassNameOfWindow(this.Gw2Process.MainWindowHandle) == GW2_GAMEWINDOW_NAME;
+                // GW2 is running if the "_gw2Process" isn't null and the name of the process
+                // is the game window name (so we know we are passed the login screen)
+                this.Gw2IsRunning = _gw2Process != null
+                                 && WindowUtil.GetClassNameOfWindow(this.Gw2Process.MainWindowHandle) == (ApplicationSettings.Instance.WindowName
+                                                                                                       ?? GW2_GAMEWINDOW_NAME);
             }
         }
 
@@ -240,7 +244,7 @@ namespace Blish_HUD {
 
         private Process GetGw2Process() {
             // Check to see if 64-bit Gw2 process is running (since it's likely the most common at this point)
-            Process[] gw2Processes = Process.GetProcessesByName(GW2_64_BIT_PROCESSNAME);
+            Process[] gw2Processes = Process.GetProcessesByName(ApplicationSettings.Instance.ProcessName ?? GW2_64_BIT_PROCESSNAME);
 
             if (gw2Processes.Length == 0) {
                 // 64-bit process not found so see if they're using a 32-bit client instead

--- a/Blish HUD/Program.cs
+++ b/Blish HUD/Program.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Threading;
 using System.Windows.Forms;
+using EntryPoint;
 
 namespace Blish_HUD {
 
@@ -10,11 +11,11 @@ namespace Blish_HUD {
     /// </summary>
     public static class Program {
 
-        private static readonly Logger Logger;
+        private static Logger Logger;
 
         public static SemVer.Version OverlayVersion { get; } = new SemVer.Version(typeof(BlishHud).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion, true);
 
-        static Program() {
+        private static void EnableLogging() {
             // Make sure logging and logging services are available as soon as possible
             DebugService.InitDebug();
             Logger = Logger.GetLogger(typeof(Program));
@@ -33,7 +34,11 @@ namespace Blish_HUD {
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main() {
+        static void Main(string[] args) {
+            Cli.Parse<ApplicationSettings>(args);
+
+            EnableLogging();
+
             if (IsMoreThanOneInstance()) {
                 Logger.Warn("Blish HUD is already running!");
                 return;

--- a/Blish HUD/_Utils/DirectoryUtil.cs
+++ b/Blish HUD/_Utils/DirectoryUtil.cs
@@ -22,7 +22,8 @@ namespace Blish_HUD {
 
         static DirectoryUtil() {
             // Prepare user documents directory
-            BasePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments,
+            BasePath = ApplicationSettings.Instance.UserSettingsPath
+                    ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments,
                                                                Environment.SpecialFolderOption.DoNotVerify),
                                      ADDON_DIR);
 


### PR DESCRIPTION
Likely more supported parameters to come in the future.

Added support for launch parameters including:

- ProcessName(process/p)
- WindowName(window/w)
- UserSettingsPath (settings/s)
- RefPath (ref/r)

Wiki document provides details and example usage: https://github.com/blish-hud/Blish-HUD/wiki/Launch-Options

Implements a solution for #169.