### PR TITLE
Fix ScrollDistance updates

### DIFF
--- a/Blish HUD/Controls/Scrollbar.cs
+++ b/Blish HUD/Controls/Scrollbar.cs
@@ -58,7 +58,9 @@ namespace Blish_HUD.Controls {
         public float ScrollDistance {
             get => _scrollDistance;
             set {
-                if (!SetProperty(ref _scrollDistance, MathHelper.Clamp(value, 0f, 1f), true)) return;
+                if (SetProperty(ref _scrollDistance, MathHelper.Clamp(value, 0f, 1f), true)) {
+                    _targetScrollDistance = _scrollDistance;
+                }
 
                 UpdateAssocContainer();
             }


### PR DESCRIPTION
Ensures that updates to ScrollDistance update the _targetScrollDistance as well so that they don't get out of sync.

Fixes #198 