### PR TITLE
Better --module param and Exit unloading

### DIFF
--- a/Blish HUD/BlishHud.cs
+++ b/Blish HUD/BlishHud.cs
@@ -6,6 +6,8 @@ namespace Blish_HUD {
 
     public class BlishHud : Game {
 
+        private static readonly Logger Logger = Logger.GetLogger<BlishHud>();
+
         #region Internal Static Members
 
         private static GraphicsDeviceManager                          _activeGraphicsDeviceManager;
@@ -49,12 +51,6 @@ namespace Blish_HUD {
             this.IsMouseVisible = true;
         }
         
-        /// <summary>
-        /// Allows the game to perform any initialization it needs to before starting to run.
-        /// This is where it can query for any required services and load any non-graphic
-        /// related content.  Calling base.Initialize will enumerate through any components
-        /// and initialize them as well.
-        /// </summary>
         protected override void Initialize() {
             FormHandle = this.Window.Handle;
             Form       = System.Windows.Forms.Control.FromHandle(FormHandle).FindForm();
@@ -87,19 +83,10 @@ namespace Blish_HUD {
             _basicSpriteBatch = new SpriteBatch(this.GraphicsDevice);
         }
 
-        /// <summary>
-        /// UnloadContent will be called once per game and is the place to unload
-        /// game-specific content.
-        /// </summary>
-        protected override void UnloadContent() {
-            // Let all of the game services have a chance to unload
-            foreach (var service in GameService.All) {
-                service.DoUnload();
-            }
-        }
-
         protected override void BeginRun() {
             base.BeginRun();
+
+            Logger.Debug("Loading services.");
 
             // Let all of the game services have a chance to load
             foreach (var service in GameService.All) {
@@ -107,11 +94,17 @@ namespace Blish_HUD {
             }
         }
 
-        /// <summary>
-        /// Allows the game to run logic such as updating the world,
-        /// checking for collisions, gathering input, and playing audio.
-        /// </summary>
-        /// <param name="gameTime">Provides a snapshot of timing values.</param>
+        protected override void UnloadContent() {
+            base.UnloadContent();
+
+            Logger.Debug("Unloading services.");
+            
+            // Let all of the game services have a chance to unload
+            foreach (var service in GameService.All) {
+                service.DoUnload();
+            }
+        }
+
         protected override void Update(GameTime gameTime) {
             // If gw2 isn't open - only update the most important things:
             if (!GameService.GameIntegration.Gw2IsRunning) {
@@ -131,10 +124,6 @@ namespace Blish_HUD {
             base.Update(gameTime);
         }
 
-        /// <summary>
-        /// This is called when the game should draw itself.
-        /// </summary>
-        /// <param name="gameTime">Provides a snapshot of timing values.</param>
         protected override void Draw(GameTime gameTime) {
             if (!GameService.GameIntegration.Gw2IsRunning) return;
 

--- a/Blish HUD/GameServices/GameIntegrationService.cs
+++ b/Blish HUD/GameServices/GameIntegrationService.cs
@@ -213,7 +213,7 @@ namespace Blish_HUD {
             this.TrayIconMenu.Items.Add(new ToolStripSeparator());
             ts_exit = this.TrayIconMenu.Items.Add($"{Strings.Common.Action_Exit} {Strings.Common.BlishHUD}");
 
-            ts_exit.Click += delegate { ActiveBlishHud.Exit(); };
+            ts_exit.Click += delegate { Overlay.Exit(); };
 
             this.TrayIconMenu.Opening += delegate {
                 ts_launchGw2.Enabled     = !this.Gw2IsRunning && File.Exists(this.Gw2ExecutablePath);
@@ -265,8 +265,8 @@ namespace Blish_HUD {
 
             Logger.Info("Guild Wars 2 application has exited!");
 
-            if (!GameService.Overlay.StayInTray.Value) {
-                Application.Exit();
+            if (!Overlay.StayInTray.Value) {
+                Overlay.Exit();
             }
         }
 

--- a/Blish HUD/GameServices/ModuleService.cs
+++ b/Blish HUD/GameServices/ModuleService.cs
@@ -173,7 +173,7 @@ namespace Blish_HUD {
                     try {
                         module.ModuleInstance.DoUpdate(gameTime);
                     } catch (Exception ex) {
-                        Logger.Error(ex, "Module '{$moduleName} ({$moduleNamespace}) threw an exception while updating.", module.Manifest.Name, module.Manifest.Namespace);
+                        Logger.Error(ex, "Module {module} threw an exception while updating.", module.Manifest.GetDetailedName());
 
                         if (ApplicationSettings.Instance.DebugEnabled) {
                             // To assist in debugging modules
@@ -188,9 +188,10 @@ namespace Blish_HUD {
             foreach (var module in _modules) {
                 if (module.Enabled) {
                     try {
+                        Logger.Info("Unloading module {module}.", module.Manifest.GetDetailedName());
                         module.ModuleInstance.Dispose();
                     } catch (Exception ex) {
-                        Logger.Error(ex, "Module '{$moduleName} ({$moduleNamespace}) threw an exception while unloading.", module.Manifest.Name, module.Manifest.Namespace);
+                        Logger.Error(ex, "Module '{module} threw an exception while unloading.", module.Manifest.GetDetailedName());
 
                         if (ApplicationSettings.Instance.DebugEnabled) {
                             // To assist in debugging modules

--- a/Blish HUD/GameServices/ModuleService.cs
+++ b/Blish HUD/GameServices/ModuleService.cs
@@ -7,6 +7,7 @@ using System.Linq.Expressions;
 using Blish_HUD.Content;
 using Blish_HUD.Modules;
 using Blish_HUD.Settings;
+using Microsoft.VisualBasic.Logging;
 using Microsoft.Xna.Framework;
 using Newtonsoft.Json;
 using File = System.IO.File;
@@ -150,9 +151,19 @@ namespace Blish_HUD {
             }
 
             if (ApplicationSettings.Instance.DebugModulePath != null) {
-                var debugModule = LoadModuleFromPackedBhm(ApplicationSettings.Instance.DebugModulePath);
+                ModuleManager debugModule = null;
 
-                debugModule.Enabled = true;
+                if (File.Exists(ApplicationSettings.Instance.DebugModulePath)) {
+                    debugModule = LoadModuleFromPackedBhm(ApplicationSettings.Instance.DebugModulePath);
+                } else if (Directory.Exists(ApplicationSettings.Instance.DebugModulePath)) {
+                    debugModule = LoadModuleFromUnpackedBhm(ApplicationSettings.Instance.DebugModulePath);
+                } else {
+                    Logger.Warn("Failed to load module from path {modulePath}.", ApplicationSettings.Instance.DebugModulePath);
+                }
+
+                if (debugModule != null) {
+                    debugModule.Enabled = true;
+                }
             }
 
             // Get the base version string and see if we've exported the modules for this version yet


### PR DESCRIPTION
### GameService.Overlay.Exit()

Allows Blish HUD to unload properly given all services and modules a chance to unload.  If unloading takes more than 4 seconds (e.g. misbehaving module blocks on unload), the application force exits to prevent from hanging open and to avoid annoying the user.

### Improved --module, -M

The `---module` param now supports load unpacked modules if a valid directory is passed instead of a .bhm file.

The file path or directory is now also checked to ensure it is valid before we attempt to load the module it points to.