### PR TITLE
Remove old AnimationService and fix wrap on DetailsButton

### DIFF
--- a/Blish HUD/Controls/DetailsButton.cs
+++ b/Blish HUD/Controls/DetailsButton.cs
@@ -357,7 +357,7 @@ namespace Blish_HUD.Controls {
                 }
 
                 if (_showFillFraction)
-                    spriteBatch.DrawStringOnCtrl(this, $"{_currentFill}/{_maxFill}", Content.DefaultFont14, new Rectangle(0, 0, iconSize, (int)(iconSize * 0.99f)), Color.White, true, true, 1, HorizontalAlignment.Center, VerticalAlignment.Bottom);
+                    spriteBatch.DrawStringOnCtrl(this, $"{_currentFill}/{_maxFill}", Content.DefaultFont14, new Rectangle(0, 0, iconSize, (int)(iconSize * 0.99f)), Color.White, false, true, 1, HorizontalAlignment.Center, VerticalAlignment.Bottom);
             } else if (_icon != null) {
                 // Draw icon without any fill effects
                 spriteBatch.DrawOnCtrl(
@@ -371,7 +371,7 @@ namespace Blish_HUD.Controls {
             }
 
             if (!_showFillFraction || !(_maxFill > 0 && _showVignette)) {
-                spriteBatch.DrawStringOnCtrl(this, _iconDetails, Content.DefaultFont14, new Rectangle(0, 0, iconSize, (int)(iconSize * 0.99f)), Color.White, true, true, 1, HorizontalAlignment.Center, VerticalAlignment.Bottom);
+                spriteBatch.DrawStringOnCtrl(this, _iconDetails, Content.DefaultFont14, new Rectangle(0, 0, iconSize, (int)(iconSize * 0.99f)), Color.White, false, true, 1, HorizontalAlignment.Center, VerticalAlignment.Bottom);
             }
 
             // Draw icon vignette (draw with or without the icon to keep a consistent look)

--- a/Blish HUD/Controls/StandardButton.cs
+++ b/Blish HUD/Controls/StandardButton.cs
@@ -1,4 +1,4 @@
-﻿using Blish_HUD;
+﻿using System.ComponentModel;
 using Blish_HUD.Content;
 using Blish_HUD.Input;
 using Glide;
@@ -65,6 +65,10 @@ namespace Blish_HUD.Controls {
             return CaptureType.Mouse;
         }
 
+        /// <summary>
+        /// Do not directly manipulate this property.  It is only public because the animation library requires it to be public.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public int AnimationState { get; set; } = 0;
 
         private Tween _animIn;

--- a/Blish HUD/GameServices/AnimationService.cs
+++ b/Blish HUD/GameServices/AnimationService.cs
@@ -4,170 +4,22 @@ using System.Linq;
 using Microsoft.Xna.Framework;
 
 namespace Blish_HUD {
-
-    public class EaseAnimation : IDisposable {
-
-        public event EventHandler<EventArgs> AnimationCompleted;
-
-        private AnimationService.EasingFunctionDelegate AnimationFunction;
-
-        private double StartValue;
-        private double ChangeInValue;
-        private double Duration;
-
-        private double StartTime;
-
-        public bool Active { get; private set; } = false;
-
-        public double CurrentValue { get; private set; }
-        public int CurrentValueInt { get { return (int)Math.Round(this.CurrentValue); } }
-
-        public bool Done { get; private set; } = false;
-
-        private bool Repeat = false;
-
-        public void Start(bool repeat = false) {
-            Repeat = repeat;
-            StartTime = DateTime.Now.TimeOfDay.TotalMilliseconds;
-            this.CurrentValue = StartValue;
-            this.Done = false;
-            this.Active = true;
-        }
-
-        public void Stop() {
-            this.Active = false;
-        }
-
-        public void Reverse() {
-            double tempStartVal = StartValue;
-            Duration = Duration * this.CurrentValue / ChangeInValue;
-            StartValue = this.CurrentValue;
-            ChangeInValue = -this.CurrentValue;
-
-            Start();
-        }
-
-        public EaseAnimation(AnimationService.EasingFunctionDelegate animFunc, double startValue, double changeInValue, double duration) {
-            StartTime = DateTime.Now.TimeOfDay.TotalMilliseconds;
-
-            this.CurrentValue = startValue;
-            AnimationFunction = animFunc;
-            StartValue = startValue;
-            ChangeInValue = changeInValue;
-            Duration = duration;
-        }
-
-        public void Update(GameTime gameTime) {
-            // Ensure everything is able to get the last value from the tween before it stops updating
-            if (this.Done) this.Active = false;
-
-            double currentTime = DateTime.Now.TimeOfDay.TotalMilliseconds - StartTime;
-
-            if (currentTime > Duration) {
-                currentTime = Duration;
-                this.Done = true;
-
-                this.AnimationCompleted?.Invoke(this, null);
-            }
-
-            this.CurrentValue = AnimationFunction.Invoke(currentTime, StartValue, ChangeInValue, Duration);
-
-            if (this.Done && Repeat) Start(Repeat);
-        }
-
-        public void Dispose() {
-            GameService.Animation.RemoveAnim(this);
-        }
-    }
-
     public class AnimationService:GameService {
 
-        public enum EasingMethod {
-            Linear,
-            EaseInQuad,
-            EaseOutQuad,
-            EaseInOutQuad,
-            EaseInCubic,
-            EaseOutCubic,
-            EaseInOutCubic,
-            EaseInQuart,
-            EaseOutQuart,
-            EaseInOutQuart,
-            EaseInQuint,
-            EaseOutQuint,
-            EaseInOutQuint,
-            EaseInSine,
-            EaseOutSine,
-            EaseInOutSine,
-            EaseInExpo,
-            EaseOutExpo,
-            EaseInOutExpo,
-            EaseInCirc,
-            EaseOutCirc,
-            EaseInOutCirc
-        }
-
-        public delegate double EasingFunctionDelegate(double currentTime, double startValue, double changeInValue, double duration);
-
-        private Dictionary<EasingMethod, EasingFunctionDelegate> EaseFuncs;
-
-        private List<EaseAnimation> CurrentAnimations;
-
-        private Glide.Tweener _tweener;
-        public Glide.Tweener Tweener => _tweener;
+        public Glide.Tweener Tweener { get; private set; }
 
         protected override void Initialize() {
-            CurrentAnimations = new List<EaseAnimation>();
-            EaseFuncs = new Dictionary<EasingMethod, EasingFunctionDelegate>();
+            Glide.Tween.TweenerImpl.SetLerper<Library.Glide.CustomLerpers.PointLerper>(typeof(Point));
 
-            Glide.Tweener.SetLerper<Library.Glide.CustomLerpers.PointLerper>(typeof(Point));
-
-            _tweener = new Glide.Tweener();
-
-            EaseFuncs.Add(EasingMethod.Linear, CalcLinear);
-            EaseFuncs.Add(EasingMethod.EaseInExpo, CalcExponentialEasingIn);
-            EaseFuncs.Add(EasingMethod.EaseInOutQuad, CalcQuadraticEasingInOut);
+            this.Tweener = new Glide.Tweener();
         }
 
-        public EaseAnimation Tween(double startValue, double changeInValue, double duration, EasingMethod method) {
-            var nanim = new EaseAnimation(EaseFuncs[method], startValue, changeInValue, duration);
-            CurrentAnimations.Add(nanim);
-            return nanim;
-        }
+        protected override void Load() { /* NOOP */ }
 
-        public void RemoveAnim(EaseAnimation anim) {
-            CurrentAnimations.Remove(anim);
-        }
+        protected override void Unload() { /* NOOP */ }
 
         protected override void Update(GameTime gameTime) {
-            CurrentAnimations.Where(a => a.Active).ToList().ForEach(a => a.Update(gameTime));
-
             this.Tweener.Update((float)gameTime.ElapsedGameTime.TotalSeconds);
-        }
-
-        // Easing functions:
-
-        private double CalcLinear(double currentTime, double startValue, double changeInValue, double duration) {
-            return changeInValue * currentTime / duration + startValue;
-        }
-
-        private double CalcExponentialEasingIn(double currentTime, double startValue, double changeInValue, double duration) {
-            return changeInValue * Math.Pow(2, 10 * (currentTime / duration - 1)) + startValue;
-        }
-
-        private double CalcQuadraticEasingInOut(double currentTime, double startValue, double changeInValue, double duration) {
-            currentTime /= duration / 2;
-            if (currentTime < 1) return changeInValue / 2 * currentTime * currentTime + startValue;
-            currentTime--;
-            return -changeInValue / 2 * (currentTime * (currentTime - 2) - 1) + startValue;
-        }
-
-        protected override void Load() {
-            // TODO: Set up animation service
-        }
-
-        protected override void Unload() {
-            // TODO: Clean up animation service
         }
     }
 }


### PR DESCRIPTION
Fully removes the old AnimationService (allowing us to close #146).  Also disables wordwrap on the DetailsButton details section / fill ratio which would cause a crash.

Technically a breaking change (removed members on AnimationService), but these should have not been implemented by anything other than the `StandardButton` control (which is swapped to using the proper implementation in this PR).