### PR TITLE
WIP: Improvements for Markers & Paths

### DIFF
--- a/Blish HUD/GameServices/Gw2Mumble/PlayerCharacter.cs
+++ b/Blish HUD/GameServices/Gw2Mumble/PlayerCharacter.cs
@@ -15,13 +15,23 @@ namespace Blish_HUD.Gw2Mumble {
         /// </summary>
         public event EventHandler<ValueEventArgs<string>> NameChanged;
 
+        /// <summary>
+        /// Fires when the current character's specialization changes.
+        /// </summary>
         public event EventHandler<ValueEventArgs<int>> SpecializationChanged;
+
+        /// <summary>
+        /// Fires when the current character starts or stops being a Commander.
+        /// </summary>
+        public event EventHandler<ValueEventArgs<bool>> IsCommanderChanged;
 
         private void OnNameChanged(ValueEventArgs<string> e) => this.NameChanged?.Invoke(this, e);
         private void OnSpecializationChanged(ValueEventArgs<int> e) => this.SpecializationChanged?.Invoke(this, e);
+        private void OnIsCommanderChanged(ValueEventArgs<bool> e) => this.IsCommanderChanged?.Invoke(this, e);
 
         private string _prevName;
         private int    _prevSpecialization;
+        private bool   _prevIsCommander;
 
         private void HandleEvents() {
             if (_prevName != this.Name) {
@@ -32,6 +42,11 @@ namespace Blish_HUD.Gw2Mumble {
             if (_prevSpecialization != this.Specialization) {
                 _prevSpecialization = this.Specialization;
                 OnSpecializationChanged(new ValueEventArgs<int>(_prevSpecialization));
+            }
+
+            if (_prevIsCommander != this.IsCommander) {
+                _prevIsCommander = this.IsCommander;
+                OnIsCommanderChanged(new ValueEventArgs<bool>(_prevIsCommander));
             }
         }
 
@@ -65,7 +80,7 @@ namespace Blish_HUD.Gw2Mumble {
         public bool IsCommander => _service.RawClient.IsCommander;
 
         internal PlayerCharacter(Gw2MumbleService service) {
-            _service      = service;
+            _service = service;
         }
 
         internal void Update(GameTime gameTime) {

--- a/Blish HUD/GameServices/Gw2Mumble/PlayerCharacter.cs
+++ b/Blish HUD/GameServices/Gw2Mumble/PlayerCharacter.cs
@@ -15,14 +15,23 @@ namespace Blish_HUD.Gw2Mumble {
         /// </summary>
         public event EventHandler<ValueEventArgs<string>> NameChanged;
 
+        public event EventHandler<ValueEventArgs<int>> SpecializationChanged;
+
         private void OnNameChanged(ValueEventArgs<string> e) => this.NameChanged?.Invoke(this, e);
+        private void OnSpecializationChanged(ValueEventArgs<int> e) => this.SpecializationChanged?.Invoke(this, e);
 
         private string _prevName;
+        private int    _prevSpecialization;
 
         private void HandleEvents() {
             if (_prevName != this.Name) {
                 _prevName = this.Name;
                 OnNameChanged(new ValueEventArgs<string>(_prevName));
+            }
+
+            if (_prevSpecialization != this.Specialization) {
+                _prevSpecialization = this.Specialization;
+                OnSpecializationChanged(new ValueEventArgs<int>(_prevSpecialization));
             }
         }
 

--- a/Blish HUD/GameServices/PathingService.cs
+++ b/Blish HUD/GameServices/PathingService.cs
@@ -30,22 +30,11 @@ namespace Blish_HUD {
 
         protected override void Initialize() { /* NOOP */ }
 
-        protected override void Load() {
-            // Subscribe to map changes so that we can hide or show markers for the new map
-            Gw2Mumble.CurrentMap.MapChanged += PlayerMapIdChanged;
-        }
-
-        private void ProcessPathableState(IPathable<Entity> pathable) {
-            if (pathable.MapId == Gw2Mumble.CurrentMap.Id || pathable.MapId == -1) {
-                //pathable.Active = true;
-                Graphics.World.Entities.Add(pathable.ManagedEntity);
-            } else if (Graphics.World.Entities.Contains(pathable.ManagedEntity)) {
-                //pathable.Active = false;
-                Graphics.World.Entities.Remove(pathable.ManagedEntity);
-            }
-        }
+        protected override void Load() { /* NOOP */ }
 
         private void ProcessAddedPathable(IPathable<Entity> pathable) {
+            if (Graphics.World.Entities.Contains(pathable.ManagedEntity)) return;
+
             Graphics.World.Entities.Add(pathable.ManagedEntity);
             this.Pathables.Add(pathable);
         }
@@ -53,13 +42,6 @@ namespace Blish_HUD {
         private void ProcessRemovedPathable(IPathable<Entity> pathable) {
             Graphics.World.Entities.Remove(pathable.ManagedEntity);
             this.Pathables.Remove(pathable);
-        }
-
-        private void PlayerMapIdChanged(object sender, EventArgs e) {
-            NewMapLoaded?.Invoke(this, EventArgs.Empty);
-
-            foreach (var packContext in this.PackManagers)
-                packContext.RunTextureDisposal();
         }
 
         public void RegisterPathable(IPathable<Entity> pathable) {


### PR DESCRIPTION
This marks the beginning of some changes to the `PathingService` and other supporting classes needed for the Markers & Paths module.

To reduce the amount of abstraction on abstraction on abstraction on abstraction, we'll be pulling the pathing specific details out of the core codebase and into the Markers & Paths module.  This should reduce complexity, allow for faster interactive changes to the Markers & Paths module, and allow for a simplification to entities needed in the core codebase to help facilitate multiple worlds which have their own transforms (such as `World` and `MiniMap`).

This change does break the Markers & Paths module (as will many upcoming changes to the pathing service).  These first several changes are primarily to help with the addition of several new attributes (`Festival`, `Profession`, `Specialization`, `Race`, and potentially `IsCommander`).