### PR TITLE
Reimplemented KeybindingAssigner and KeybindingAssignerWindow controls + KeyboardManager fixes

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -93,6 +93,8 @@
   <ItemGroup>
     <Compile Include="Common\Gw2\ChatCode.cs" />
     <Compile Include="Common\Gw2\KeyBindings.cs" />
+    <Compile Include="Controls\KeybindingAssignmentWindow.cs" />
+    <Compile Include="Controls\KeybindingAssigner.cs" />
     <Compile Include="Controls\Intern\Mouse.cs" />
     <Compile Include="Controls\ViewContainer.cs" />
     <Compile Include="Controls\_Types\ViewState.cs" />

--- a/Blish HUD/Controls/Control.cs
+++ b/Blish HUD/Controls/Control.cs
@@ -4,9 +4,11 @@ using Microsoft.Xna.Framework.Input;
 using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Windows.Forms;
 using Blish_HUD.Controls.Effects;
 using Blish_HUD.Input;
 using Newtonsoft.Json;
+using MouseEventArgs = Blish_HUD.Input.MouseEventArgs;
 
 namespace Blish_HUD.Controls {
 
@@ -154,11 +156,20 @@ namespace Blish_HUD.Controls {
             this.LeftMouseButtonPressed?.Invoke(this, e);
         }
 
+        private double _lastClickTime = 0;
+
         protected virtual void OnLeftMouseButtonReleased(MouseEventArgs e) {
             this.LeftMouseButtonReleased?.Invoke(this, e);
 
-            if (_enabled)
-                OnClick(e);
+            if (_enabled) {
+                // Distinguish click from double-click
+                if (GameService.Overlay.CurrentGameTime.TotalGameTime.TotalMilliseconds - _lastClickTime < SystemInformation.DoubleClickTime) {
+                    OnClick(new MouseEventArgs(e.EventType, true));
+                } else {
+                    _lastClickTime = GameService.Overlay.CurrentGameTime.TotalGameTime.TotalMilliseconds;
+                    OnClick(e);
+                }
+            }
         }
 
         protected virtual void OnMouseMoved(MouseEventArgs e) {
@@ -185,9 +196,6 @@ namespace Blish_HUD.Controls {
             this.MouseLeft?.Invoke(this, e);
         }
 
-        /// <summary>
-        /// Fires <see cref="OnLeftMouseButtonReleased"/> if the control is enabled.
-        /// </summary>
         protected virtual void OnClick(MouseEventArgs e) {
             this.Click?.Invoke(this, e);
         }

--- a/Blish HUD/Controls/KeybindingAssigner.cs
+++ b/Blish HUD/Controls/KeybindingAssigner.cs
@@ -1,0 +1,138 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using System;
+using Blish_HUD.Input;
+using Microsoft.Xna.Framework;
+
+namespace Blish_HUD.Controls {
+    public class KeybindingAssigner : LabelBase {
+
+        private const int UNIVERSAL_PADDING = 2;
+
+        private const int DOUBLE_CLICK_THRESHOLD = 600;
+
+        private int _nameWidth = 183;
+
+        /// <summary>
+        /// The width of the name area of the <see cref="KeybindingAssigner"/>.
+        /// The remaining width of the control is used to show the key binding.
+        /// </summary>
+        public int NameWidth {
+            get => _nameWidth;
+            set => SetProperty(ref _nameWidth, value, true);
+        }
+
+        private KeyBinding _keyBinding;
+
+        /// <summary>
+        /// The name shown as the key binding name.
+        /// </summary>
+        public string KeyBindingName {
+            get => _text;
+            set => SetProperty(ref _text, value);
+        }
+
+        private Rectangle _nameRegion;
+        private Rectangle _hotkeyRegion;
+
+        private DateTime _lastClickTime;
+        private bool     _overHotkey;
+
+        public KeyBinding KeyBinding {
+            get => _keyBinding;
+            set => SetProperty(ref _keyBinding, value);
+        }
+
+        public KeybindingAssigner(KeyBinding keyBinding) {
+            _keyBinding = keyBinding;
+
+            // Configure LabelBase
+            _font       = Content.DefaultFont14;
+            _showShadow = true;
+            _cacheLabel = false;
+
+            this.Size = new Point(340, 16);
+
+            _lastClickTime = DateTime.MinValue;
+        }
+
+        protected override void OnClick(MouseEventArgs e) {
+            if (_overHotkey) {
+                // This is used to make it require a double-click to open the assignment window instead of just a single-click
+                if (DateTime.Now.Subtract(_lastClickTime).TotalMilliseconds < DOUBLE_CLICK_THRESHOLD) {
+                    SetupNewAssignmentWindow();
+                } else {
+                    _lastClickTime = DateTime.Now;
+                }
+            }
+
+            base.OnClick(e);
+        }
+
+        protected override void OnMouseMoved(MouseEventArgs e) {
+            _overHotkey = this.RelativeMousePosition.X >= _hotkeyRegion.Left;
+
+            base.OnMouseMoved(e);
+        }
+
+        protected override void OnMouseLeft(MouseEventArgs e) {
+            _overHotkey = false;
+
+            base.OnMouseLeft(e);
+        }
+
+        public override void RecalculateLayout() {
+            _nameRegion   = new Rectangle(0,                              0, _nameWidth,                               _size.Y);
+            _hotkeyRegion = new Rectangle(_nameWidth + UNIVERSAL_PADDING, 0, _size.X - _nameWidth - UNIVERSAL_PADDING, _size.Y);
+        }
+
+        private void SetupNewAssignmentWindow() {
+            var newHkAssign = new KeybindingAssignmentWindow(_text, _keyBinding.ModifierKeys, _keyBinding.PrimaryKey) {
+                Parent = Graphics.SpriteScreen
+            };
+
+            newHkAssign.AssignmentAccepted += delegate {
+                _keyBinding.ModifierKeys = newHkAssign.ModifierKeys;
+                _keyBinding.PrimaryKey   = newHkAssign.PrimaryKey;
+            };
+
+            newHkAssign.Show();
+        }
+
+        protected override CaptureType CapturesInput() { return CaptureType.Filter | CaptureType.Mouse; }
+
+        protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
+            // Draw white panel for keybinding name
+            spriteBatch.DrawOnCtrl(this,
+                                   ContentService.Textures.Pixel,
+                                   _nameRegion,
+                                   Color.White * 0.15f);
+
+            // Draw keybinding name
+            DrawText(spriteBatch, _nameRegion);
+
+            // Draw white panel for hotkey
+            spriteBatch.DrawOnCtrl(this,
+                                   ContentService.Textures.Pixel,
+                                   _hotkeyRegion,
+                                   Color.White * (_overHotkey ? 0.20f : 0.15f));
+
+            // Draw keybind string
+            spriteBatch.DrawStringOnCtrl(this,
+                                         _keyBinding.GetBindingDisplayText(),
+                                         Content.DefaultFont14,
+                                         _hotkeyRegion.OffsetBy(1, 1),
+                                         Color.Black,
+                                         false,
+                                         HorizontalAlignment.Center);
+
+            spriteBatch.DrawStringOnCtrl(this,
+                                         _keyBinding.GetBindingDisplayText(),
+                                         Content.DefaultFont14,
+                                         _hotkeyRegion,
+                                         Color.White,
+                                         false,
+                                         HorizontalAlignment.Center);
+        }
+
+    }
+}

--- a/Blish HUD/Controls/KeybindingAssigner.cs
+++ b/Blish HUD/Controls/KeybindingAssigner.cs
@@ -8,8 +8,6 @@ namespace Blish_HUD.Controls {
 
         private const int UNIVERSAL_PADDING = 2;
 
-        private const int DOUBLE_CLICK_THRESHOLD = 600;
-
         private int _nameWidth = 183;
 
         /// <summary>
@@ -34,8 +32,7 @@ namespace Blish_HUD.Controls {
         private Rectangle _nameRegion;
         private Rectangle _hotkeyRegion;
 
-        private DateTime _lastClickTime;
-        private bool     _overHotkey;
+        private bool _overHotkey;
 
         public KeyBinding KeyBinding {
             get => _keyBinding;
@@ -51,18 +48,11 @@ namespace Blish_HUD.Controls {
             _cacheLabel = false;
 
             this.Size = new Point(340, 16);
-
-            _lastClickTime = DateTime.MinValue;
         }
 
         protected override void OnClick(MouseEventArgs e) {
-            if (_overHotkey) {
-                // This is used to make it require a double-click to open the assignment window instead of just a single-click
-                if (DateTime.Now.Subtract(_lastClickTime).TotalMilliseconds < DOUBLE_CLICK_THRESHOLD) {
-                    SetupNewAssignmentWindow();
-                } else {
-                    _lastClickTime = DateTime.Now;
-                }
+            if (_overHotkey && e.IsDoubleClick) {
+                SetupNewAssignmentWindow();
             }
 
             base.OnClick(e);

--- a/Blish HUD/Controls/KeybindingAssignmentWindow.cs
+++ b/Blish HUD/Controls/KeybindingAssignmentWindow.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Blish_HUD.Input;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+
+namespace Blish_HUD.Controls {
+    public class KeybindingAssignmentWindow : Container {
+
+        #region Load Static
+
+        private static readonly Texture2D _textureWindowTexture;
+
+        static KeybindingAssignmentWindow() {
+            _textureWindowTexture = Content.GetTexture("hotkey-window");
+        }
+
+        #endregion
+
+        #region Events
+
+        /// <summary>
+        /// Fires when the "Accept" button is pressed within the assignment window.
+        /// Indicates that the assignment was accepted and the resulting primary and
+        /// modifier keys should update their target.
+        /// </summary>
+        public event EventHandler<EventArgs> AssignmentAccepted;
+
+        /// <summary>
+        /// Fires when the "Cancel" button or escape is pressed within the assignment window.
+        /// Indicates that the assignment was canceled and the resulting primary and modifier
+        /// keys should be ignored.
+        /// </summary>
+        public event EventHandler<EventArgs> AssignmentCanceled;
+
+        private void OnAssignmentAccepted(EventArgs e) {
+            this.AssignmentAccepted?.Invoke(this, e);
+
+            FinishAssignment();
+        }
+
+        private void OnAssignmentCanceled(EventArgs e) {
+            this.AssignmentCanceled?.Invoke(this, e);
+
+            FinishAssignment();
+        }
+
+        #endregion
+
+        private readonly Rectangle _normalizedHotkeyRegion = new Rectangle(60, 80, 225, 30);
+        private readonly Rectangle _normalizedWindowRegion = new Rectangle(0,  0,  371, 200);
+
+        private ModifierKeys _modifierKeys;
+        private Keys         _primaryKey;
+
+        /// <summary>
+        /// The current modifier key(s) assignment.
+        /// </summary>
+        public ModifierKeys ModifierKeys {
+            get => _modifierKeys;
+            private set => SetProperty(ref _modifierKeys, value, true);
+        }
+
+        /// <summary>
+        /// The current primary key assignment.
+        /// </summary>
+        public Keys PrimaryKey {
+            get => _primaryKey;
+            private set => SetProperty(ref _primaryKey, value, true);
+        }
+
+        private readonly string _assignmentName;
+
+        private string _assignmentDisplayString;
+
+        public KeybindingAssignmentWindow(string assignmentName, ModifierKeys modifierKeys = ModifierKeys.None, Keys primaryKey = Keys.None) {
+            _assignmentName = assignmentName;
+            _modifierKeys   = modifierKeys;
+            _primaryKey     = primaryKey;
+
+            this.BackgroundColor = Color.Black * 0.3f;
+            this.Size            = new Point(_normalizedWindowRegion.Width, _normalizedWindowRegion.Height);
+            this.ZIndex          = int.MaxValue - 2;
+            this.Visible         = false;
+
+            BuildChildElements();
+
+            Input.Keyboard.KeyStateChanged += KeyboardOnKeyStateChanged;
+        }
+
+        protected override void OnShown(EventArgs e) {
+            Invalidate();
+
+            base.OnShown(e);
+        }
+
+        private void KeyboardOnKeyStateChanged(object sender, KeyboardEventArgs e) {
+            if (e.Key == Keys.Escape) {
+                if (e.EventType == KeyboardEventType.KeyUp) {
+                    OnAssignmentCanceled(EventArgs.Empty);
+                }
+
+                return;
+            }
+
+            if (e.EventType == KeyboardEventType.KeyDown) {
+                (this.ModifierKeys, this.PrimaryKey) = KeysUtil.SplitToBindingPair(Input.Keyboard.KeysDown);
+            }
+        }
+
+        private void FinishAssignment() {
+            this.Dispose();
+        }
+
+        private StandardButton _acceptBttn;
+        private StandardButton _unbindBttn;
+        private StandardButton _cancelBttn;
+
+        private void BuildChildElements() {
+            var assignInputsLbl = new Label() {
+                Text           = string.Format(Strings.GameServices.InputService.Hotkey_AssignInputsTo, _assignmentName),
+                Location       = new Point(40, 35),
+                ShowShadow     = true,
+                AutoSizeWidth  = true,
+                AutoSizeHeight = true,
+                Parent         = this
+            };
+
+            _unbindBttn = new StandardButton() {
+                Text     = Strings.GameServices.InputService.Hotkey_Unbind,
+                Location = new Point(275, 85),
+                Width    = 70,
+                Height   = 25,
+                Parent   = this
+            };
+
+            _cancelBttn = new StandardButton() {
+                Text     = Strings.Common.Action_Cancel,
+                Location = new Point(275, 140),
+                Width    = 70,
+                Height   = 25,
+                Parent   = this
+            };
+
+            _acceptBttn = new StandardButton() {
+                Text   = Strings.Common.Action_Accept,
+                Width  = 105,
+                Height = 25,
+                Parent = this
+            };
+            _acceptBttn.Location = new Point(_cancelBttn.Left - 8 - _acceptBttn.Width, _cancelBttn.Top);
+
+            _unbindBttn.Click += delegate {
+                this.ModifierKeys = ModifierKeys.None;
+                this.PrimaryKey   = Keys.None;
+            };
+
+            _cancelBttn.Click += delegate {
+                OnAssignmentCanceled(EventArgs.Empty);
+            };
+
+            _acceptBttn.Click += delegate {
+                OnAssignmentAccepted(EventArgs.Empty);
+            };
+        }
+
+        private Rectangle _hotkeyRegion;
+        private Rectangle _windowRegion;
+
+        public override void RecalculateLayout() {
+            base.RecalculateLayout();
+
+            if (this.Parent != null) {
+                _size = this.Parent.Size;
+
+                var distanceInwards = new Point(_size.X / 2 - _normalizedWindowRegion.Width  / 2,
+                                                _size.Y / 2 - _normalizedWindowRegion.Height / 2);
+
+                _hotkeyRegion = _normalizedHotkeyRegion.OffsetBy(distanceInwards);
+                _windowRegion = _normalizedWindowRegion.OffsetBy(distanceInwards);
+
+                this.ContentRegion = _windowRegion;
+            }
+
+            _assignmentDisplayString = KeysUtil.GetFriendlyName(_modifierKeys, _primaryKey);
+
+            if (_unbindBttn != null) {
+                _unbindBttn.Enabled = this.PrimaryKey != Keys.None;
+            }
+        }
+
+        public override void PaintBeforeChildren(SpriteBatch spriteBatch, Rectangle bounds) {
+            spriteBatch.DrawOnCtrl(this, _textureWindowTexture, _windowRegion);
+
+            spriteBatch.DrawStringOnCtrl(this, _assignmentDisplayString, Content.DefaultFont16, _hotkeyRegion.OffsetBy(1, 1), Color.Black);
+            spriteBatch.DrawStringOnCtrl(this, _assignmentDisplayString, Content.DefaultFont16, _hotkeyRegion,                Color.White);
+        }
+
+        protected override void DisposeControl() {
+            base.DisposeControl();
+
+            Input.Keyboard.KeyStateChanged -= KeyboardOnKeyStateChanged;
+        }
+
+    }
+}

--- a/Blish HUD/GameServices/Input/InputManager.cs
+++ b/Blish HUD/GameServices/Input/InputManager.cs
@@ -29,11 +29,18 @@ namespace Blish_HUD.Input {
             _hookThread              = new Thread(DoHook);
             _hookThread.IsBackground = true;
             _hookThread.Start();
+
+            OnEnable();
         }
 
         internal void Disable() {
             _hook.DisableHook();
+
+            OnDisable();
         }
+
+        protected virtual void OnEnable() { /* NOOP */ }
+        protected virtual void OnDisable() { /* NOOP */ }
 
         internal abstract void Update();
 

--- a/Blish HUD/GameServices/Input/KeyBinding.cs
+++ b/Blish HUD/GameServices/Input/KeyBinding.cs
@@ -102,19 +102,7 @@ namespace Blish_HUD.Input {
         /// Gets a display string representing the <see cref="KeyBinding"/> suitable
         /// for display in the UI.
         /// </summary>
-        public string GetBindingDisplayText() {
-            string displayText = "";
-
-            if (this.PrimaryKey != Keys.None) {
-                if (this.ModifierKeys != ModifierKeys.None) {
-                    displayText = $"{this.ModifierKeys.ToString().Replace(", ", " + ")} + ";
-                }
-
-                displayText += KeysUtil.GetFriendlyName(this.PrimaryKey);
-            }
-
-            return displayText;
-        }
+        public string GetBindingDisplayText() => KeysUtil.GetFriendlyName(this.ModifierKeys, this.PrimaryKey);
 
         /// <summary>
         /// Manually triggers the actions bound to this <see cref="KeyBinding"/>.

--- a/Blish HUD/GameServices/Input/KeysUtil.cs
+++ b/Blish HUD/GameServices/Input/KeysUtil.cs
@@ -106,6 +106,24 @@ namespace Blish_HUD.Input {
         }
 
         /// <summary>
+        /// Gets a display string representing a <see cref="ModifierKeys"/> and
+        /// <see cref="Keys"/> pair suitable for display in the UI.
+        /// </summary>
+        public static string GetFriendlyName(ModifierKeys modifierKeys, Keys primaryKey) {
+            string displayText = "";
+
+            if (primaryKey != Keys.None) {
+                if (modifierKeys != ModifierKeys.None) {
+                    displayText = $"{modifierKeys.ToString().Replace(", ", " + ")} + ";
+                }
+
+                displayText += GetFriendlyName(primaryKey);
+            }
+
+            return displayText;
+        }
+
+        /// <summary>
         /// Returns a flag indicating the set <see cref="ModifierKeys"/> and the remaining <see cref="Keys"/> value
         /// suitable for a <see cref="KeyBinding"/> from an <see cref="Enumerable"/> of <see cref="Keys"/>.
         /// </summary>
@@ -116,9 +134,9 @@ namespace Blish_HUD.Input {
             var firstModifier = Keys.None;
 
             foreach (var providedKey in keys) {
-                if (key == Keys.None) {
-                    key = providedKey;
-                }
+                //if (key == Keys.None) {
+                //    key = providedKey;
+                //}
 
                 var modifier = ModifierKeyFromKey(providedKey);
 

--- a/Blish HUD/GameServices/Input/KeysUtil.cs
+++ b/Blish HUD/GameServices/Input/KeysUtil.cs
@@ -134,10 +134,6 @@ namespace Blish_HUD.Input {
             var firstModifier = Keys.None;
 
             foreach (var providedKey in keys) {
-                //if (key == Keys.None) {
-                //    key = providedKey;
-                //}
-
                 var modifier = ModifierKeyFromKey(providedKey);
 
                 if (modifier == ModifierKeys.None) { 

--- a/Blish HUD/GameServices/Input/MouseEventArgs.cs
+++ b/Blish HUD/GameServices/Input/MouseEventArgs.cs
@@ -19,10 +19,19 @@ namespace Blish_HUD.Input {
         /// </summary>
         public Point MousePosition => GameService.Input.Mouse.Position;
 
+        /// <summary>
+        /// Indicates if the click event is considered a double-click.
+        /// </summary>
+        public bool IsDoubleClick { get; }
+
         internal MouseLLHookStruct Details { get; }
 
         public MouseEventArgs(MouseEventType eventType) {
             this.EventType = eventType;
+        }
+
+        public MouseEventArgs(MouseEventType eventType, bool isDoubleClick) : this(eventType) {
+            this.IsDoubleClick = isDoubleClick;
         }
 
         internal MouseEventArgs(MouseEventType eventType, MouseLLHookStruct details) : this(eventType) {


### PR DESCRIPTION
Force keys to depress when the keyboard hook is disabled to prevent stuck keys when the game gains and loses focus.  Prevented keys being held down from filling the _keysDown list and from firing keydown when the key was already down.

Added GetFriendlyName with ModifierKeys and Keys params for full KeyBinding display strings which could be referenced both by KeyBindings and the new KeybindingAssinger control.

Added the KeybindingAssigner control back into the repo which allows you to tie a KeyBinding to it to then manipulate it.  When double-clicked, a KeybindingAssignmentWindow is shown which allows the user to update the keybinding.

The new controls can be seen in action, here: https://gfycat.com/smoothpreciousbandicoot