### PR TITLE
Added TokenBucket and TokenCompliantCacheWrapper.

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -217,6 +217,8 @@
     <Compile Include="GameServices\ArcDpsService.cs" />
     <Compile Include="GameServices\Content\IDataReader.cs" />
     <Compile Include="GameServices\Gw2WebApi\ManagedConnection.cs" />
+    <Compile Include="GameServices\Gw2WebApi\TokenBucket.cs" />
+    <Compile Include="GameServices\Gw2WebApi\TokenCompliantCacheWrapper.cs" />
     <Compile Include="GameServices\Input\Hook.cs" />
     <Compile Include="GameServices\Input\InputManager.cs" />
     <Compile Include="GameServices\Input\KeyBinding.cs" />

--- a/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
@@ -49,7 +49,7 @@ namespace Blish_HUD.Gw2WebApi {
                 double elapsedTime = (DateTime.Now - _lastUpdate).TotalMilliseconds / REFILL_INTERVAL;
                 _lastUpdate = DateTime.Now;
 
-                return Math.Min(_tokens += elapsedTime * this.RefillAmount, this.MaxTokens);
+                return _tokens = Math.Min(_tokens + elapsedTime * this.RefillAmount, this.MaxTokens);
             }
         }
 

--- a/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Threading.Tasks;
+using Gw2Sharp.WebApi.Http;
+
+namespace Blish_HUD.Gw2WebApi {
+    public class TokenBucket {
+
+        private const int REFILL_INTERVAL        = 1000;
+        private const int FAILED_CONSUME_RETRIES = 3;
+
+        /// <summary>
+        /// The maximum number of tokens in the bucket.
+        /// </summary>
+        /// <remarks>
+        /// Also represents the maximum burst.
+        /// </remarks>
+        public double MaxTokens { get; set; }
+
+        private double _tokens;
+
+        public double Tokens {
+            get => GetLatestTokenBalance();
+            set {
+                lock (_tokenLock) {
+                    _tokens = Math.Min(value, this.MaxTokens);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The number of tokens added to the bucket each second.
+        /// </summary>
+        public double RefillAmount { get; set; }
+
+        private readonly object _tokenLock = new object();
+
+        private DateTime _lastUpdate;
+
+        public TokenBucket(double maxBurst, double refillAmountPerSecond) {
+            this.MaxTokens    = maxBurst;
+            this.RefillAmount = refillAmountPerSecond;
+            this.Tokens       = maxBurst;
+
+            _lastUpdate = DateTime.Now;
+        }
+
+        private double GetLatestTokenBalance() {
+            lock (_tokenLock) {
+                double elapsedTime = (DateTime.Now - _lastUpdate).TotalMilliseconds / REFILL_INTERVAL;
+                _lastUpdate = DateTime.Now;
+
+                return Math.Min(_tokens += elapsedTime * this.RefillAmount, this.MaxTokens);
+            }
+        }
+
+        public async Task<T> ConsumeCompliant<T>(Func<Task<T>> updateFunc, int remainingAttempts = FAILED_CONSUME_RETRIES) {
+            GetLatestTokenBalance();
+
+            double remainingTokens = --this.Tokens;
+
+            if (remainingTokens < 0) {
+                await Task.Delay((int)Math.Ceiling(-remainingTokens * (REFILL_INTERVAL / this.RefillAmount)));
+            }
+
+            try {
+                return await updateFunc().ConfigureAwait(false);
+            } catch (TooManyRequestsException ex) {
+                // Penalize our token count - we've hit the rate limited
+                this.Tokens = Math.Min(this.Tokens - this.RefillAmount, -1);
+
+                if (remainingAttempts > 0) {
+                    return await ConsumeCompliant<T>(updateFunc, --remainingAttempts);
+                }
+
+                // Too many attempts
+                throw;
+            }
+        }
+
+    }
+}

--- a/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
@@ -18,6 +18,12 @@ namespace Blish_HUD.Gw2WebApi {
 
         private double _tokens;
 
+        /// <summary>
+        /// How many tokens are currently available in the <see cref="TokenBucket"/>.
+        /// </summary>
+        /// <remarks>
+        /// Tokens can be negative if there are multiple calls attempting to be made after all tokens have been exhausted and represents a token debt.
+        /// </remarks>
         public double Tokens {
             get => GetLatestTokenBalance();
             set {

--- a/Blish HUD/GameServices/Gw2WebApi/TokenCompliantCacheWrapper.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/TokenCompliantCacheWrapper.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Blish_HUD.Gw2WebApi;
+using Gw2Sharp.WebApi.Caching;
+
+namespace Blish_HUD.Gw2WebApi {
+    public class TokenCompliantCacheWrapper : ICacheMethod {
+
+        private readonly ICacheMethod _cache;
+        private readonly TokenBucket _bucket;
+
+        public TokenCompliantCacheWrapper(ICacheMethod cacheMethod, TokenBucket tokenBucket) {
+            _cache  = cacheMethod;
+            _bucket = tokenBucket;
+        }
+
+        public async Task<CacheItem<T>> TryGetAsync<T>(string category, object id) {
+            return await _cache.TryGetAsync<T>(category, id).ConfigureAwait(false);
+        }
+
+        public async Task SetAsync<T>(CacheItem<T> item) {
+            await _cache.SetAsync(item).ConfigureAwait(false);
+        }
+
+        public async Task SetAsync<T>(string category, object id, T item, DateTimeOffset expiryTime) {
+            await _cache.SetAsync(category, id, item, expiryTime).ConfigureAwait(false);
+        }
+
+        public async Task<IDictionary<object, CacheItem<T>>> GetManyAsync<T>(string category, IEnumerable<object> ids) {
+            return await _cache.GetManyAsync<T>(category, ids).ConfigureAwait(false);
+        }
+
+        public async Task SetManyAsync<T>(IEnumerable<CacheItem<T>> items) {
+            await _cache.SetManyAsync(items).ConfigureAwait(false);
+        }
+
+        public async Task<CacheItem<T>> GetOrUpdateAsync<T>(string category, object id, Func<Task<(T, DateTimeOffset)>> updateFunc) {
+            return await _cache.GetOrUpdateAsync<T>(category, id, async () => await _bucket.ConsumeCompliant(updateFunc)).ConfigureAwait(false);
+        }
+
+        public async Task<CacheItem<T>> GetOrUpdateAsync<T>(string category, object id, DateTimeOffset expiryTime, Func<Task<T>> updateFunc) {
+            return await _cache.GetOrUpdateAsync(category, id, expiryTime, async () => await _bucket.ConsumeCompliant(updateFunc)).ConfigureAwait(false);
+        }
+
+        public async Task<IList<CacheItem<T>>> GetOrUpdateManyAsync<T>(string category, IEnumerable<object> ids, Func<IList<object>, Task<(IDictionary<object, T>, DateTimeOffset)>> updateFunc) {
+            return await _cache.GetOrUpdateManyAsync(category, ids, updateFunc).ConfigureAwait(false);
+        }
+
+        public async Task<IList<CacheItem<T>>> GetOrUpdateManyAsync<T>(string category, IEnumerable<object> ids, DateTimeOffset expiryTime, Func<IList<object>, Task<IDictionary<object, T>>> updateFunc) {
+            return await _cache.GetOrUpdateManyAsync(category, ids, expiryTime, updateFunc).ConfigureAwait(false);
+        }
+
+        public async Task ClearAsync() {
+            await _cache.ClearAsync().ConfigureAwait(false);
+        }
+
+        public void Dispose() {
+            _cache.Dispose();
+        }
+
+    }
+}

--- a/Blish HUD/GameServices/Gw2WebApiService.cs
+++ b/Blish HUD/GameServices/Gw2WebApiService.cs
@@ -28,8 +28,10 @@ namespace Blish_HUD {
         private ICacheMethod _sharedRenderCache;
 
         private void InitCache() {
-            _sharedWebCache    = new MemoryCacheMethod();
-            _sharedRenderCache = new MemoryCacheMethod();
+            var bucket = new TokenBucket(300, 5);
+
+            _sharedWebCache    = new TokenCompliantCacheWrapper(new MemoryCacheMethod(), bucket);
+            _sharedRenderCache = new TokenCompliantCacheWrapper(new MemoryCacheMethod(), bucket);
         }
 
         #endregion


### PR DESCRIPTION
Introduced `TokenCompliantCacheWrapper` which wraps any `ICacheMethod` and enforces that requests do not exceed the rate of the provided token bucket.

Review of the [CloudFront throttling docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-request-throttling.html) (which I expect is being used based on [comments by dsnider](https://discordapp.com/channels/384735285197537290/384735523521953792/676482812957949988)) and testing, I found the following:

Despite the reported 600 request limit, the API's bucket appears to have:
- a 300 max burst
- a refill rate of 5 tokens per second (or 300 requests per minute)

I can reliably make tens of thousands of requests with the above parameters without any 429s. 
 Anything more than the above reliably gives me 429s on a regular interval.

The `TokenBucket` implementation here attempts to sit right on that line to maximize throughput without hitting the rate limit and getting back a 429.

To avoid all requests needing to build in this logic, any requests that are made when we have 0 or less tokens have a delay prepended to them based on the current request/token debt and the refill rate.

For instance, if we are currently at -10 tokens and have a refill rate of 5 tokens per second, we can assume that we'll have enough tokens in 2 seconds, thus allowing us to schedule the request ahead of time without the requester needing to do anything extra.

In the event that we do exceed the rate limit (other apps on the system have made requests outside of our control or some other issue), we penalize the `TokenBucket` by setting the `Token` count to `-1` or to `Tokens - RefillRate`, whichever is smaller to help realign ourselves with the APIs token bucket.  Requests that do return a 429 have up to 3 attempts to try again before we truly bubble up the exception.