### PR TITLE
Ensure TextInputBase/TextBox cleans up hold on InputListner.

### DIFF
--- a/Blish HUD/Controls/Textbox.cs
+++ b/Blish HUD/Controls/Textbox.cs
@@ -30,7 +30,11 @@ namespace Blish_HUD.Controls {
         /// </summary>
         public event EventHandler<EventArgs> EnterPressed;
 
-        protected virtual void OnEnterPressed(EventArgs e) => EnterPressed?.Invoke(this, e);
+        protected virtual void OnEnterPressed(EventArgs e) {
+            this.Focused = false;
+
+            EnterPressed?.Invoke(this, e);
+        }
 
         private int _prevCursorIndex  = 0;
         private int _horizontalOffset = 0;

--- a/Blish HUD/GameServices/Input/KeyboardManager.cs
+++ b/Blish HUD/GameServices/Input/KeyboardManager.cs
@@ -59,7 +59,7 @@ namespace Blish_HUD.Input {
         /// A list of keys currently being pressed down.
         /// </summary>
         public IReadOnlyList<Keys> KeysDown => _keysDown.AsReadOnly();
-
+        
         private Action<string> _textInputDelegate;
 
         internal KeyboardManager() : base(HookType.WH_KEYBOARD_LL) {
@@ -118,7 +118,7 @@ namespace Blish_HUD.Input {
         }
 
         private void EndTextInputAsyncInvoke(IAsyncResult asyncResult) {
-            _textInputDelegate.EndInvoke(asyncResult);
+            _textInputDelegate?.EndInvoke(asyncResult);
         }
 
         private bool ProcessInput(KeyboardEventType eventType, Keys key) {


### PR DESCRIPTION
Focus changes now update the InputListner.  Global mouse and keyboard events are subscribed and unsubscribed when focused and unfocused.  Key repeats moved to start of method handler so that repeat list isn't modified when textbox is deselected from pressing enter.

Fixes #210 