### PR TITLE
Update Gw2Sharp to 0.9.4 and fixes

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -524,7 +524,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Gw2Sharp">
-      <Version>0.9.4</Version>
+      <Version>0.9.5</Version>
     </PackageReference>
     <PackageReference Include="Humanizer.Core.de">
       <Version>2.6.2</Version>

--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -524,7 +524,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Gw2Sharp">
-      <Version>0.9.3</Version>
+      <Version>0.9.4</Version>
     </PackageReference>
     <PackageReference Include="Humanizer.Core.de">
       <Version>2.6.2</Version>

--- a/Blish HUD/GameServices/ContentService.cs
+++ b/Blish HUD/GameServices/ContentService.cs
@@ -221,7 +221,7 @@ namespace Blish_HUD {
         public AsyncTexture2D GetRenderServiceTexture(string signature, string fileId) {
             AsyncTexture2D returnedTexture = new AsyncTexture2D(Textures.TransparentPixel.Duplicate());
 
-            string requestUrl = $"{RENDERSERVICE_REQUESTURL}{signature}/{fileId}";
+            string requestUrl = $"{RENDERSERVICE_REQUESTURL}{signature}/{fileId}.png";
 
             Gw2WebApi.AnonymousConnection.Client.Render.DownloadToByteArrayAsync(requestUrl)
                      .ContinueWith((textureDataResponse) => {

--- a/Blish HUD/GameServices/GraphicsService.cs
+++ b/Blish HUD/GameServices/GraphicsService.cs
@@ -105,8 +105,8 @@ namespace Blish_HUD {
             this.GraphicsDevice.Clear(Color.Transparent);
 
             GameService.Debug.StartTimeFunc("3D objects");
-            // Only draw 3D elements if we are in game
-            if (GameService.GameIntegration.IsInGame && (!GameService.ArcDps.RenderPresent || GameService.ArcDps.HudIsActive))
+            // Only draw 3D elements if we are in game and map is closed
+            if (GameService.GameIntegration.IsInGame && !GameService.Gw2Mumble.UI.IsMapOpen)
                 this.World.DoDraw(this.GraphicsDevice);
             GameService.Debug.StopTimeFunc("3D objects");
 

--- a/Blish HUD/GameServices/Gw2WebApi/ManagedConnection.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/ManagedConnection.cs
@@ -26,7 +26,7 @@ namespace Blish_HUD.Gw2WebApi {
                                                  GameService.Overlay.UserLocale.Value,
                                                  webApiCache,
                                                  renderCache,
-                                                 renderCacheDuration,
+                                                 renderCacheDuration ?? TimeSpan.MaxValue,
                                                  ua);
 
             _internalClient = new Gw2Client(_internalConnection).WebApi;

--- a/Blish HUD/GameServices/Gw2WebApiService.cs
+++ b/Blish HUD/GameServices/Gw2WebApiService.cs
@@ -20,8 +20,7 @@ namespace Blish_HUD {
 
         private const string GW2WEBAPI_SETTINGS = "Gw2ApiConfiguration";
 
-        private const string SETTINGS_ENTRY_APIKEYS     = "ApiKeyRepository";
-        private const string SETTINGS_ENTRY_PERMISSIONS = "Permissions";
+        private const string SETTINGS_ENTRY_APIKEYS = "ApiKeyRepository";
 
         #region Cache Handling
 
@@ -52,8 +51,6 @@ namespace Blish_HUD {
         #endregion
 
         private ConcurrentDictionary<string, string>            _characterRepository;
-        private ConcurrentDictionary<string, TokenPermission[]> _permissionDetails;
-
         private ConcurrentDictionary<string, ManagedConnection> _cachedConnections;
 
         private SettingCollection _apiSettings;
@@ -139,14 +136,6 @@ namespace Blish_HUD {
 
         private async Task<List<string>> GetCharacters(ManagedConnection connection) {
             return (await connection.Client.V2.Characters.IdsAsync()).ToList();
-        }
-
-        private async Task<TokenInfo> GetTokenInfo(ManagedConnection connection) {
-            return await connection.Client.V2.TokenInfo.GetAsync();
-        }
-
-        private async Task<Account> GetAccount(ManagedConnection connection) {
-            return await connection.Client.V2.Account.GetAsync();
         }
 
         internal async Task<string> RequestPrivilegedSubtoken(IEnumerable<TokenPermission> permissions, int days) {

--- a/Blish HUD/GameServices/Gw2WebApiService.cs
+++ b/Blish HUD/GameServices/Gw2WebApiService.cs
@@ -18,7 +18,7 @@ namespace Blish_HUD {
 
         private static readonly Logger Logger = Logger.GetLogger<Gw2WebApiService>();
 
-        private const string GW2WEBAPI_SETTINGS = "Gw2ApiConfiguration";
+        private const string GW2WEBAPI_SETTINGS = "Gw2WebApiConfiguration";
 
         private const string SETTINGS_ENTRY_APIKEYS = "ApiKeyRepository";
 


### PR DESCRIPTION
- IsMapOpen is now used to toggle 3D entity visibility instead of requiring ArcDps.
- ContentService Render Service queries now use Gw2Sharp and responses are cached (in memory still).
- Removed unused fields and methods from Gw2ApiService.
- Removed old render service methods for using darth's CDN.