### PR TITLE
Adds post processing support to trails

### DIFF
--- a/Blish HUD/GameServices/Pathing/Entities/ScrollingTrail.cs
+++ b/Blish HUD/GameServices/Pathing/Entities/ScrollingTrail.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Blish_HUD.Pathing.Trails;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -97,6 +98,16 @@ namespace Blish_HUD.Pathing.Entities {
             }
         }
 
+        private List<Func<List<Vector3>, List<Vector3>>> _postProcessFunctions;
+        public List<Func<List<Vector3>, List<Vector3>>> PostProcessFunctions {
+            get => _postProcessFunctions;
+            set {
+                if (SetProperty(ref _postProcessFunctions, value)) {
+                    _sections.ForEach(s => s.PostProcessFunctions = value);
+                }
+            }
+        }
+
         private readonly List<ScrollingTrailSection> _sections;
 
         public ScrollingTrail(List<List<Vector3>> trailSections) {
@@ -118,14 +129,15 @@ namespace Blish_HUD.Pathing.Entities {
         }
 
         public void AddSection(ScrollingTrailSection newSection) {
-            newSection.AnimationSpeed   = _animationSpeed;
-            newSection.FadeFar          = _fadeFar;
-            newSection.FadeNear         = _fadeNear;
-            newSection.FadeCenter       = _fadeCenter;
-            newSection.PlayerFadeRadius = _playerFadeRadius;
-            newSection.Scale            = _scale;
-            newSection.TrailTexture     = _trailTexture;
-            newSection.Opacity          = _opacity;
+            newSection.AnimationSpeed       = _animationSpeed;
+            newSection.FadeFar              = _fadeFar;
+            newSection.FadeNear             = _fadeNear;
+            newSection.FadeCenter           = _fadeCenter;
+            newSection.PlayerFadeRadius     = _playerFadeRadius;
+            newSection.Scale                = _scale;
+            newSection.TrailTexture         = _trailTexture;
+            newSection.Opacity              = _opacity;
+            newSection.PostProcessFunctions = _postProcessFunctions;
 
             _sections.Add(newSection);
         }

--- a/Blish HUD/GameServices/Pathing/Entities/ScrollingTrail.cs
+++ b/Blish HUD/GameServices/Pathing/Entities/ScrollingTrail.cs
@@ -143,7 +143,7 @@ namespace Blish_HUD.Pathing.Entities {
         }
 
         public void AddSection(List<Vector3> newSectionPoints) {
-            AddSection(new ScrollingTrailSection(newSectionPoints));
+            AddSection(new ScrollingTrailSection(newSectionPoints) { PostProcessFunctions = _postProcessFunctions });
         }
 
         public override void Update(GameTime gameTime) {

--- a/Blish HUD/GameServices/Pathing/Entities/Trail.cs
+++ b/Blish HUD/GameServices/Pathing/Entities/Trail.cs
@@ -47,6 +47,8 @@ namespace Blish_HUD.Pathing.Entities {
             InitTrailPoints();
         }
 
+        protected virtual void PostProcess() { }
+
         protected virtual void InitTrailPoints() {
             _renderEffect ??= StandardEffect;
             _renderEffect.VertexColorEnabled = true;

--- a/Blish HUD/GameServices/Pathing/Entities/Trail.cs
+++ b/Blish HUD/GameServices/Pathing/Entities/Trail.cs
@@ -47,7 +47,7 @@ namespace Blish_HUD.Pathing.Entities {
             InitTrailPoints();
         }
 
-        protected virtual void PostProcess() { }
+        protected virtual List<Vector3> PostProcess() { return new List<Vector3>(); }
 
         protected virtual void InitTrailPoints() {
             _renderEffect ??= StandardEffect;

--- a/Blish HUD/_Extensions/Vector3Extensions.cs
+++ b/Blish HUD/_Extensions/Vector3Extensions.cs
@@ -18,6 +18,31 @@ namespace Blish_HUD {
             return $"X: {vector.X:0,0} Y: {vector.Y:0,0} Z: {vector.Z:0,0}";
         }
 
+        public static List<Vector3> SetResolution(this List<Vector3> points, float pointResolution) {
+            List<Vector3> tempPoints = new List<Vector3>();
+     
+            var lstPoint = points[0];
+
+            for (int i = 0; i < points.Count; i++) {
+                var dist = Vector3.Distance(lstPoint, points[i]);
+
+                var s = dist / pointResolution;
+                var inc = 1 / s;
+
+                for (float v = inc; v < s - inc; v += inc) {
+                    var nPoint = Vector3.Lerp(lstPoint, points[i], v / s);
+
+                    tempPoints.Add(nPoint);
+                }
+
+                tempPoints.Add(points[i]);
+
+                lstPoint = points[i];
+            }
+
+            return tempPoints;
+        }
+
         /// <summary>
         /// Creates a list of points sampled semi-equidistant along the Cubic-Hermite interpolated curve from a list of points.
         /// </summary>


### PR DESCRIPTION
You can now set the post processing functions to be used when initialising the trail, by setting the `PostProcessFunctions` property of `ScrollingTrail` and `ScrollingTrailSection`.

Example usage:
```cs
this.ManagedEntity.PostProcessFunctions = new List<Func<List<Vector3>, List<Vector3>>>() { x => x.SetResolution(30f) };
```

Also moved `SetTrailResolution` to `Vector3Extensions` and renamed it to `SetResolution`. 