### PR TITLE
Dropdown (and some Tooltip) Improvements

### DIFF
--- a/Blish HUD/Controls/Control.cs
+++ b/Blish HUD/Controls/Control.cs
@@ -450,9 +450,15 @@ namespace Blish_HUD.Controls {
             set {
                 if (!SetProperty(ref _basicTooltipText, value)) return;
 
-                // In the event that the tooltip text is changed while it's being shown, this will update it
+                // In the event that the tooltip text is changed while it's
+                // being shown (or the mouse is over the control), this
+                // portion will update it and display it (if it isn't already).
                 if (Control.ActiveControl == this) {
                     _sharedTooltipLabel.Text = value;
+
+                    if (!string.IsNullOrEmpty(value)) {
+                        _sharedTooltip.Show(Input.Mouse.Position + new Point(Tooltip.MOUSE_VERTICAL_MARGIN, -Tooltip.MOUSE_VERTICAL_MARGIN * 2));
+                    }
                 }
 
                 if (!string.IsNullOrEmpty(value)) {
@@ -462,7 +468,7 @@ namespace Blish_HUD.Controls {
                         _sharedTooltipLabel.Text = this.BasicTooltipText;
                     };
                 } else {
-                    this.Tooltip.Hide();
+                    this.Tooltip?.Hide();
                     this.Tooltip = null;
                 }
             }

--- a/Blish HUD/Controls/Screen.cs
+++ b/Blish HUD/Controls/Screen.cs
@@ -1,16 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework.Input;
 
 namespace Blish_HUD.Controls {
     public class Screen:Container {
 
-        public const int MENUUI_BASEINDEX = 30; // Skillbox
-        public const int TOOLTIP3D_BASEINDEX = 40;
-        public const int WINDOW_BASEZINDEX = 41;
+        public const int MENUUI_BASEINDEX      = 30; // Skillbox
+        public const int TOOLTIP3D_BASEINDEX   = 40;
+        public const int WINDOW_BASEZINDEX     = 41;
         public const int TOOLWINDOW_BASEZINDEX = 45;
-        public const int TOOLTIP_BASEZINDEX = 55;
         public const int CONTEXTMENU_BASEINDEX = 50;
+        public const int DROPDOWN_BASEINDEX    = int.MaxValue - 64;
+        public const int TOOLTIP_BASEZINDEX    = int.MaxValue - 32;
 
         /// <inheritdoc />
         protected override CaptureType CapturesInput() {

--- a/Blish HUD/Controls/Tooltip.cs
+++ b/Blish HUD/Controls/Tooltip.cs
@@ -7,10 +7,10 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Blish_HUD.Controls {
    public class Tooltip : Container {
+        
+        internal const int MOUSE_VERTICAL_MARGIN = 18;
 
         private const int PADDING = 2;
-
-        private const int MOUSE_VERTICAL_MARGIN = 18;
 
         #region Load Static
 
@@ -27,17 +27,19 @@ namespace Blish_HUD.Controls {
 
             _allTooltips = new List<Tooltip>();
 
-            Control.ActiveControlChanged += ControlOnActiveControlChanged;
+            ActiveControlChanged   += ControlOnActiveControlChanged;
+            Input.Mouse.MouseMoved += HandleMouseMoved;
+        }
 
-            Input.Mouse.MouseMoved += delegate(object sender, MouseEventArgs args) {
-                if (ActiveControl?.Tooltip != null) {
-                    ActiveControl.Tooltip.CurrentControl = ActiveControl;
-                    UpdateTooltipPosition(ActiveControl.Tooltip);
+        private static void HandleMouseMoved(object sender, MouseEventArgs e) {
+            if (ActiveControl?.Tooltip != null) {
+                ActiveControl.Tooltip.CurrentControl = ActiveControl;
+                UpdateTooltipPosition(ActiveControl.Tooltip);
 
-                    if (!ActiveControl.Tooltip.Visible)
-                        ActiveControl.Tooltip.Show();
+                if (!ActiveControl.Tooltip.Visible) {
+                    ActiveControl.Tooltip.Show();
                 }
-            };
+            }
         }
 
         private static Control _prevControl;
@@ -121,7 +123,7 @@ namespace Blish_HUD.Controls {
 
         public override void UpdateContainer(GameTime gameTime) {
             if (this.CurrentControl != null && !this.CurrentControl.Visible) {
-                this.Visible = false;
+                this.Visible        = false;
                 this.CurrentControl = null;
             }
         }


### PR DESCRIPTION
Updated dropdown panel to drop in the direction that will show as much of the panel as possible (like what was done with the ContextMenuStrip in PR #257).  Previously if the panel displayed below the bottom of the screen by even one pixel, it would flip upwards without checking how much space there was above it.  This had the potential to obscur it more than it would have if it had just left it to flip down.

Dropdown will now show a tooltip when hovering over an individual item for long enough (800ms) to aid in cases where the item is too wide for the control area.  This resolves #222.

![image](https://user-images.githubusercontent.com/1950594/85544659-35a16b00-b5e9-11ea-9634-ffc2d5839537.png)

Dropdown has a new property "PanelOpen" which can be used to determine if the panel is actively open or not (to assist with and potentially act as a good enough work around for issue #224).

Additionally, when setting `BasicTooltipText` on a control when the tooltip is not already active (such as when the tooltip text was previously `string.Empty`), the tooltip will be immediately shown now (since there is a valid value to display) instead of waiting until the mouse moves on the control again to trigger it.  Previously a tooltip could be updated with a valid value while the user was already moused over the control and the tooltip would not display until the mouse was moved to trigger the recheck.

The internally defined constants indicating the intended base ZIndex for both Tooltips and DropdownPanels have been updated to ensure that tooltips show over top of DropdownPanels (which were previously set to draw on top of everything which is not necessary).