### PR TITLE
Stop rate-limiting the render service

### DIFF
--- a/Blish HUD/GameServices/Gw2WebApiService.cs
+++ b/Blish HUD/GameServices/Gw2WebApiService.cs
@@ -31,7 +31,7 @@ namespace Blish_HUD {
             var bucket = new TokenBucket(300, 5);
 
             _sharedWebCache    = new TokenCompliantCacheWrapper(new MemoryCacheMethod(), bucket);
-            _sharedRenderCache = new TokenCompliantCacheWrapper(new MemoryCacheMethod(), bucket);
+            _sharedRenderCache = new MemoryCacheMethod();
         }
 
         #endregion


### PR DESCRIPTION
Previously we were rate-limiting the render service (which does not actually have a rate limit).  This had the potential to slow down render service requests, but more importantly, meant that render-service requests would impact token counts for the web API since they shared a bucket meaning we would potentially rate-limit much sooner than necessary if a large number of render service requests were made.