### PR TITLE
Update readme to link to the latest build on dev branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ﻿# Blish HUD
-[![Build status](https://ci.appveyor.com/api/projects/status/43fg2d3hy4jt5ip1?svg=true)](https://ci.appveyor.com/project/dlamkins/blish-hud)
+[![Build status](https://ci.appveyor.com/api/projects/status/43fg2d3hy4jt5ip1?svg=true)](https://ci.appveyor.com/project/dlamkins/blish-hud/branch/dev/artifacts)
 [![Discord](https://img.shields.io/discord/531175899588984842.svg?logo=discord&logoColor=%237289DA)](https://discord.gg/FYKN3qh)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?branch=dev&project=blish-hud_Blish-HUD&metric=alert_status)](https://sonarcloud.io/dashboard?id=blish-hud_Blish-HUD&branch=dev)
 


### PR DESCRIPTION
The current version is linking to the latest ci build, and not to the latest build of the dev. This PR fixes this