### PR TITLE
Add opacity support for control effects.

### DIFF
--- a/Blish HUD/Content/effects/glow.fx
+++ b/Blish HUD/Content/effects/glow.fx
@@ -10,6 +10,8 @@
 float  TextureWidth;
 float4 GlowColor;
 
+float Opacity = 1.0f;
+
 sampler s0 = sampler_state {
     AddressU = Clamp;
     AddressV = Clamp;
@@ -33,15 +35,15 @@ float4 DrawGlow(float4 Position : SV_POSITION, float4 Color : COLOR0, float2 Tex
     clr += tex2D(s0, float2(TexCoords.x        , TexCoords.y - Pixel - Pixel));
     clr += tex2D(s0, float2(TexCoords.x - Pixel, TexCoords.y - Pixel));
 	
-    return float4(clr.rgb * 12, clr.a * 0.1) * GlowColor;
+    return float4(clr.rgb * 12, clr.a * 0.1) * GlowColor * Opacity;
 }
 
 float4 DrawIcon(float4 Position : SV_POSITION, float4 Color : COLOR0, float2 TexCoords : TEXCOORD0) : COLOR0 {
-    return tex2D(s0, TexCoords) * Color;
+    return tex2D(s0, TexCoords) * Color * Opacity;
 }
 
 float4 DrawSilhouette(float4 Position : SV_POSITION, float4 Color : COLOR0, float2 TexCoords : TEXCOORD0) : COLOR0 {
-	return tex2D(s0, TexCoords) * float4(0, 0, 0, 1);
+	return tex2D(s0, TexCoords) * float4(0, 0, 0, 1) * Opacity;
 }
 
 technique

--- a/Blish HUD/Content/effects/menuitem.fx
+++ b/Blish HUD/Content/effects/menuitem.fx
@@ -8,6 +8,7 @@
 #endif
 
 float Roller;
+float Opacity = 1.0f;
 
 sampler s0 = sampler_state
 {
@@ -44,7 +45,7 @@ float4 PixelShaderFunction(float4 Position : SV_POSITION, float4 Color : COLOR0,
         return control_clr;
     }
 
-    return overlay_clr;
+    return overlay_clr * Opacity;
 }
 
 technique

--- a/Blish HUD/Content/effects/menuitem2.fx
+++ b/Blish HUD/Content/effects/menuitem2.fx
@@ -10,6 +10,8 @@
 float Roller;
 float VerticalDraw;
 
+float Opacity = 1.0f;
+
 sampler s0 = sampler_state
 {
     AddressU = Clamp;
@@ -51,12 +53,12 @@ float4 PSScroll(float4 Position : SV_POSITION, float4 Color : COLOR0, float2 Tex
         return float4(0, 0, 0, 0);
     }
 
-    return overlay_clr;
+    return overlay_clr * Opacity;
 }
 
 float4 PSControl(float4 Position : SV_POSITION, float4 Color : COLOR0, float2 TexCoords : TEXCOORD0) : COLOR0
 {
-    return tex2D(s0, TexCoords) * Color;
+    return tex2D(s0, TexCoords) * Color * Opacity;
 }
 
 

--- a/Blish HUD/Content/effects/silhouette.fx
+++ b/Blish HUD/Content/effects/silhouette.fx
@@ -10,6 +10,8 @@
 float  TextureWidth;
 float4 GlowColor;
 
+float Opacity = 1.0f;
+
 sampler s0 = sampler_state {
     AddressU = Clamp;
     AddressV = Clamp;
@@ -33,11 +35,11 @@ float4 DrawGlow(float4 Position : SV_POSITION, float4 Color : COLOR0, float2 Tex
     clr += tex2D(s0, float2(TexCoords.x        , TexCoords.y - Pixel - Pixel));
     clr += tex2D(s0, float2(TexCoords.x - Pixel, TexCoords.y - Pixel));
     
-    return float4(clr.rgb, clr.a * 0.1) * GlowColor;
+    return float4(clr.rgb, clr.a * 0.1) * GlowColor * Opacity;
 }
 
 float4 DrawSilhouette(float4 Position : SV_POSITION, float4 Color : COLOR0, float2 TexCoords : TEXCOORD0) : COLOR0 {
-    return tex2D(s0, TexCoords) * float4(0, 0, 0, 1);
+    return tex2D(s0, TexCoords) * float4(0, 0, 0, 1) * Opacity;
 }
 
 technique

--- a/Blish HUD/Controls/Effects/ScrollingHighlightEffect.cs
+++ b/Blish HUD/Controls/Effects/ScrollingHighlightEffect.cs
@@ -13,6 +13,7 @@ namespace Blish_HUD.Controls.Effects {
         private const string SPARAM_MASK                = "Mask";
         private const string SPARAM_OVERLAY             = "Overlay";
         private const string SPARAM_ROLLER              = "Roller";
+        private const string SPARAM_OPACITY             = "Opacity";
         private const float  DEFAULT_ANIMATION_DURATION = 0.5f;
 
         #region Static Persistant Effect
@@ -76,6 +77,7 @@ namespace Blish_HUD.Controls.Effects {
 
             _scrollEffect.Parameters[SPARAM_MASK].SetValue(GameService.Content.GetTexture("156072"));
             _scrollEffect.Parameters[SPARAM_OVERLAY].SetValue(GameService.Content.GetTexture("156071"));
+            _scrollEffect.Parameters[SPARAM_OPACITY].SetValue(assignedControl.Opacity);
 
             assignedControl.MouseEntered += AssignedControlOnMouseEntered;
             assignedControl.MouseLeft    += AssignedControlOnMouseLeft;
@@ -93,6 +95,8 @@ namespace Blish_HUD.Controls.Effects {
 
         private void AssignedControlOnMouseEntered(object sender, MouseEventArgs e) {
             if (!_enabled || _forceActive) return;
+
+            _scrollEffect.Parameters[SPARAM_OPACITY].SetValue(this.AssignedControl.Opacity);
 
             this.ScrollRoller = 0f;
 

--- a/Blish HUD/Controls/GlowButton.cs
+++ b/Blish HUD/Controls/GlowButton.cs
@@ -72,6 +72,7 @@ namespace Blish_HUD.Controls {
             _glowEffect = _glowEffect ?? BlishHud.ActiveContentManager.Load<Effect>(@"effects\glow");
             _glowEffect.Parameters["TextureWidth"].SetValue((float)this.Width);
             _glowEffect.Parameters["GlowColor"].SetValue(_glowColor.ToVector4());
+            _glowEffect.Parameters["Opacity"].SetValue(this.Opacity);
 
             return _glowEffect;
         }


### PR DESCRIPTION
Adds an `Opacity` parameter to effects: `glow.fx`, `silhouette.fx`, `menuitem.fx`, `menuitem2.fx`. 

Additionally, ScrollHighlightEffect now uses the assigned control's opacity, and GlowButton's effect now also uses the GlowButton's opacity.

Effects will by default be opaque. But can be changed by setting the `Opacity` parameter.

Closes #24