### PR TITLE
Reimplement ColorBox + ColorPicker

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -269,6 +269,7 @@
     <Compile Include="GameServices\Pathing\Entities\Effects\MarkerEffect.cs" />
     <Compile Include="GameServices\Pathing\PathableAttribute.cs" />
     <Compile Include="GameServices\Pathing\PathableAttributeCollection.cs" />
+    <Compile Include="_Extensions\ColorExtensions.cs" />
     <Compile Include="_Utils\DirectoryUtil.cs" />
     <Compile Include="_Utils\InvariantUtil.cs" />
     <Compile Include="_Utils\LoadingSpinnerUtil.cs" />

--- a/Blish HUD/Controls/ColorBox.cs
+++ b/Blish HUD/Controls/ColorBox.cs
@@ -20,13 +20,13 @@ namespace Blish_HUD.Controls {
         public event EventHandler<EventArgs> OnColorChanged;
         public event EventHandler<EventArgs> OnSelected;
 
-        private const int DEFAULT_COLOR_SIZE = 32;
-        private const string COLOR_CHANGE_SOUND_NAME = "audio/color-change";
-        private const string DRAW_VARIATION_VERSION_ONE_NAME = "colorpicker/cp-clr-v1";
-        private const string DRAW_VARIATION_VERSION_TWO_NAME = "colorpicker/cp-clr-v2";
+        private const int    DEFAULT_COLOR_SIZE                = 32;
+        private const string COLOR_CHANGE_SOUND_NAME           = "audio/color-change";
+        private const string DRAW_VARIATION_VERSION_ONE_NAME   = "colorpicker/cp-clr-v1";
+        private const string DRAW_VARIATION_VERSION_TWO_NAME   = "colorpicker/cp-clr-v2";
         private const string DRAW_VARIATION_VERSION_THREE_NAME = "colorpicker/cp-clr-v3";
-        private const string DRAW_VARIATION_VERSION_FOUR_NAME = "colorpicker/cp-clr-v4";
-        private const string HIGHLIGHT_NAME = "colorpicker/cp-clr-active";
+        private const string DRAW_VARIATION_VERSION_FOUR_NAME  = "colorpicker/cp-clr-v4";
+        private const string HIGHLIGHT_NAME                    = "colorpicker/cp-clr-active";
 
         private readonly int drawVariation;
 
@@ -38,8 +38,7 @@ namespace Blish_HUD.Controls {
                 if (SetProperty(ref selected, value)) {
                     this.OnSelected?.Invoke(this, EventArgs.Empty);
 
-                    if (this.Visible)
-                        Content.PlaySoundEffectByName(COLOR_CHANGE_SOUND_NAME);
+                    if (this.Visible) Content.PlaySoundEffectByName(COLOR_CHANGE_SOUND_NAME);
                 }
             }
         }
