### PR TITLE
Handle EntryPoint OnUserFacingException and OnHelpInvoked

### DIFF
--- a/Blish HUD/ApplicationSettings.cs
+++ b/Blish HUD/ApplicationSettings.cs
@@ -1,5 +1,7 @@
 ﻿using System.Diagnostics;
+using System.Windows.Forms;
 using EntryPoint;
+using EntryPoint.Exceptions;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 
@@ -10,11 +12,21 @@ namespace Blish_HUD {
         private static ApplicationSettings _instance;
 
         internal static ApplicationSettings Instance => _instance;
-        
+
+        public bool CliExitEarly => this.UserFacingExceptionThrown || this.HelpInvoked;
+
         public ApplicationSettings() : base("Blish HUD") {
-            _instance = this;
+            _instance ??= this;
 
             InitDebug();
+        }
+
+        public override void OnUserFacingException(UserFacingException e, string message) {
+            MessageBox.Show("Invalid launch option(s) specified.  See --help for available options.", "Failed to launch Blish HUD", MessageBoxButtons.OK);
+        }
+
+        public override void OnHelpInvoked(string helpText) {
+            MessageBox.Show(helpText, "Launch Options", MessageBoxButtons.OK);
         }
 
         [Conditional("DEBUG")]

--- a/Blish HUD/Program.cs
+++ b/Blish HUD/Program.cs
@@ -38,7 +38,7 @@ namespace Blish_HUD {
         /// </summary>
         [STAThread]
         static void Main(string[] args) {
-            Cli.Parse<ApplicationSettings>(args);
+            if (Cli.Parse<ApplicationSettings>(args).CliExitEarly) return;
 
             Directory.SetCurrentDirectory(Path.GetDirectoryName(Application.ExecutablePath));
 


### PR DESCRIPTION
Handle invalid launch arguments with an error message and actually display launch option documentation when --help flag is passed.

Fixes #226 