### PR TITLE
Support Module Localization

### DIFF
--- a/Blish HUD/GameServices/Modules/ModuleManager.cs
+++ b/Blish HUD/GameServices/Modules/ModuleManager.cs
@@ -103,7 +103,7 @@ namespace Blish_HUD.Modules {
 
                     string assemblyName = $"{assemblyDetails.Name}.dll";
 
-                    if (!Equals(assemblyDetails.CultureInfo, CultureInfo.InvariantCulture)) {
+                    if (!Equals(assemblyDetails.CultureInfo, CultureInfo.InvariantCulture) && !string.Equals(assemblyDetails.CultureInfo.TwoLetterISOLanguageName, "en")) {
                         assemblyName = $"{assemblyDetails.CultureName}/{assemblyName}";
                     }
 

--- a/Blish HUD/GameServices/Modules/ModuleManager.cs
+++ b/Blish HUD/GameServices/Modules/ModuleManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using Blish_HUD.Content;
@@ -86,11 +87,10 @@ namespace Blish_HUD.Modules {
             }
         }
 
-        private Assembly LoadPackagedAssembly(string assemblyName) {
-            // All assemblies must be at the root of the BHM.
-            string symbolsPath = assemblyName.Replace(".dll", ".pdb");
+        private Assembly LoadPackagedAssembly(string assemblyPath) {
+            string symbolsPath = assemblyPath.Replace(".dll", ".pdb");
 
-            byte[] assemblyData = _dataReader.GetFileBytes(assemblyName);
+            byte[] assemblyData = _dataReader.GetFileBytes(assemblyPath);
             byte[] symbolData   = _dataReader.GetFileBytes(symbolsPath) ?? new byte[0];
 
             return Assembly.Load(assemblyData, symbolData);
@@ -99,7 +99,13 @@ namespace Blish_HUD.Modules {
         private Assembly CurrentDomainOnAssemblyResolve(object sender, ResolveEventArgs args) {
             if (_enabled && _moduleAssembly == args.RequestingAssembly) {
                 try {
-                    string assemblyName = $"{new AssemblyName(args.Name).Name}.dll";
+                    var assemblyDetails = new AssemblyName(args.Name);
+
+                    string assemblyName = $"{assemblyDetails.Name}.dll";
+
+                    if (!Equals(assemblyDetails.CultureInfo, CultureInfo.InvariantCulture)) {
+                        assemblyName = $"{assemblyDetails.CultureName}/{assemblyName}";
+                    }
 
                     Logger.Debug("Module {module} requested to load dependency {dependency} ({assemblyName}).", _manifest.GetDetailedName(), args.Name, assemblyName);
 


### PR DESCRIPTION
If a module requests a satellite assembly (generally strings for localization), the `CultureName` provided in the assembly request is used to specify the directory within the BHM to load the assembly from.

_Modules should use the neutral language (i.e. "de" instead of "de-de" or "en" instead of "en-US") as `CultureName` does not provide the specific language preventing us from finding the correct directory._