### PR TITLE
OverlayService and Gw2ClientContext Improvements

### DIFF
--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -164,8 +164,6 @@ namespace Blish_HUD {
                 }
             };
 
-            this.BlishHudWindow.AddTab(Strings.GameServices.OverlayService.HomeTab, Content.GetTexture("255369"), BuildHomePanel(this.BlishHudWindow), int.MinValue);
-
             PrepareClientDetection();
         }
 
@@ -193,25 +191,23 @@ namespace Blish_HUD {
         }
 
         private void DetectClientType() {
-            if (Contexts.GetContext<Gw2ClientContext>().TryGetClientType(out var contextResult) == ContextAvailability.Available) {
-                _clientType = contextResult.Value;
+            var checkClientTypeResult = Contexts.GetContext<Gw2ClientContext>().TryGetClientType(out var contextResult);
 
-                if (_clientType == Gw2ClientContext.ClientType.Unknown) {
-                    Logger.Warn("Failed to detect current Guild Wars 2 client version: {statusForUnknown}.", contextResult.Status);
-                } else {
+            switch (checkClientTypeResult) {
+                case ContextAvailability.Available:
+                    _clientType    = contextResult.Value;
+                    _checkedClient = true;
+
                     Logger.Info("Detected Guild Wars 2 client to be the {clientVersionType} version.", _clientType);
-                }
-
-                _checkedClient = true;
-            } else {
-                Logger.Warn("Failed to detect current Guild Wars 2 client version: {statusForUnknown}", contextResult.Status);
+                    break;
+                case ContextAvailability.Unavailable:
+                case ContextAvailability.NotReady:
+                    Logger.Debug("Unable to detect current Guild Wars 2 client version: {statusForUnknown}.", contextResult.Status);
+                    break;
+                case ContextAvailability.Failed:
+                    Logger.Warn("Failed to detect current Guild Wars 2 client version: {statusForUnknown}", contextResult.Status);
+                    break;
             }
-        }
-
-        private Panel BuildHomePanel(WindowBase wndw) {
-            var hPanel = new ViewContainer();
-
-            return hPanel;
         }
 
         protected override void Unload() {


### PR DESCRIPTION
The home tab has been removed temporarily from the OverlayService.  It's historically been blank or held random labels and has so far only served to confuse users.

Resolves #256.

Additionally changed the log levels of the `Gw2ClientContext` to avoid confusing people.  The `CdnInfoContext` is rarely ready by the time the `Gw2ClientContext` reaches out to it, so the first attempt always reported a warning in the logs because the CDN were still the default of 0 and don't match what MumbleLink is providing us yet.

`Gw2ClientContext` will now take the `CdnInfoContext`'s availability into consideration before reporting its own availability allowing us to set the log level to debug for more results and reduce the number of false-positive warnings in the log.