@@ -49,8 +48,7 @@ namespace Blish_HUD.Controls {
         public Gw2Sharp.WebApi.V2.Models.Color Color {
             get => color;
             set {
-                if (color == value)
-                    return;
+                if (color == value) return;
 
                 color = value;
 
@@ -63,18 +61,15 @@ namespace Blish_HUD.Controls {
         public int ColorId => this.Color?.Id ?? -1;
 
         private static TextureRegion2D[] _possibleDrawVariations;
-        private static TextureRegion2D _spriteHighlight;
+        private static TextureRegion2D   _spriteHighlight;
 
         private static void LoadStatics() {
-            if (_possibleDrawVariations != null)
-                return;
+            if (_possibleDrawVariations != null) return;
 
             // Load static sprite regions
             _possibleDrawVariations = new TextureRegion2D[] {
-                Resources.Control.TextureAtlasControl.GetRegion(DRAW_VARIATION_VERSION_ONE_NAME),
-                Resources.Control.TextureAtlasControl.GetRegion(DRAW_VARIATION_VERSION_TWO_NAME),
-                Resources.Control.TextureAtlasControl.GetRegion(DRAW_VARIATION_VERSION_THREE_NAME),
-                Resources.Control.TextureAtlasControl.GetRegion(DRAW_VARIATION_VERSION_FOUR_NAME),
+                Resources.Control.TextureAtlasControl.GetRegion(DRAW_VARIATION_VERSION_ONE_NAME), Resources.Control.TextureAtlasControl.GetRegion(DRAW_VARIATION_VERSION_TWO_NAME),
+                Resources.Control.TextureAtlasControl.GetRegion(DRAW_VARIATION_VERSION_THREE_NAME), Resources.Control.TextureAtlasControl.GetRegion(DRAW_VARIATION_VERSION_FOUR_NAME),
             };
 
             _spriteHighlight = Resources.Control.TextureAtlasControl.GetRegion(HIGHLIGHT_NAME);
@@ -102,8 +97,7 @@ namespace Blish_HUD.Controls {
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
             spriteBatch.DrawOnCtrl(this, _possibleDrawVariations[drawVariation], bounds, this.Color?.Cloth?.ToXnaColor() ?? Microsoft.Xna.Framework.Color.White);
 
-            if (this.MouseOver || this.Selected)
-                spriteBatch.DrawOnCtrl(this, _spriteHighlight, bounds, Microsoft.Xna.Framework.Color.White * 0.7f);
+            if (this.MouseOver || this.Selected) spriteBatch.DrawOnCtrl(this, _spriteHighlight, bounds, Microsoft.Xna.Framework.Color.White * 0.7f);
         }
 
     }

--- a/Blish HUD/Controls/ColorBox.cs
+++ b/Blish HUD/Controls/ColorBox.cs
@@ -14,20 +14,20 @@ using Blish_HUD._Extensions;
 namespace Blish_HUD.Controls {
 
     // TODO: Need to have events updated in ColorBox to match the standard applied in Control class
-    // TODO: Need to revisit the implementation of ColorBox
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class ColorBox : Control {
 
         public event EventHandler<EventArgs> OnColorChanged;
         public event EventHandler<EventArgs> OnSelected;
 
-        private const int ColorSize = 32;
-        private const string ColorChangeSoundName = @"audio\color-change";
-        private const string DrawVariationVersionOneName = "colorpicker/cp-clr-v1";
-        private const string DrawVariationVersionTwoName = "colorpicker/cp-clr-v2";
-        private const string DrawVariationVersionThreeName = "colorpicker/cp-clr-v3";
-        private const string DrawVariationVersionFourName = "colorpicker/cp-clr-v4";
-        private const string HighlightName = "colorpicker/cp-clr-active";
+        private const int DEFAULT_COLOR_SIZE = 32;
+        private const string COLOR_CHANGE_SOUND_NAME = @"audio\color-change";
+        private const string DRAW_VARIATION_VERSION_ONE_NAME = "colorpicker/cp-clr-v1";
+        private const string DRAW_VARIATION_VERSION_TWO_NAME = "colorpicker/cp-clr-v2";
+        private const string DRAW_VARIATION_VERSION_THREE_NAME = "colorpicker/cp-clr-v3";
+        private const string DRAW_VARIATION_VERSION_FOUR_NAME = "colorpicker/cp-clr-v4";
+        private const string HIGHLIGHT_NAME = "colorpicker/cp-clr-active";
+
         private readonly int drawVariation;
 
         private bool selected = false;
@@ -39,7 +39,7 @@ namespace Blish_HUD.Controls {
                     this.OnSelected?.Invoke(this, EventArgs.Empty);
 
                     if (this.Visible)
-                        Content.PlaySoundEffectByName(ColorChangeSoundName);
+                        Content.PlaySoundEffectByName(COLOR_CHANGE_SOUND_NAME);
                 }
             }
         }
@@ -71,20 +71,20 @@ namespace Blish_HUD.Controls {
 
             // Load static sprite regions
             _possibleDrawVariations = new TextureRegion2D[] {
-                Resources.Control.TextureAtlasControl.GetRegion(DrawVariationVersionOneName),
-                Resources.Control.TextureAtlasControl.GetRegion(DrawVariationVersionTwoName), 
-                Resources.Control.TextureAtlasControl.GetRegion(DrawVariationVersionThreeName),
-                Resources.Control.TextureAtlasControl.GetRegion(DrawVariationVersionFourName),
+                Resources.Control.TextureAtlasControl.GetRegion(DRAW_VARIATION_VERSION_ONE_NAME),
+                Resources.Control.TextureAtlasControl.GetRegion(DRAW_VARIATION_VERSION_TWO_NAME),
+                Resources.Control.TextureAtlasControl.GetRegion(DRAW_VARIATION_VERSION_THREE_NAME),
+                Resources.Control.TextureAtlasControl.GetRegion(DRAW_VARIATION_VERSION_FOUR_NAME),
             };
 
-            _spriteHighlight = Resources.Control.TextureAtlasControl.GetRegion(HighlightName);
+            _spriteHighlight = Resources.Control.TextureAtlasControl.GetRegion(HIGHLIGHT_NAME);
         }
 
 
         public ColorBox() : base() {
             LoadStatics();
 
-            Size = new Point(ColorSize);
+            Size = new Point(DEFAULT_COLOR_SIZE);
 
             drawVariation = RandomUtil.GetRandom(0, _possibleDrawVariations.Length - 1);
         }
@@ -100,7 +100,7 @@ namespace Blish_HUD.Controls {
         }
 
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
-            spriteBatch.DrawOnCtrl(this, _possibleDrawVariations[drawVariation], bounds, this.Color?.Fur?.ToXnaColor() ?? Microsoft.Xna.Framework.Color.White);
+            spriteBatch.DrawOnCtrl(this, _possibleDrawVariations[drawVariation], bounds, this.Color?.Cloth?.ToXnaColor() ?? Microsoft.Xna.Framework.Color.White);
 
             if (this.MouseOver || this.Selected)
                 spriteBatch.DrawOnCtrl(this, _spriteHighlight, bounds, Microsoft.Xna.Framework.Color.White * 0.7f);

--- a/Blish HUD/Controls/ColorBox.cs
+++ b/Blish HUD/Controls/ColorBox.cs
@@ -21,7 +21,7 @@ namespace Blish_HUD.Controls {
         public event EventHandler<EventArgs> OnSelected;
 
         private const int DEFAULT_COLOR_SIZE = 32;
-        private const string COLOR_CHANGE_SOUND_NAME = @"audio\color-change";
+        private const string COLOR_CHANGE_SOUND_NAME = "audio/color-change";
         private const string DRAW_VARIATION_VERSION_ONE_NAME = "colorpicker/cp-clr-v1";
         private const string DRAW_VARIATION_VERSION_TWO_NAME = "colorpicker/cp-clr-v2";
         private const string DRAW_VARIATION_VERSION_THREE_NAME = "colorpicker/cp-clr-v3";

--- a/Blish HUD/Controls/ColorBox.cs
+++ b/Blish HUD/Controls/ColorBox.cs
@@ -1,114 +1,181 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
+using Blish_HUD.Input;
+using Gw2Sharp.WebApi.V2.Models;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.TextureAtlases;
+using Rectangle = Microsoft.Xna.Framework.Rectangle;
+using Blish_HUD._Extensions;
 
-namespace Blish_HUD.Controls {
+namespace Blish_HUD.Controls
+{
 
     // TODO: Need to have events updated in ColorBox to match the standard applied in Control class
     // TODO: Need to revisit the implementation of ColorBox
-    //[EditorBrowsable(EditorBrowsableState.Never)]
-    //public class ColorBox:Control {
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class ColorBox : Control
+    {
 
-        //public event EventHandler<EventArgs> OnColorChanged;
-        //public event EventHandler<EventArgs> OnSelected;
+        public event EventHandler<EventArgs> OnColorChanged;
+        public event EventHandler<EventArgs> OnSelected;
 
-        //private const int COLOR_SIZE = 32;
+        private const int COLOR_SIZE = 32;
 
-        //private bool _selected = false;
-        //public bool Selected {
-        //    get => _selected;
-        //    set {
-        //        if (SetProperty(ref _selected, value)) {
-        //            this.OnSelected?.Invoke(this, EventArgs.Empty);
-        //            if (this.Visible)
-        //                Content.PlaySoundEffectByName(@"audio\color-change");
-        //        }
-        //    }
-        //}
+        private bool _selected = false;
+        public bool Selected
+        {
+            get => _selected;
+            set
+            {
+                if (SetProperty(ref _selected, value))
+                {
+                    this.OnSelected?.Invoke(this, EventArgs.Empty);
+                    if (this.Visible)
+                        Content.PlaySoundEffectByName(@"audio\color-change");
+                }
+            }
+        }
 
-        //private DyeColor _color;
+        private Gw2Sharp.WebApi.V2.Models.Color _color;
 
-        //public DyeColor Color {
-        //    get => _color;
-        //    set {
-        //        if (_color == value) return;
+        public Gw2Sharp.WebApi.V2.Models.Color Color
+        {
+            get => _color;
+            set
+            {
+                if (_color == value)
+                    return;
 
-        //        _color = value;
-        //        _colorId = value?.Id ?? -1;
+                _color = value;
+                _colorId = value?.Id ?? -1;
 
-        //        OnPropertyChanged("ColorId");
-        //        OnPropertyChanged();
-        //        this.OnColorChanged?.Invoke(this, EventArgs.Empty);
-        //    }
-        //}
+                OnPropertyChanged("ColorId");
+                OnPropertyChanged();
+                this.OnColorChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
 
-        //private int _colorId;
-        //public int ColorId {
-        //    get { return _colorId; }
-        //    set {
-        //        if (_colorId == value) return;
-                
-        //        Task<DyeColor> aDye = BHGw2Api.DyeColor.GetById(this.ColorId);
-        //        aDye.ContinueWith(clr => {
-        //            if (!clr.IsFaulted) {
-        //                _colorId = value;
-        //                _color = aDye.Result;
+        private static Gw2Sharp.WebApi.V2.Models.Color[] Colors = new Gw2Sharp.WebApi.V2.Models.Color[]
+        {
+            new Gw2Sharp.WebApi.V2.Models.Color()
+            {
+                Id =  10,
+                Name = "Sky",
+                BaseRgb = new List<int>() {128, 26, 26},
+                Cloth = new ColorMaterial()
+                {
+                    Brightness = 22,
+                    Contrast = 1.25,
+                    Hue = 196,
+                    Saturation = 0.742188,
+                    Lightness = 1.32813,
+                    Rgb = new List<int>() {91, 123, 146}
+                },
+                Leather = new ColorMaterial()
+                {
+                    Brightness = 22,
+                    Contrast = 1.25,
+                    Hue = 196,
+                    Saturation = 0.664063,
+                    Lightness = 1.32813,
+                    Rgb = new List<int>() {61, 123, 146}
+                },
+                Metal = new ColorMaterial()
+                {
+                    Brightness = 22,
+                    Contrast = 1.28906,
+                    Hue = 196,
+                    Saturation = 0.546875,
+                    Lightness = 1.32813,
+                    Rgb = new List<int>() {65, 123, 146}
+                },
+                Fur = new ColorMaterial()
+                {
+                    Brightness = 22,
+                    Contrast = 1.25,
+                    Hue = 196,
+                    Saturation = 0.742188,
+                    Lightness = 1.32813,
+                    Rgb = new List<int>() {54, 123, 146}
+                },
+                Item = 20370,
+                Categories = new List<string>() {"Blue", "Vibrant", "Rare"}
+            }
+        };
 
-        //                OnPropertyChanged();
-        //                OnPropertyChanged("Color");
-        //                this.OnColorChanged?.Invoke(this, EventArgs.Empty);
-        //            }
-        //        });
-        //    }
-        //}
+        private int _colorId;
+        public int ColorId
+        {
+            get { return _colorId; }
+            set
+            {
+                if (_colorId == value)
+                    return;
 
-        //#region "Statics (Sprites & Shared Resources)"
+                _colorId = value;
+                _color = Colors.FirstOrDefault(x => x.Id == this.ColorId);
 
-        //private static TextureRegion2D[] spriteBoxes;
-        //private static TextureRegion2D spriteHighlight;
+                OnPropertyChanged();
+                OnPropertyChanged("Color");
+                this.OnColorChanged?.Invoke(this, EventArgs.Empty);
 
-        //private static void LoadStatics() {
-        //    if (spriteBoxes != null) return;
+            }
+        }
 
-        //    // Load static sprite regions
-        //    spriteBoxes = new TextureRegion2D[] {
-        //        Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-v1"), Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-v2"), Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-v3"), Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-v4"),
-        //    };
-        //    spriteHighlight = Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-active");
-        //}
+        #region "Statics (Sprites & Shared Resources)"
 
-        //#endregion
+        private static TextureRegion2D[] spriteBoxes;
+        private static TextureRegion2D spriteHighlight;
 
-        //private readonly int _drawVariation;
+        private static void LoadStatics()
+        {
+            if (spriteBoxes != null)
+                return;
 
-        //public ColorBox() : base() {
-        //    LoadStatics();
+            // Load static sprite regions
+            spriteBoxes = new TextureRegion2D[] {
+                Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-v1"), Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-v2"), Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-v3"), Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-v4"),
+            };
+            spriteHighlight = Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-active");
+        }
 
-        //    this.Size = new Point(COLOR_SIZE);
+        #endregion
 
-        //    _drawVariation = RandomUtil.GetRandom(0, 3);
-        //}
+        private readonly int _drawVariation;
 
-        //protected override void OnMouseMoved(MouseEventArgs e) {
-        //    base.OnMouseMoved(e);
+        public ColorBox() : base()
+        {
+            LoadStatics();
 
-        //    this.BasicTooltipText = this.Color?.Id.ToString() ?? "None";
-        //}
+            this.Size = new Point(COLOR_SIZE);
 
-        //protected override CaptureType CapturesInput() {
-        //    return CaptureType.Mouse;
-        //}
+            _drawVariation = RandomUtil.GetRandom(0, 3);
+        }
 
-        //protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
-        //    spriteBatch.Draw(spriteBoxes[_drawVariation], bounds, this.Color?.Fur?.Rgb.ToXnaColor() ?? Microsoft.Xna.Framework.Color.White);
+        protected override void OnMouseMoved(MouseEventArgs e)
+        {
+            base.OnMouseMoved(e);
 
-        //    if (this.MouseOver || this.Selected)
-        //        spriteBatch.Draw(spriteHighlight, bounds, Microsoft.Xna.Framework.Color.White * 0.7f);
-        //}
+            this.BasicTooltipText = this.Color?.Id.ToString() ?? "None";
+        }
 
-    //}
+        protected override CaptureType CapturesInput()
+        {
+            return CaptureType.Mouse;
+        }
+
+        protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds)
+        {
+            spriteBatch.DrawOnCtrl(this, spriteBoxes[_drawVariation], bounds, this.Color?.Fur?.ToXnaColor() ?? Microsoft.Xna.Framework.Color.White);
+
+            if (this.MouseOver || this.Selected)
+                spriteBatch.DrawOnCtrl(this, spriteHighlight, bounds, Microsoft.Xna.Framework.Color.White * 0.7f);
+        }
+
+    }
 
 }

--- a/Blish HUD/Controls/ColorBox.cs
+++ b/Blish HUD/Controls/ColorBox.cs
@@ -47,13 +47,10 @@ namespace Blish_HUD.Controls {
         public Gw2Sharp.WebApi.V2.Models.Color Color {
             get => color;
             set {
-                if (color == value) return;
-
-                color = value;
-
-                OnPropertyChanged(nameof(this.ColorId));
-                OnPropertyChanged();
-                this.ColorChanged?.Invoke(this, EventArgs.Empty);
+                if (SetProperty(ref color, value)) {
+                    OnPropertyChanged(nameof(this.ColorId));
+                    this.ColorChanged?.Invoke(this, EventArgs.Empty);
+                }
             }
         }
 

--- a/Blish HUD/Controls/ColorBox.cs
+++ b/Blish HUD/Controls/ColorBox.cs
@@ -56,11 +56,10 @@ namespace Blish_HUD.Controls {
 
         public int ColorId => this.Color?.Id ?? -1;
 
-        private static TextureRegion2D[] _possibleDrawVariations;
-        private static TextureRegion2D   _spriteHighlight;
+        private static readonly TextureRegion2D[] _possibleDrawVariations;
+        private static readonly TextureRegion2D   _spriteHighlight;
 
-        private static void LoadStatics() {
-            if (_possibleDrawVariations != null) return;
+        static ColorBox() {
 
             // Load static sprite regions
             _possibleDrawVariations = new TextureRegion2D[] {
@@ -73,8 +72,6 @@ namespace Blish_HUD.Controls {
 
 
         public ColorBox() : base() {
-            LoadStatics();
-
             Size = new Point(DEFAULT_COLOR_SIZE);
 
             drawVariation = RandomUtil.GetRandom(0, _possibleDrawVariations.Length - 1);

--- a/Blish HUD/Controls/ColorBox.cs
+++ b/Blish HUD/Controls/ColorBox.cs
@@ -13,12 +13,11 @@ using Blish_HUD._Extensions;
 
 namespace Blish_HUD.Controls {
 
-    // TODO: Need to have events updated in ColorBox to match the standard applied in Control class
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class ColorBox : Control {
 
-        public event EventHandler<EventArgs> OnColorChanged;
-        public event EventHandler<EventArgs> OnSelected;
+        public event EventHandler<EventArgs> ColorChanged;
+        public event EventHandler<EventArgs> Selected;
 
         private const int    DEFAULT_COLOR_SIZE                = 32;
         private const string COLOR_CHANGE_SOUND_NAME           = "audio/color-change";
@@ -30,13 +29,13 @@ namespace Blish_HUD.Controls {
 
         private readonly int drawVariation;
 
-        private bool selected = false;
+        private bool isSelected = false;
 
-        public bool Selected {
-            get => selected;
+        public bool IsSelected {
+            get => isSelected;
             set {
-                if (SetProperty(ref selected, value)) {
-                    this.OnSelected?.Invoke(this, EventArgs.Empty);
+                if (SetProperty(ref isSelected, value)) {
+                    this.Selected?.Invoke(this, EventArgs.Empty);
 
                     if (this.Visible) Content.PlaySoundEffectByName(COLOR_CHANGE_SOUND_NAME);
                 }
@@ -54,7 +53,7 @@ namespace Blish_HUD.Controls {
 
                 OnPropertyChanged(nameof(this.ColorId));
                 OnPropertyChanged();
-                this.OnColorChanged?.Invoke(this, EventArgs.Empty);
+                this.ColorChanged?.Invoke(this, EventArgs.Empty);
             }
         }
 
@@ -97,7 +96,7 @@ namespace Blish_HUD.Controls {
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
             spriteBatch.DrawOnCtrl(this, _possibleDrawVariations[drawVariation], bounds, this.Color?.Cloth?.ToXnaColor() ?? Microsoft.Xna.Framework.Color.White);
 
-            if (this.MouseOver || this.Selected) spriteBatch.DrawOnCtrl(this, _spriteHighlight, bounds, Microsoft.Xna.Framework.Color.White * 0.7f);
+            if (this.MouseOver || this.IsSelected) spriteBatch.DrawOnCtrl(this, _spriteHighlight, bounds, Microsoft.Xna.Framework.Color.White * 0.7f);
         }
 
     }

--- a/Blish HUD/Controls/ColorBox.cs
+++ b/Blish HUD/Controls/ColorBox.cs
@@ -48,13 +48,10 @@ namespace Blish_HUD.Controls {
             get => color;
             set {
                 if (SetProperty(ref color, value)) {
-                    OnPropertyChanged(nameof(this.ColorId));
                     this.ColorChanged?.Invoke(this, EventArgs.Empty);
                 }
             }
         }
-
-        public int ColorId => this.Color?.Id ?? -1;
 
         private static readonly TextureRegion2D[] _possibleDrawVariations;
         private static readonly TextureRegion2D   _spriteHighlight;

--- a/Blish HUD/Controls/ColorBox.cs
+++ b/Blish HUD/Controls/ColorBox.cs
@@ -11,46 +11,48 @@ using MonoGame.Extended.TextureAtlases;
 using Rectangle = Microsoft.Xna.Framework.Rectangle;
 using Blish_HUD._Extensions;
 
-namespace Blish_HUD.Controls
-{
+namespace Blish_HUD.Controls {
 
     // TODO: Need to have events updated in ColorBox to match the standard applied in Control class
     // TODO: Need to revisit the implementation of ColorBox
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class ColorBox : Control
-    {
+    public class ColorBox : Control {
 
         public event EventHandler<EventArgs> OnColorChanged;
         public event EventHandler<EventArgs> OnSelected;
 
-        private const int COLOR_SIZE = 32;
+        private const int ColorSize = 32;
+        private const string ColorChangeSoundName = @"audio\color-change";
+        private const string DrawVariationVersionOneName = "colorpicker/cp-clr-v1";
+        private const string DrawVariationVersionTwoName = "colorpicker/cp-clr-v2";
+        private const string DrawVariationVersionThreeName = "colorpicker/cp-clr-v3";
+        private const string DrawVariationVersionFourName = "colorpicker/cp-clr-v4";
+        private const string HighlightName = "colorpicker/cp-clr-active";
+        private readonly int drawVariation;
 
-        private bool _selected = false;
-        public bool Selected
-        {
-            get => _selected;
-            set
-            {
-                if (SetProperty(ref _selected, value))
-                {
+        private bool selected = false;
+
+        public bool Selected {
+            get => selected;
+            set {
+                if (SetProperty(ref selected, value)) {
                     this.OnSelected?.Invoke(this, EventArgs.Empty);
+
                     if (this.Visible)
-                        Content.PlaySoundEffectByName(@"audio\color-change");
+                        Content.PlaySoundEffectByName(ColorChangeSoundName);
                 }
             }
         }
 
-        private Gw2Sharp.WebApi.V2.Models.Color _color;
+        private Gw2Sharp.WebApi.V2.Models.Color color;
 
-        public Gw2Sharp.WebApi.V2.Models.Color Color
-        {
-            get => _color;
-            set
-            {
-                if (_color == value)
+        public Gw2Sharp.WebApi.V2.Models.Color Color {
+            get => color;
+            set {
+                if (color == value)
                     return;
 
-                _color = value;
+                color = value;
 
                 OnPropertyChanged(nameof(this.ColorId));
                 OnPropertyChanged();
@@ -60,54 +62,48 @@ namespace Blish_HUD.Controls
 
         public int ColorId => this.Color?.Id ?? -1;
 
-        #region "Statics (Sprites & Shared Resources)"
+        private static TextureRegion2D[] _possibleDrawVariations;
+        private static TextureRegion2D _spriteHighlight;
 
-        private static TextureRegion2D[] spriteBoxes;
-        private static TextureRegion2D spriteHighlight;
-
-        private static void LoadStatics()
-        {
-            if (spriteBoxes != null)
+        private static void LoadStatics() {
+            if (_possibleDrawVariations != null)
                 return;
 
             // Load static sprite regions
-            spriteBoxes = new TextureRegion2D[] {
-                Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-v1"), Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-v2"), Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-v3"), Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-v4"),
+            _possibleDrawVariations = new TextureRegion2D[] {
+                Resources.Control.TextureAtlasControl.GetRegion(DrawVariationVersionOneName),
+                Resources.Control.TextureAtlasControl.GetRegion(DrawVariationVersionTwoName), 
+                Resources.Control.TextureAtlasControl.GetRegion(DrawVariationVersionThreeName),
+                Resources.Control.TextureAtlasControl.GetRegion(DrawVariationVersionFourName),
             };
-            spriteHighlight = Resources.Control.TextureAtlasControl.GetRegion("colorpicker/cp-clr-active");
+
+            _spriteHighlight = Resources.Control.TextureAtlasControl.GetRegion(HighlightName);
         }
 
-        #endregion
 
-        private readonly int _drawVariation;
-
-        public ColorBox() : base()
-        {
+        public ColorBox() : base() {
             LoadStatics();
 
-            this.Size = new Point(COLOR_SIZE);
+            Size = new Point(ColorSize);
 
-            _drawVariation = RandomUtil.GetRandom(0, 3);
+            drawVariation = RandomUtil.GetRandom(0, _possibleDrawVariations.Length - 1);
         }
 
-        protected override void OnMouseMoved(MouseEventArgs e)
-        {
+        protected override void OnMouseMoved(MouseEventArgs e) {
             base.OnMouseMoved(e);
 
-            this.BasicTooltipText = this.Color?.Id.ToString() ?? "None";
+            this.BasicTooltipText = this.Color?.Name ?? "None";
         }
 
-        protected override CaptureType CapturesInput()
-        {
+        protected override CaptureType CapturesInput() {
             return CaptureType.Mouse;
         }
 
-        protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds)
-        {
-            spriteBatch.DrawOnCtrl(this, spriteBoxes[_drawVariation], bounds, this.Color?.Fur?.ToXnaColor() ?? Microsoft.Xna.Framework.Color.White);
+        protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
+            spriteBatch.DrawOnCtrl(this, _possibleDrawVariations[drawVariation], bounds, this.Color?.Fur?.ToXnaColor() ?? Microsoft.Xna.Framework.Color.White);
 
             if (this.MouseOver || this.Selected)
-                spriteBatch.DrawOnCtrl(this, spriteHighlight, bounds, Microsoft.Xna.Framework.Color.White * 0.7f);
+                spriteBatch.DrawOnCtrl(this, _spriteHighlight, bounds, Microsoft.Xna.Framework.Color.White * 0.7f);
         }
 
     }

--- a/Blish HUD/Controls/ColorBox.cs
+++ b/Blish HUD/Controls/ColorBox.cs
@@ -51,80 +51,14 @@ namespace Blish_HUD.Controls
                     return;
 
                 _color = value;
-                _colorId = value?.Id ?? -1;
 
-                OnPropertyChanged("ColorId");
+                OnPropertyChanged(nameof(this.ColorId));
                 OnPropertyChanged();
                 this.OnColorChanged?.Invoke(this, EventArgs.Empty);
             }
         }
 
-        private static Gw2Sharp.WebApi.V2.Models.Color[] Colors = new Gw2Sharp.WebApi.V2.Models.Color[]
-        {
-            new Gw2Sharp.WebApi.V2.Models.Color()
-            {
-                Id =  10,
-                Name = "Sky",
-                BaseRgb = new List<int>() {128, 26, 26},
-                Cloth = new ColorMaterial()
-                {
-                    Brightness = 22,
-                    Contrast = 1.25,
-                    Hue = 196,
-                    Saturation = 0.742188,
-                    Lightness = 1.32813,
-                    Rgb = new List<int>() {91, 123, 146}
-                },
-                Leather = new ColorMaterial()
-                {
-                    Brightness = 22,
-                    Contrast = 1.25,
-                    Hue = 196,
-                    Saturation = 0.664063,
-                    Lightness = 1.32813,
-                    Rgb = new List<int>() {61, 123, 146}
-                },
-                Metal = new ColorMaterial()
-                {
-                    Brightness = 22,
-                    Contrast = 1.28906,
-                    Hue = 196,
-                    Saturation = 0.546875,
-                    Lightness = 1.32813,
-                    Rgb = new List<int>() {65, 123, 146}
-                },
-                Fur = new ColorMaterial()
-                {
-                    Brightness = 22,
-                    Contrast = 1.25,
-                    Hue = 196,
-                    Saturation = 0.742188,
-                    Lightness = 1.32813,
-                    Rgb = new List<int>() {54, 123, 146}
-                },
-                Item = 20370,
-                Categories = new List<string>() {"Blue", "Vibrant", "Rare"}
-            }
-        };
-
-        private int _colorId;
-        public int ColorId
-        {
-            get { return _colorId; }
-            set
-            {
-                if (_colorId == value)
-                    return;
-
-                _colorId = value;
-                _color = Colors.FirstOrDefault(x => x.Id == this.ColorId);
-
-                OnPropertyChanged();
-                OnPropertyChanged("Color");
-                this.OnColorChanged?.Invoke(this, EventArgs.Empty);
-
-            }
-        }
+        public int ColorId => this.Color?.Id ?? -1;
 
         #region "Statics (Sprites & Shared Resources)"
 

--- a/Blish HUD/Controls/ColorPicker.cs
+++ b/Blish HUD/Controls/ColorPicker.cs
@@ -8,8 +8,6 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Blish_HUD.Controls {
 
-    // TODO: The ColorPicker needs updates for events, it should probably inherit from FlowPanel,
-    // and needs to get reconnected once we have Gorrik.NET included in the project
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class ColorPicker : Panel {
 

--- a/Blish HUD/Controls/ColorPicker.cs
+++ b/Blish HUD/Controls/ColorPicker.cs
@@ -13,8 +13,8 @@ namespace Blish_HUD.Controls {
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class ColorPicker : Panel {
 
-        private const int COLOR_SIZE = 32;
-        private const int COLOR_PADDING = 3;
+        private const int    COLOR_SIZE              = 32;
+        private const int    COLOR_PADDING           = 3;
         private const string BACKGROUND_TEXTURE_NAME = @"common\solid";
 
         public event EventHandler<EventArgs> SelectedColorChanged;
@@ -31,9 +31,11 @@ namespace Blish_HUD.Controls {
             protected set {
                 if (selectedColor != value) {
                     selectedColor = value;
+
                     if (this.AssociatedColorBox != null) {
                         this.AssociatedColorBox.Color = value;
                     }
+
                     this.SelectedColorChanged?.Invoke(this, new EventArgs());
                 }
             }
@@ -44,21 +46,20 @@ namespace Blish_HUD.Controls {
             get => associatedColorBox;
             set {
                 if (associatedColorBox != value) {
-                    if (associatedColorBox != null)
-                        associatedColorBox.Selected = false;
+                    if (associatedColorBox != null) associatedColorBox.Selected = false;
 
-                    associatedColorBox = value;
+                    associatedColorBox          = value;
                     associatedColorBox.Selected = true;
-                    this.SelectedColor = this.AssociatedColorBox.Color;
+                    this.SelectedColor          = this.AssociatedColorBox.Color;
                 }
             }
         }
 
         public ColorPicker() : base() {
-            this.Colors = new ObservableCollection<Gw2Sharp.WebApi.V2.Models.Color>();
+            this.Colors                   =  new ObservableCollection<Gw2Sharp.WebApi.V2.Models.Color>();
             this.Colors.CollectionChanged += Colors_CollectionChanged;
 
-            this.ContentRegion = new Rectangle(COLOR_PADDING, COLOR_PADDING, (this.Width - 10) - (COLOR_PADDING * 2), this.Height - (COLOR_PADDING * 2));
+            this.ContentRegion = new Rectangle(COLOR_PADDING, COLOR_PADDING, this.Width - (COLOR_PADDING * 2) - 10, this.Height - (COLOR_PADDING * 2));
 
             colorBoxes = new Dictionary<Gw2Sharp.WebApi.V2.Models.Color, ColorBox>();
         }
@@ -68,9 +69,9 @@ namespace Blish_HUD.Controls {
             // that item in both OldItems and NewItems)
             if (e.OldItems != null) {
                 foreach (var deletedItem in e
-                                       .OldItems
-                                       .Cast<Gw2Sharp.WebApi.V2.Models.Color>()
-                                       .Where(delItem => colorBoxes.ContainsKey(delItem))) {
+                                           .OldItems
+                                           .Cast<Gw2Sharp.WebApi.V2.Models.Color>()
+                                           .Where(delItem => colorBoxes.ContainsKey(delItem))) {
                     colorBoxes[deletedItem].Dispose();
                     colorBoxes.Remove(deletedItem);
                 }
@@ -80,9 +81,9 @@ namespace Blish_HUD.Controls {
                 foreach (Gw2Sharp.WebApi.V2.Models.Color addedItem in e.NewItems) {
                     if (!colorBoxes.ContainsKey(addedItem)) {
                         var colorBox = new ColorBox() {
-                            Color = addedItem,
+                            Color  = addedItem,
                             Parent = this,
-                            Size = new Point(COLOR_SIZE),
+                            Size   = new Point(COLOR_SIZE),
                         };
 
                         colorBoxes[addedItem] = colorBox;
@@ -92,7 +93,7 @@ namespace Blish_HUD.Controls {
                                 box.Selected = false;
                             }
 
-                            colorBox.Selected = true;
+                            colorBox.Selected  = true;
                             this.SelectedColor = colorBox.Color;
                         };
                     }
@@ -102,22 +103,24 @@ namespace Blish_HUD.Controls {
             // Relayout the color grid
             for (int i = 0; i < this.Colors.Count; i++) {
                 var currentColor = this.Colors[i];
-                var currentBox = colorBoxes[currentColor];
+                var currentBox   = colorBoxes[currentColor];
 
                 int horizontalPosition = i % colorsPerRow;
-                int verticalPosition = i / colorsPerRow;
+                int verticalPosition   = i / colorsPerRow;
 
                 currentBox.Location = new Point(
-                    horizontalPosition * (currentBox.Width + COLOR_PADDING),
-                    verticalPosition * (currentBox.Width + COLOR_PADDING)
-                );
+                                                horizontalPosition * (currentBox.Width + COLOR_PADDING),
+                                                verticalPosition   * (currentBox.Width + COLOR_PADDING)
+                                               );
             }
         }
 
         public override void Invalidate() {
             base.Invalidate();
 
-            colorsPerRow = (this.Width -10 ) / (COLOR_SIZE + COLOR_PADDING);
+            colorsPerRow = (this.Width - 10) / (COLOR_SIZE + COLOR_PADDING);
+
+            //this.Width = Math.Max(colorsPerRow * (COLOR_SIZE + COLOR_PADDING) + COLOR_PADDING, COLOR_SIZE + COLOR_PADDING * 2);
             this.ContentRegion = new Rectangle(COLOR_PADDING, COLOR_PADDING, (this.Width - 10) - (COLOR_PADDING * 2), this.Height - (COLOR_PADDING * 2));
         }
 
@@ -125,5 +128,7 @@ namespace Blish_HUD.Controls {
             // Draw background
             spriteBatch.DrawOnCtrl(this, Content.GetTexture(BACKGROUND_TEXTURE_NAME), bounds, Color.Black * 0.5f);
         }
+
     }
+
 }

--- a/Blish HUD/Controls/ColorPicker.cs
+++ b/Blish HUD/Controls/ColorPicker.cs
@@ -15,6 +15,8 @@ namespace Blish_HUD.Controls {
         private const int    COLOR_PADDING           = 3;
         private const string BACKGROUND_TEXTURE_NAME = @"common\solid";
 
+        private static readonly Texture2D _backgroundTexture;
+
         public event EventHandler<EventArgs> SelectedColorChanged;
 
         public ObservableCollection<Gw2Sharp.WebApi.V2.Models.Color> Colors { get; protected set; }
@@ -46,6 +48,10 @@ namespace Blish_HUD.Controls {
                     this.SelectedColor            = this.AssociatedColorBox.Color;
                 }
             }
+        }
+
+        static ColorPicker() {
+            _backgroundTexture = Content.GetTexture(BACKGROUND_TEXTURE_NAME);
         }
 
         public ColorPicker() : base() {
@@ -118,7 +124,7 @@ namespace Blish_HUD.Controls {
 
         public override void PaintBeforeChildren(SpriteBatch spriteBatch, Rectangle bounds) {
             // Draw background
-            spriteBatch.DrawOnCtrl(this, Content.GetTexture(BACKGROUND_TEXTURE_NAME), bounds, Color.Black * 0.5f);
+            spriteBatch.DrawOnCtrl(this, _backgroundTexture, bounds, Color.Black * 0.5f);
         }
 
     }

--- a/Blish HUD/Controls/ColorPicker.cs
+++ b/Blish HUD/Controls/ColorPicker.cs
@@ -113,7 +113,6 @@ namespace Blish_HUD.Controls {
 
             colorsPerRow = (this.Width - 10) / (COLOR_SIZE + COLOR_PADDING);
 
-            //this.Width = Math.Max(colorsPerRow * (COLOR_SIZE + COLOR_PADDING) + COLOR_PADDING, COLOR_SIZE + COLOR_PADDING * 2);
             this.ContentRegion = new Rectangle(COLOR_PADDING, COLOR_PADDING, (this.Width - 10) - (COLOR_PADDING * 2), this.Height - (COLOR_PADDING * 2));
         }
 

--- a/Blish HUD/Controls/ColorPicker.cs
+++ b/Blish HUD/Controls/ColorPicker.cs
@@ -27,9 +27,7 @@ namespace Blish_HUD.Controls {
         public Gw2Sharp.WebApi.V2.Models.Color SelectedColor {
             get => selectedColor;
             protected set {
-                if (selectedColor != value) {
-                    selectedColor = value;
-
+                if (SetProperty(ref selectedColor, value)) {
                     if (this.AssociatedColorBox != null) {
                         this.AssociatedColorBox.Color = value;
                     }
@@ -43,12 +41,9 @@ namespace Blish_HUD.Controls {
         public ColorBox AssociatedColorBox {
             get => associatedColorBox;
             set {
-                if (associatedColorBox != value) {
-                    if (associatedColorBox != null) associatedColorBox.Selected = false;
-
-                    associatedColorBox          = value;
-                    associatedColorBox.Selected = true;
-                    this.SelectedColor          = this.AssociatedColorBox.Color;
+                if (SetProperty(ref associatedColorBox, value)) {
+                    associatedColorBox.IsSelected = true;
+                    this.SelectedColor            = this.AssociatedColorBox.Color;
                 }
             }
         }
@@ -88,11 +83,11 @@ namespace Blish_HUD.Controls {
 
                         colorBox.LeftMouseButtonPressed += delegate {
                             foreach (var box in colorBoxes.Values) {
-                                box.Selected = false;
+                                box.IsSelected = false;
                             }
 
-                            colorBox.Selected  = true;
-                            this.SelectedColor = colorBox.Color;
+                            colorBox.IsSelected = true;
+                            this.SelectedColor  = colorBox.Color;
                         };
                     }
                 }

--- a/Blish HUD/Controls/ColorPicker.cs
+++ b/Blish HUD/Controls/ColorPicker.cs
@@ -108,8 +108,8 @@ namespace Blish_HUD.Controls {
             }
         }
 
-        public override void Invalidate() {
-            base.Invalidate();
+        public override void RecalculateLayout() {
+            base.RecalculateLayout();
 
             colorsPerRow = (this.Width - 10) / (COLOR_SIZE + COLOR_PADDING);
 

--- a/Blish HUD/Controls/ColorPicker.cs
+++ b/Blish HUD/Controls/ColorPicker.cs
@@ -118,7 +118,6 @@ namespace Blish_HUD.Controls {
             base.Invalidate();
 
             colorsPerRow = (this.Width -10 ) / (COLOR_SIZE + COLOR_PADDING);
-            //this.Width = Math.Max(colorsPerRow * (COLOR_SIZE + COLOR_PADDING) + COLOR_PADDING, COLOR_SIZE + COLOR_PADDING * 2);
             this.ContentRegion = new Rectangle(COLOR_PADDING, COLOR_PADDING, (this.Width - 10) - (COLOR_PADDING * 2), this.Height - (COLOR_PADDING * 2));
         }
 

--- a/Blish HUD/Controls/ColorPicker.cs
+++ b/Blish HUD/Controls/ColorPicker.cs
@@ -58,7 +58,7 @@ namespace Blish_HUD.Controls {
             this.Colors = new ObservableCollection<Gw2Sharp.WebApi.V2.Models.Color>();
             this.Colors.CollectionChanged += Colors_CollectionChanged;
 
-            this.ContentRegion = new Rectangle(COLOR_PADDING, COLOR_PADDING, this.Width - (COLOR_PADDING * 2) - 10, this.Height - (COLOR_PADDING * 2));
+            this.ContentRegion = new Rectangle(COLOR_PADDING, COLOR_PADDING, (this.Width - 10) - (COLOR_PADDING * 2), this.Height - (COLOR_PADDING * 2));
 
             colorBoxes = new Dictionary<Gw2Sharp.WebApi.V2.Models.Color, ColorBox>();
         }

--- a/Blish HUD/_Extensions/ColorExtensions.cs
+++ b/Blish HUD/_Extensions/ColorExtensions.cs
@@ -5,13 +5,14 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
 
-namespace Blish_HUD._Extensions
-{
-    public static class ColorExtensions
-    {
-        public static Microsoft.Xna.Framework.Color ToXnaColor(this Gw2Sharp.WebApi.V2.Models.ColorMaterial color)
-        {
-            return  new Color(color.Rgb[0], color.Rgb[1], color.Rgb[2]);
+namespace Blish_HUD._Extensions {
+
+    public static class ColorExtensions {
+
+        public static Microsoft.Xna.Framework.Color ToXnaColor(this Gw2Sharp.WebApi.V2.Models.ColorMaterial color) {
+            return new Color(color.Rgb[0], color.Rgb[1], color.Rgb[2]);
         }
+
     }
+
 }

--- a/Blish HUD/_Extensions/ColorExtensions.cs
+++ b/Blish HUD/_Extensions/ColorExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework;
+
+namespace Blish_HUD._Extensions
+{
+    public static class ColorExtensions
+    {
+        public static Microsoft.Xna.Framework.Color ToXnaColor(this Gw2Sharp.WebApi.V2.Models.ColorMaterial color)
+        {
+            return  new Color(color.Rgb[0], color.Rgb[1], color.Rgb[2]);
+        }
+    }
+}


### PR DESCRIPTION
Reimplemented ColorBox and ColorPicker. Appearance/Functionality should be the same, just don't know how it behaves previously.

Breaking Changes:

- ColorId on ColorBox is now readonly and the consumer of the ColorBox needs to provide the Gw2Sharp Color-Object for the box. This removes the need of an api call.

Here the control(s) in action: https://drive.google.com/uc?id=1uZsMH836PYzjTTy2X-dWcP4ULg-pmQkO
The position of the cursor seems off bc of YoloMouse