### PR TITLE
Fixed typo with new public value and made typo version obsolete.

### DIFF
--- a/Blish HUD/_Events/ValueChangedEventArgs[T].cs
+++ b/Blish HUD/_Events/ValueChangedEventArgs[T].cs
@@ -8,19 +8,25 @@ namespace Blish_HUD {
 
     public class ValueChangedEventArgs<T> : EventArgs {
 
+        private readonly T _previousValue;
+        private readonly T _newValue;
+
         /// <summary>
         /// The value of the property before it was changed.
         /// </summary>
-        public T PrevousValue { get; }
+        public T PreviousValue => _previousValue;
+
+        [Obsolete("Typo.  Use 'PreviousValue' instead.")]
+        public T PrevousValue => _previousValue;
 
         /// <summary>
         /// The value of the property now that it has been changed.
         /// </summary>
-        public T NewValue { get; }
+        public T NewValue => _newValue;
 
         public ValueChangedEventArgs(T previousValue, T newValue) {
-            this.PrevousValue = previousValue;
-            this.NewValue     = newValue;
+            _previousValue = previousValue;
+            _newValue      = newValue;
         }
 
     }


### PR DESCRIPTION
Keeping old typo property (marked obsolete now) for a bit to avoid breaking change.