### PR TITLE
Show no modules message

### DIFF
--- a/Blish HUD/GameServices/Modules/UI/Views/NoModulesView.cs
+++ b/Blish HUD/GameServices/Modules/UI/Views/NoModulesView.cs
@@ -1,4 +1,5 @@
-﻿using Blish_HUD.Controls;
+﻿using System.Diagnostics;
+using Blish_HUD.Controls;
 using Blish_HUD.Graphics.UI;
 using Microsoft.Xna.Framework;
 
@@ -20,6 +21,10 @@ namespace Blish_HUD.Modules.UI.Views {
                 Parent   = buildPanel,
                 Width    = 200,
                 Location = new Point(buildPanel.Size.X / 2 - 100, info.Bottom - 100),
+            };
+
+            openDir.Click += delegate {
+                Process.Start("explorer.exe", $"/open, \"{DirectoryUtil.BasePath + "\\modules"}\\\"");
             };
         }
 

--- a/Blish HUD/GameServices/Modules/UI/Views/NoModulesView.cs
+++ b/Blish HUD/GameServices/Modules/UI/Views/NoModulesView.cs
@@ -1,0 +1,27 @@
+﻿using Blish_HUD.Controls;
+using Blish_HUD.Graphics.UI;
+using Microsoft.Xna.Framework;
+
+namespace Blish_HUD.Modules.UI.Views {
+    public class NoModulesView : View {
+
+        protected override void Build(Panel buildPanel) {
+            var info = new Label() {
+                Size                = buildPanel.Size / new Point(1, 2),
+                Parent              = buildPanel,
+                Text                = Strings.GameServices.ModulesService.NoModules_Info,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment   = VerticalAlignment.Middle,
+                Font                = GameService.Content.GetFont(ContentService.FontFace.Menomonia, ContentService.FontSize.Size18, ContentService.FontStyle.Italic),
+            };
+
+            var openDir = new StandardButton() {
+                Text     = Strings.GameServices.ModulesService.NoModules_OpenFolder,
+                Parent   = buildPanel,
+                Width    = 200,
+                Location = new Point(buildPanel.Size.X / 2 - 100, info.Bottom - 100),
+            };
+        }
+
+    }
+}

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -2,11 +2,13 @@
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Threading;
+using System.Windows.Forms;
 using Blish_HUD.Contexts;
 using Blish_HUD.Controls;
 using Blish_HUD.Settings;
 using Gw2Sharp.WebApi;
 using Microsoft.Xna.Framework;
+using ContextMenuStrip = Blish_HUD.Controls.ContextMenuStrip;
 
 namespace Blish_HUD {
 
@@ -139,7 +141,8 @@ namespace Blish_HUD {
             };
 
             this.BlishContextMenu = this.BlishMenuIcon.Menu;
-            this.BlishContextMenu.AddMenuItem($"{Strings.Common.Action_Exit} {Strings.Common.BlishHUD}").Click += delegate { Exit(); };
+            this.BlishContextMenu.AddMenuItem(string.Format(Strings.Common.Action_Restart, Strings.Common.BlishHUD)).Click += delegate { Application.Restart(); Exit(); };
+            this.BlishContextMenu.AddMenuItem(string.Format(Strings.Common.Action_Exit, Strings.Common.BlishHUD)).Click += delegate { Exit(); };
 
             this.BlishHudWindow = new TabbedWindow() {
                 Parent = Graphics.SpriteScreen,

--- a/Blish HUD/GameServices/SettingsService.cs
+++ b/Blish HUD/GameServices/SettingsService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Blish_HUD.Controls;
 using Blish_HUD.Gw2WebApi.UI.Views;
+using Blish_HUD.Input;
 using Blish_HUD.Modules.UI.Presenters;
 using Blish_HUD.Modules.UI.Views;
 using Blish_HUD.Overlay.UI.Views;
@@ -262,6 +263,12 @@ namespace Blish_HUD {
                         var manageModuleView = new ManageModuleView();
 
                         cPanel.Show(manageModuleView.WithPresenter(new ManageModulePresenter(manageModuleView, module)));
+                    };
+                }
+
+                if (!Module.Modules.Any()) {
+                    settingsMiModules.Click += delegate {
+                        cPanel.Show(new NoModulesView());
                     };
                 }
             };

--- a/Blish HUD/Strings/Common.de.resx
+++ b/Blish HUD/Strings/Common.de.resx
@@ -124,7 +124,7 @@
     <value>Abbrechen</value>
   </data>
   <data name="Action_Exit" xml:space="preserve">
-    <value>Verlassen</value>
+    <value>Verlassen {0}</value>
   </data>
   <data name="Options" xml:space="preserve">
     <value>Optionen</value>
@@ -133,6 +133,6 @@
     <value>Unbekannt</value>
   </data>
   <data name="Action_Restart" xml:space="preserve">
-    <value>Neustart</value>
+    <value>Neustart {0}</value>
   </data>
 </root>

--- a/Blish HUD/Strings/Common.resx
+++ b/Blish HUD/Strings/Common.resx
@@ -106,7 +106,7 @@
     <comment>Found on a button to cancel the operation.</comment>
   </data>
   <data name="Action_Exit" xml:space="preserve">
-    <value>Exit</value>
+    <value>Exit {0}</value>
   </data>
   <data name="BlishHUD" xml:space="preserve">
     <value>Blish HUD</value>
@@ -126,6 +126,6 @@
     <value>Instructions</value>
   </data>
   <data name="Action_Restart" xml:space="preserve">
-    <value>Restart</value>
+    <value>Restart {0}</value>
   </data>
 </root>

--- a/Blish HUD/Strings/GameServices/ModulesService.Designer.cs
+++ b/Blish HUD/Strings/GameServices/ModulesService.Designer.cs
@@ -356,5 +356,24 @@ namespace Blish_HUD.Strings.GameServices {
                 return ResourceManager.GetString("ModuleState_Loading", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You don&apos;t currently have any modules.
+        ///Download some modules and place them in the modules folder..
+        /// </summary>
+        internal static string NoModules_Info {
+            get {
+                return ResourceManager.GetString("NoModules_Info", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open Modules Folder.
+        /// </summary>
+        internal static string NoModules_OpenFolder {
+            get {
+                return ResourceManager.GetString("NoModules_OpenFolder", resourceCulture);
+            }
+        }
     }
 }

--- a/Blish HUD/Strings/GameServices/ModulesService.resx
+++ b/Blish HUD/Strings/GameServices/ModulesService.resx
@@ -196,4 +196,11 @@
   <data name="ModuleOption_OpenDir" xml:space="preserve">
     <value>Open '{0}' Directory</value>
   </data>
+  <data name="NoModules_Info" xml:space="preserve">
+    <value>You don't currently have any modules.
+Download some modules and place them in the modules folder.</value>
+  </data>
+  <data name="NoModules_OpenFolder" xml:space="preserve">
+    <value>Open Modules Folder</value>
+  </data>
 </root>


### PR DESCRIPTION
Added a right-click menu item to the Blish HUD icon to restart the overlay.

![image](https://user-images.githubusercontent.com/1950594/90092995-8172b580-dcf8-11ea-870c-ca2f89834218.png)

Shows a new page indicating there are no modules if there are no modules in the modules folder.

![image](https://user-images.githubusercontent.com/1950594/90093103-be3eac80-dcf8-11ea-916a-e5980c99fdd3.png)
