### PR TITLE
Prevent categories from overriding pathable texture attributes.

### DIFF
--- a/Blish HUD/GameServices/Pathing/Format/LoadedMarkerPathable.cs
+++ b/Blish HUD/GameServices/Pathing/Format/LoadedMarkerPathable.cs
@@ -95,6 +95,8 @@ namespace Blish_HUD.Pathing.Format {
 
             // IMarker:Icon
             RegisterAttribute("iconFile", delegate (PathableAttribute attribute) {
+                if (this.IconReferencePath != null) return true;
+
                 if (!string.IsNullOrEmpty(attribute.Value)) {
                     this.IconReferencePath = attribute.Value.Trim();
 

--- a/Blish HUD/GameServices/Pathing/Format/LoadedTrailPathable.cs
+++ b/Blish HUD/GameServices/Pathing/Format/LoadedTrailPathable.cs
@@ -42,6 +42,8 @@ namespace Blish_HUD.Pathing.Format {
 
             // ITrail:Texture
             RegisterAttribute("texture", delegate(PathableAttribute attribute) {
+                                  if (this.TextureReferencePath != null) return true;
+
                                   if (!string.IsNullOrEmpty(attribute.Value)) {
                                       this.TextureReferencePath = attribute.Value.Trim();
 


### PR DESCRIPTION
Fixes #148 

If the texture (marker icon or trail texture) for the pathable has already been set, it will not be set again while loading from the attributes.