### PR TITLE
Improved module handling and debug

### DIFF
--- a/Blish HUD/ApplicationSettings.cs
+++ b/Blish HUD/ApplicationSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Diagnostics;
 using EntryPoint;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Local
@@ -10,9 +10,14 @@ namespace Blish_HUD {
         private static ApplicationSettings _instance;
 
         internal static ApplicationSettings Instance => _instance;
-
+        
         public ApplicationSettings() : base("Blish HUD") {
             _instance = this;
+        }
+
+        [Conditional("DEBUG")]
+        private void InitDebug() {
+            this.DebugEnabled = true;
         }
 
         #region Game Integration
@@ -50,6 +55,34 @@ namespace Blish_HUD {
             Help("The path to the ref.dat file.")
         ]
         public string RefPath { get; private set; }
+
+        [
+            OptionParameter("maxfps", 'f'),
+            Help("The frame rate Blish HUD should target when rendering.")
+        ]
+        public double TargetFramerate { get; private set; } = 60d;
+
+        [
+            Option("unlockfps", 'F'),
+            Help("Unlocks the frame limit allowing Blish HUD to render as fast as possible.  This will cause high CPU utilization.")
+        ]
+        public bool UnlockFps { get; private set; }
+
+        #endregion
+
+        #region Debug
+
+        [
+            Option("debug", 'd'),
+            Help("Launches Blish HUD in debug mode.")
+        ]
+        public bool DebugEnabled { get; private set; }
+
+        [
+            OptionParameter("module", 'M'),
+            Help("The path to a module (*.bhm) that will be force loaded when Blish HUD launches.")
+        ]
+        public string DebugModulePath { get; private set; }
 
         #endregion
 

--- a/Blish HUD/BlishHud.cs
+++ b/Blish HUD/BlishHud.cs
@@ -62,11 +62,13 @@ namespace Blish_HUD {
             this.Window.IsBorderless = true;
             this.Window.AllowAltF4   = false;
 
-#if DEBUG
-            ActiveGraphicsDeviceManager.SynchronizeWithVerticalRetrace = false;
-            this.IsFixedTimeStep = false;
-            //this.TargetElapsedTime = TimeSpan.FromSeconds(1d / 60d);
-#endif
+            if (ApplicationSettings.Instance.UnlockFps) {
+                ActiveGraphicsDeviceManager.SynchronizeWithVerticalRetrace = false;
+                this.IsFixedTimeStep                                       = false;
+            } else {
+                // Defaults to 60fps
+                this.TargetElapsedTime = TimeSpan.FromSeconds(1d / ApplicationSettings.Instance.TargetFramerate);
+            }
 
             // Initialize all game services
             foreach (var service in GameService.All) {
@@ -138,13 +140,14 @@ namespace Blish_HUD {
 
             GameService.Graphics.Render(gameTime, _basicSpriteBatch);
 
-#if DEBUG
-            _basicSpriteBatch.Begin();
+            if (ApplicationSettings.Instance.DebugEnabled) {
+                _basicSpriteBatch.Begin();
 
-            GameService.Debug.DrawDebugOverlay(_basicSpriteBatch, gameTime);
+                GameService.Debug.DrawDebugOverlay(_basicSpriteBatch, gameTime);
 
-            _basicSpriteBatch.End();
-#endif
+                _basicSpriteBatch.End();
+            }
+
 
             base.Draw(gameTime);
         }

--- a/Blish HUD/GameServices/ModuleService.cs
+++ b/Blish HUD/GameServices/ModuleService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Linq.Expressions;
 using Blish_HUD.Content;
 using Blish_HUD.Modules;
 using Blish_HUD.Settings;
@@ -23,7 +24,8 @@ namespace Blish_HUD {
 
         private const string MODULES_DIRECTORY = "modules";
 
-        private const string MODULE_EXTENSION = ".bhm";
+        private const string MODULE_EXTENSION    = ".bhm";
+        private const string MODULE_MANIFESTNAME = "manifest.json";
 
         private SettingCollection _moduleSettings;
 
@@ -53,8 +55,13 @@ namespace Blish_HUD {
         }
 
         public ModuleManager RegisterModule(IDataReader moduleReader) {
+            if (!moduleReader.FileExists(MODULE_MANIFESTNAME)) {
+                Logger.Warn("Attempted to load an invalid module {modulePath}: {manifestName} is missing.", moduleReader.GetPathRepresentation(), MODULE_MANIFESTNAME);
+                return null;
+            }
+
             string manifestContents;
-            using (var manifestReader = new StreamReader(moduleReader.GetFileStream("manifest.json"))) {
+            using (var manifestReader = new StreamReader(moduleReader.GetFileStream(MODULE_MANIFESTNAME))) {
                 manifestContents = manifestReader.ReadToEnd();
             }
             var moduleManifest = JsonConvert.DeserializeObject<Manifest>(manifestContents);
@@ -78,10 +85,10 @@ namespace Blish_HUD {
         }
 
         private void ExtractPackagedModule(Stream fileData, IDataReader reader) {
-            string moduleName = string.Empty;
+            string moduleName;
 
             using (var moduleArchive = new ZipArchive(fileData, ZipArchiveMode.Read)) {
-                using (var manifestStream = moduleArchive.GetEntry("manifest.json")?.Open()) {
+                using (var manifestStream = moduleArchive.GetEntry(MODULE_MANIFESTNAME)?.Open()) {
                     if (manifestStream == null) return;
 
                     string manifestContents;
@@ -91,13 +98,13 @@ namespace Blish_HUD {
 
                     var moduleManifest = JsonConvert.DeserializeObject<Manifest>(manifestContents);
 
-                    Logger.Info("Exporting internally packaged module {moduleName} ({$moduleNamespace}) v{$moduleVersion}", moduleManifest.Name, moduleManifest.Namespace, moduleManifest.Version);
+                    Logger.Info("Exporting internally packaged module {module}", moduleManifest.GetDetailedName());
 
                     moduleName = moduleManifest.Name;
                 }
             }
 
-            if (!string.IsNullOrEmpty(moduleName)) {
+            if (moduleName != null) {
                 File.WriteAllBytes(Path.Combine(this.ModulesDirectory, $"{moduleName}.bhm"), ((MemoryStream)fileData).GetBuffer());
             }
         }
@@ -105,22 +112,48 @@ namespace Blish_HUD {
         private void UnpackInternalModules() {
             var internalModulesReader = new ZipArchiveReader("ref.dat");
 
-            internalModulesReader.LoadOnFileType(ExtractPackagedModule, ".bhm");
+            internalModulesReader.LoadOnFileType(ExtractPackagedModule, MODULE_EXTENSION);
+        }
+        
+        private ModuleManager LoadModuleFromPackedBhm(string modulePath) {
+            if (modulePath == null)
+                throw new ArgumentNullException(nameof(modulePath));
+
+            if (!File.Exists(modulePath)) {
+                Logger.Warn("Attempted to load a module {modulePath} which does not exist.", modulePath);
+                return null;
+            }
+
+            return RegisterModule(new ZipArchiveReader(modulePath));
+        }
+
+        private ModuleManager LoadModuleFromUnpackedBhm(string moduleDir) {
+            if (moduleDir == null)
+                throw new ArgumentNullException(nameof(moduleDir));
+
+            if (!Directory.Exists(moduleDir)) {
+                Logger.Warn("Attempted to load a module {moduleDir} which does not exist.", moduleDir);
+                return null;
+            }
+
+            return RegisterModule(new DirectoryReader(moduleDir));
         }
 
         protected override void Load() {
-#if DEBUG && !NODIRMODULES
-            // Allows devs to symlink the output directories of modules in development straight to the modules folder
-            foreach (string manifestPath in Directory.GetFiles(this.ModulesDirectory, "manifest.json", SearchOption.AllDirectories)) {
-                string moduleDir = Directory.GetParent(manifestPath).FullName;
+            if (ApplicationSettings.Instance.DebugEnabled) {
+                // Allows devs to symlink the output directories of modules in development straight to the modules folder
+                foreach (string manifestPath in Directory.GetFiles(this.ModulesDirectory, MODULE_MANIFESTNAME, SearchOption.AllDirectories)) {
+                    string moduleDir = Directory.GetParent(manifestPath).FullName;
 
-                var moduleReader = new DirectoryReader(moduleDir);
-
-                if (moduleReader.FileExists("manifest.json")) {
-                    RegisterModule(moduleReader);
+                    LoadModuleFromUnpackedBhm(moduleDir);
                 }
             }
-#endif
+
+            if (ApplicationSettings.Instance.DebugModulePath != null) {
+                var debugModule = LoadModuleFromPackedBhm(ApplicationSettings.Instance.DebugModulePath);
+
+                debugModule.Enabled = true;
+            }
 
             // Get the base version string and see if we've exported the modules for this version yet
             string baseVersionString = Program.OverlayVersion.BaseVersion().ToString();
@@ -130,40 +163,42 @@ namespace Blish_HUD {
             }
 
             foreach (string moduleArchivePath in Directory.GetFiles(this.ModulesDirectory, $"*{MODULE_EXTENSION}", SearchOption.AllDirectories)) {
-                var moduleReader = new ZipArchiveReader(moduleArchivePath);
+                LoadModuleFromPackedBhm(moduleArchivePath);
+            }
+        }
 
-                if (moduleReader.FileExists("manifest.json")) {
-                    RegisterModule(moduleReader);
+        protected override void Update(GameTime gameTime) {
+            foreach (var module in _modules) {
+                if (module.Enabled) {
+                    try {
+                        module.ModuleInstance.DoUpdate(gameTime);
+                    } catch (Exception ex) {
+                        Logger.Error(ex, "Module '{$moduleName} ({$moduleNamespace}) threw an exception while updating.", module.Manifest.Name, module.Manifest.Namespace);
+
+                        if (ApplicationSettings.Instance.DebugEnabled) {
+                            // To assist in debugging modules
+                            throw;
+                        }
+                    }
                 }
             }
         }
 
         protected override void Unload() {
-            _modules.ForEach(s => {
-                try {
-                    // TODO: Unload module
-                } catch (Exception ex) {
-                    #if DEBUG
-                    // To assist in debugging
-                    throw;
-                    #endif
-                    Logger.Error(ex, "Module '{$moduleName} ({$moduleNamespace}) threw an exception while being unloaded.", s.Manifest.Name, s.Manifest.Namespace);
-                }
-            });
-        }
+            foreach (var module in _modules) {
+                if (module.Enabled) {
+                    try {
+                        module.ModuleInstance.Dispose();
+                    } catch (Exception ex) {
+                        Logger.Error(ex, "Module '{$moduleName} ({$moduleNamespace}) threw an exception while unloading.", module.Manifest.Name, module.Manifest.Namespace);
 
-        protected override void Update(GameTime gameTime) {
-            _modules.ForEach(s => {
-                                 try {
-                                     if (s.Enabled) s.ModuleInstance.DoUpdate(gameTime);
-                                 } catch (Exception ex) {
-                                     #if DEBUG
-                                     // To assist in debugging
-                                     throw;
-                                     #endif
-                                     Logger.Error(ex, "Module '{$moduleName} ({$moduleNamespace}) threw an exception.", s.Manifest.Name, s.Manifest.Namespace);
-                                 }
-            });
+                        if (ApplicationSettings.Instance.DebugEnabled) {
+                            // To assist in debugging modules
+                            throw;
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/Blish HUD/GameServices/Modules/Manifest.cs
+++ b/Blish HUD/GameServices/Modules/Manifest.cs
@@ -62,6 +62,14 @@ namespace Blish_HUD.Modules {
             this.ApiPermissions = this.ApiPermissions ?? new Dictionary<TokenPermission, ModuleApiPermissions>(0);
         }
 
+        /// <summary>
+        /// Gets the detailed name of the module suitable for displaying in logs.
+        /// [ModuleName] ([ModuleNamespace] v[ModuleVersion])
+        /// </summary>
+        public virtual string GetDetailedName() {
+            return $"{this.Name} ({this.Namespace}) v{this.Version}";
+        }
+
     }
 
 }

--- a/Blish HUD/GameServices/Modules/Module.cs
+++ b/Blish HUD/GameServices/Modules/Module.cs
@@ -98,11 +98,12 @@ namespace Blish_HUD.Modules {
                     var loadError = new UnobservedTaskExceptionEventArgs(_loadTask.Exception);
                     OnModuleException(loadError);
 
-                    if (!loadError.Observed) {
-                        Logger.Error(_loadTask.Exception, "Module '{$moduleName} ({$moduleNamespace})' had an unhandled exception while loading:", this.Name, this.Namespace);
-                        #if DEBUG
-                        throw _loadTask.Exception;
-                        #endif
+                    if (!loadError.Observed && _loadTask.Exception != null) {
+                        Logger.Error(_loadTask.Exception, "Module {module} had an unhandled exception while loading.", ModuleParameters.Manifest.GetDetailedName());
+
+                        if (ApplicationSettings.Instance.DebugEnabled) {
+                            throw _loadTask.Exception;
+                        }
                     } else {
                         RunState = ModuleRunState.Loaded;
                     }
@@ -110,18 +111,18 @@ namespace Blish_HUD.Modules {
 
                 case TaskStatus.RanToCompletion:
                     RunState = ModuleRunState.Loaded;
-                    Logger.Info("Module '{$moduleName} ({$moduleNamespace})' finished loading.", this.Name, this.Namespace);
+                    Logger.Info("Module {module} finished loading.", ModuleParameters.Manifest.GetDetailedName());
                     break;
 
                 case TaskStatus.Canceled:
-                    Logger.Warn("Module '{$moduleName} ({$moduleNamespace})' was cancelled before it could finish loading.", this.Name, this.Namespace);
+                    Logger.Warn("Module {module} was cancelled before it could finish loading.", ModuleParameters.Manifest.GetDetailedName());
                     break;
 
                 case TaskStatus.WaitingForActivation:
                     break;
 
                 default:
-                    Logger.Warn("Module '{$moduleName} ({$moduleNamespace})' load state of {loadTaskStatus} was unexpected.", this.Name, this.Namespace, _loadTask.Status.ToString());
+                    Logger.Warn("Module {module} load state of {loadTaskStatus} was unexpected.", ModuleParameters.Manifest.GetDetailedName(), _loadTask.Status.ToString());
                     break;
             }
         }

--- a/Blish HUD/GameServices/Modules/ModuleManager.cs
+++ b/Blish HUD/GameServices/Modules/ModuleManager.cs
@@ -99,7 +99,7 @@ namespace Blish_HUD.Modules {
         private Assembly CurrentDomainOnAssemblyResolve(object sender, ResolveEventArgs args) {
             if (_enabled && _moduleAssembly == args.RequestingAssembly) {
                 try {
-                    string assemblyName = $"{args.Name.Split(',')[0]}.dll";
+                    string assemblyName = $"{new AssemblyName(args.Name).Name}.dll";
 
                     Logger.Debug("Module {module} requested to load dependency {dependency} ({assemblyName}).", _manifest.GetDetailedName(), args.Name, assemblyName);
 

--- a/Blish HUD/GameServices/Modules/ModuleManager.cs
+++ b/Blish HUD/GameServices/Modules/ModuleManager.cs
@@ -59,6 +59,8 @@ namespace Blish_HUD.Modules {
             _manifest   = manifest;
             _state      = state;
             _dataReader = dataReader;
+
+            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomainOnAssemblyResolve;
         }
 
         private void Enable() {
@@ -74,6 +76,7 @@ namespace Blish_HUD.Modules {
 
                     if (this.ModuleInstance != null) {
                         _enabled = true;
+
                         this.ModuleInstance.DoInitialize();
                         this.ModuleInstance.DoLoad();
                     }
@@ -81,6 +84,32 @@ namespace Blish_HUD.Modules {
                     throw new FileNotFoundException($"Assembly '{packagePath}' could not be loaded from {_dataReader.GetType().Name}.");
                 }
             }
+        }
+
+        private Assembly LoadPackagedAssembly(string assemblyName) {
+            // All assemblies must be at the root of the BHM.
+            string symbolsPath = assemblyName.Replace(".dll", ".pdb");
+
+            byte[] assemblyData = _dataReader.GetFileBytes(assemblyName);
+            byte[] symbolData   = _dataReader.GetFileBytes(symbolsPath) ?? new byte[0];
+
+            return Assembly.Load(assemblyData, symbolData);
+        }
+
+        private Assembly CurrentDomainOnAssemblyResolve(object sender, ResolveEventArgs args) {
+            if (_enabled && _moduleAssembly == args.RequestingAssembly) {
+                try {
+                    string assemblyName = $"{args.Name.Split(',')[0]}.dll";
+
+                    Logger.Debug("Module {module} requested to load dependency {dependency} ({assemblyName}).", _manifest.GetDetailedName(), args.Name, assemblyName);
+
+                    return LoadPackagedAssembly(assemblyName);
+                } catch (Exception ex) {
+                    Logger.Warn(ex, "Failed to load dependency {dependency} for {module}.", args.Name, _manifest.GetDetailedName());
+                }
+            }
+
+            return null;
         }
 
         private void Disable() {
@@ -91,14 +120,9 @@ namespace Blish_HUD.Modules {
         }
 
         private void ComposeModuleFromFileSystemReader(string dllName, ModuleParameters parameters) {
-            string symbolsPath = dllName.Replace(".dll", ".pdb");
-
-            byte[] assemblyData = _dataReader.GetFileBytes(dllName);
-            byte[] symbolData   = _dataReader.GetFileBytes(symbolsPath) ?? new byte[0];
-
             if (_moduleAssembly == null) {
                 try {
-                    _moduleAssembly = Assembly.Load(assemblyData, symbolData);
+                    _moduleAssembly = LoadPackagedAssembly(dllName);
                 } catch (ReflectionTypeLoadException ex) {
                     Logger.Warn(ex, "Module {module} failed to load due to a type exception. Ensure that you are using the correct version of the Module", _manifest.GetDetailedName());
                     return;

--- a/Blish HUD/GameServices/Modules/ModuleManager.cs
+++ b/Blish HUD/GameServices/Modules/ModuleManager.cs
@@ -100,13 +100,13 @@ namespace Blish_HUD.Modules {
                 try {
                     _moduleAssembly = Assembly.Load(assemblyData, symbolData);
                 } catch (ReflectionTypeLoadException ex) {
-                    Logger.Warn(ex, "Module {module} failed to load due to a type exception. Ensure that you are using the correct version of the Module", this);
+                    Logger.Warn(ex, "Module {module} failed to load due to a type exception. Ensure that you are using the correct version of the Module", _manifest.GetDetailedName());
                     return;
                 } catch (BadImageFormatException ex) {
-                    Logger.Warn(ex, "Module {module} failed to load.  Check that it is a compiled module.", this);
+                    Logger.Warn(ex, "Module {module} failed to load.  Check that it is a compiled module.", _manifest.GetDetailedName());
                     return;
                 } catch (Exception ex) {
-                    Logger.Warn(ex, "Module {module} failed to load due to an unexpected error.", this);
+                    Logger.Warn(ex, "Module {module} failed to load due to an unexpected error.", _manifest.GetDetailedName());
                     return;
                 }
             }
@@ -119,7 +119,9 @@ namespace Blish_HUD.Modules {
             try {
                 container.SatisfyImportsOnce(this);
             } catch (CompositionException ex) {
-                Logger.Warn(ex, "Module {module} failed to be composed", this);
+                Logger.Warn(ex, "Module {module} failed to be composed.", _manifest.GetDetailedName());
+            } catch (FileNotFoundException ex) {
+                Logger.Warn(ex, "Module {module} failed to load a dependency.", _manifest.GetDetailedName());
             }
         }
 

--- a/Blish HUD/GameServices/Settings/UI/SingleModuleSettingsUIBuilder.cs
+++ b/Blish HUD/GameServices/Settings/UI/SingleModuleSettingsUIBuilder.cs
@@ -121,6 +121,12 @@ namespace Blish_HUD.Settings.UI {
                 moduleState.Text      = "Loading";
                 moduleState.TextColor = Control.StandardColors.Yellow;
 
+                if (cModuleMan.ModuleInstance == null) {
+                    moduleState.Text      = "Failed to load";
+                    moduleState.TextColor = Control.StandardColors.Red;
+                    return;
+                }
+
                 cModuleMan.ModuleInstance.ModuleLoaded += delegate {
                     enableButton.Enabled  = !cModuleMan.Enabled;
                     disableButton.Enabled = cModuleMan.Enabled;

--- a/Blish HUD/Program.cs
+++ b/Blish HUD/Program.cs
@@ -39,6 +39,8 @@ namespace Blish_HUD {
 
             EnableLogging();
 
+            Logger.Debug("Launched with args {launchOptions}.", string.Join(" ", args));
+
             if (IsMoreThanOneInstance()) {
                 Logger.Warn("Blish HUD is already running!");
                 return;


### PR DESCRIPTION
## Added new launch options:
**--module, -M**
Allows you to specify the path of a packed module bhm.  This module will be loaded and enabled when Blish HUD is launched.  Useful when developing modules.

**--unlockfps, -F**
Allows you to unlock the max FPS from the default 60fps.

**--maxfps, -f**
Allows you to set the max target FPS (mutually exclusive with --unlockfps).  Defaults to 60 if not specified.

**--debug, -d**
Allows you to set "DebugEnabled" which enables the FPS, timings overlay, special handling for module exceptions (rethrows instead of catching them nicely), and lowers the minimum output log level to DEBUG.  The "DEBUG" compiler flag will implicitly enable this.  The goal is to move away from using compiler flags and to instead use launch options so that release versions of Blish HUD can toggle some of these settings.

## Module improvements
- Improved error handling for missing module dependency exceptions.
- Improved logging details when something happens specific to a module (loads, unloads, throws an exception, etc.).
- Indicates when a module has failed to load entirely.
_This is a basic stopgap until more of the mvp stuff is cherry picked over new a new branch since larger improvements to how modules are handled when they are loading have been made in that branch.  If a module immediately fails to load (missing dependency, etc.) it will say so now in the UI and disable both the ENABLE and DISABLE buttons._
- "AppDomain.CurrentDomain.UnhandledException" swapped away from compiler flag to the "DebugEnabled" setting so that module exceptions aren't caught gracefully and can allow the debugger to step in and take over.
- ModuleService unload now disposes of modules.
- Modules can now load DLLs within their BHM archive dynamically when they are referenced as long as the full name matches the actual name of the DLL.
_This removes the need for costura/fody to manage these referenced DLLs in modules._