### PR TITLE
SettingRender fixes, scrollbar fixes, and locale event wiring.

### DIFF
--- a/Blish HUD/Controls/Panel.cs
+++ b/Blish HUD/Controls/Panel.cs
@@ -295,7 +295,7 @@ namespace Blish_HUD.Controls {
                 _scrollbarBindings.Add(Adhesive.Binding.CreateOneWayBinding(() => _panelScrollbar.ZIndex, () => this.ZIndex, (z) => z + 2, applyLeft: true));
             } else {
                 // TODO: Switch to breaking these bindings once it is supported in Adhesive
-                _scrollbarBindings.ForEach((bind) => bind.Disable());
+                _scrollbarBindings.ToList().ForEach((bind) => bind.Disable());
                 _scrollbarBindings.Clear();
 
                 _panelScrollbar?.Dispose();

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -22,7 +22,7 @@ namespace Blish_HUD {
 
         private const int FORCE_EXIT_TIMEOUT = 4000;
 
-        public event EventHandler<EventArgs> UserLocaleChanged;
+        public event EventHandler<ValueEventArgs<CultureInfo>> UserLocaleChanged;
 
         public TabbedWindow     BlishHudWindow   { get; private set; }
         public CornerIcon       BlishMenuIcon    { get; private set; }
@@ -76,7 +76,12 @@ namespace Blish_HUD {
         }
 
         private void UserLocaleOnSettingChanged(object sender, ValueChangedEventArgs<Locale> e) {
-            CultureInfo.CurrentUICulture = GetCultureFromGw2Locale(e.NewValue);
+            var culture = GetCultureFromGw2Locale(e.NewValue);
+
+            CultureInfo.DefaultThreadCurrentUICulture = culture;
+            CultureInfo.CurrentUICulture              = culture;
+
+            this.UserLocaleChanged?.Invoke(this, new ValueEventArgs<CultureInfo>(culture));
         }
 
         /// <summary>

--- a/Blish HUD/GameServices/Settings/SettingCollection.cs
+++ b/Blish HUD/GameServices/Settings/SettingCollection.cs
@@ -93,9 +93,10 @@ namespace Blish_HUD.Settings {
                 _entries.Add(definedEntry);
             }
 
-            definedEntry.DisplayName = displayName;
-            definedEntry.Description = description;
-            definedEntry.Renderer    = renderer;
+            definedEntry.DisplayName    = displayName;
+            definedEntry.Description    = description;
+            definedEntry.Renderer       = renderer;
+            definedEntry.SessionDefined = true;
 
             return definedEntry;
         }

--- a/Blish HUD/GameServices/Settings/SettingEntry.cs
+++ b/Blish HUD/GameServices/Settings/SettingEntry.cs
@@ -64,6 +64,9 @@ namespace Blish_HUD.Settings {
         [JsonProperty(SETTINGNAME_KEY)]
         public string EntryKey { get; protected set; }
 
+        [JsonIgnore]
+        public bool SessionDefined { get; internal set; }
+
         protected abstract Type GetSettingType();
 
         protected abstract object GetSettingValue();

--- a/Blish HUD/GameServices/Settings/UI/Views/SettingsView.cs
+++ b/Blish HUD/GameServices/Settings/UI/Views/SettingsView.cs
@@ -1,4 +1,5 @@
-﻿using Blish_HUD.Controls;
+﻿using System.Linq;
+using Blish_HUD.Controls;
 using Blish_HUD.Graphics.UI;
 using Microsoft.Xna.Framework;
 
@@ -50,7 +51,7 @@ namespace Blish_HUD.Settings.UI.Views {
                 Parent              = buildPanel
             };
 
-            foreach (var setting in _settings) {
+            foreach (var setting in _settings.Where(s => s.SessionDefined)) {
                 IView settingView;
 
                 if ((settingView = SettingView.FromType(setting, _settingFlowPanel.Width)) != null) {


### PR DESCRIPTION
Addresses a number of issues brought up on 6/4/2020

- Settings are no longer rendered unless something in that session has ensured they are defined (prevents old and unused settings from rendering).
- Avoid condition where a view unloads/loads overlapping and causes scrollbar bindings to modify the collection while being enumerated.
- Wired UserLocaleChanged event.
- Ensured default CurrentUICulture matches on all new threads automatically.