### PR TITLE
Improved FestivalContext

### DIFF
--- a/Blish HUD/GameServices/Contexts/FestivalContext.cs
+++ b/Blish HUD/GameServices/Contexts/FestivalContext.cs
@@ -21,6 +21,10 @@ namespace Blish_HUD.Contexts {
 
             private static FestivalContext _context;
 
+            private static readonly Dictionary<string, Festival> _festivalLookup = new Dictionary<string, Festival>(StringComparer.InvariantCultureIgnoreCase);
+
+            public static IEnumerable<Festival> All = _festivalLookup.Values;
+
             private readonly string _name;
             private readonly string _displayName;
 
@@ -37,6 +41,8 @@ namespace Blish_HUD.Contexts {
             public Festival(string name, string displayName) {
                 _name        = name;
                 _displayName = displayName;
+
+                _festivalLookup.Add(name, this);
             }
 
             /// <summary>
@@ -51,6 +57,26 @@ namespace Blish_HUD.Contexts {
                 // _context can still be null if it has not registered with the ContextService yet
                 return _context?.FestivalIsActive(this) ?? false;
             }
+
+            /// <summary>
+            /// Gets a known festival by name.
+            /// </summary>
+            /// <param name="name">The internal name of the festival.</param>
+            /// <returns>The associated <see cref="Festival"/> if it is known or <see cref="UnknownFestival"/> if it is unknown.</returns>
+            public static Festival FromName(string name) {
+                if (_festivalLookup.TryGetValue(name, out var festival)) {
+                    return festival;
+                }
+
+                Logger.Warn("Request for unknown festival {festival}.", name);
+
+                return UnknownFestival;
+            }
+
+            /// <summary>
+            /// A festival that was not recognized.
+            /// </summary>
+            public static readonly Festival UnknownFestival = new Festival("unknown", Strings.Common.Unknown);
 
             // Known festivals
 

--- a/Blish HUD/Strings/Common.Designer.cs
+++ b/Blish HUD/Strings/Common.Designer.cs
@@ -104,5 +104,14 @@ namespace Blish_HUD.Strings {
                 return ResourceManager.GetString("Options", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unknown.
+        /// </summary>
+        internal static string Unknown {
+            get {
+                return ResourceManager.GetString("Unknown", resourceCulture);
+            }
+        }
     }
 }

--- a/Blish HUD/Strings/Common.de.resx
+++ b/Blish HUD/Strings/Common.de.resx
@@ -129,4 +129,7 @@
   <data name="Options" xml:space="preserve">
     <value>Optionen</value>
   </data>
+  <data name="Unknown" xml:space="preserve">
+    <value>Unbekannt</value>
+  </data>
 </root>

--- a/Blish HUD/Strings/Common.fr.resx
+++ b/Blish HUD/Strings/Common.fr.resx
@@ -123,4 +123,7 @@
   <data name="Action_Cancel" xml:space="preserve">
     <value>Annuler</value>
   </data>
+  <data name="Unknown" xml:space="preserve">
+    <value>Inconnue</value>
+  </data>
 </root>

--- a/Blish HUD/Strings/Common.resx
+++ b/Blish HUD/Strings/Common.resx
@@ -114,4 +114,8 @@
   <data name="Options" xml:space="preserve">
     <value>Options</value>
   </data>
+  <data name="Unknown" xml:space="preserve">
+    <value>Unknown</value>
+    
+  </data>
 </root>

--- a/Blish HUD/Strings/GameServices/ModulesService.de.resx
+++ b/Blish HUD/Strings/GameServices/ModulesService.de.resx
@@ -159,9 +159,6 @@
   <data name="ModuleState_FatalError" xml:space="preserve">
     <value>Schwerwiegender Fehler</value>
   </data>
-  <data name="ModuleAuthor_Unknown" xml:space="preserve">
-    <value>Unbekannt</value>
-  </data>
   <data name="ModuleManagement_AuthoredBy" xml:space="preserve">
     <value>Verfasst von</value>
   </data>

--- a/Blish HUD/Strings/GameServices/ModulesService.resx
+++ b/Blish HUD/Strings/GameServices/ModulesService.resx
@@ -139,9 +139,6 @@
   <data name="ModuleState_FatalError" xml:space="preserve">
     <value>Fatal Error</value>
   </data>
-  <data name="ModuleAuthor_Unknown" xml:space="preserve">
-    <value>Unknown</value>
-  </data>
   <data name="ModuleManagement_AuthoredBy" xml:space="preserve">
     <value>Authored by</value>
   </data>


### PR DESCRIPTION
Added way to query list of all known festivals and a way to pull festivals by their internal name.

Moved localized string "Unknown" to "String.Common".

The new `FromName` endpoint will be used by the Markers & Paths module to ensure it can easily take user input and convert it to the relevant Festival.