### PR TITLE
Use GitVersion action instead of a custom PowerShell script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,36 +13,40 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - run: git fetch --prune --unshallow
-      - uses: microsoft/setup-msbuild@v1.0.0
+        with:
+          fetch-depth: 0
+      - uses: microsoft/setup-msbuild@v1.0.2
 
-      - name: Patch nightly version
+      # GitVersion action doesn't support /ensureassemblyinfo, see https://github.com/GitTools/actions/issues/220
+      # So we need to create a new file to let GitVersion populate it
+      - name: Create assembly info file for GitVersion
         shell: powershell
         run: |
-          $version = GitVersion /output json /updateassemblyinfo "Blish HUD/Properties/AssemblyVersionInfo.cs" /ensureassemblyinfo
-          Write-Output $version
-          $version = $version | ConvertFrom-Json
-          $nuget = $version.SemVer
-          Write-Output "Assembly version: $($version.AssemblySemVer)"
-          Write-Output "Assembly file version: $($version.AssemblySemFileVer)"
-          Write-Output "Informational version: $($version.InformationalVersion)"
-          Write-Output "NuGet version: $nuget"
-          echo "::set-env name=VERSION::$nuget"
+          set-Content -Path 'Blish HUD/Properties/AssemblyVersionInfo.cs' -Value 'using System.Reflection;'
+      - uses: gittools/actions/gitversion/setup@v0.9.6
+        with:
+          versionSpec: '5.x'
+
+      - uses: gittools/actions/gitversion/execute@v0.9.6
+        id: gitversion
+        with:
+          updateAssemblyInfo: true
+          updateAssemblyInfoFilename: Blish HUD/Properties/AssemblyVersionInfo.cs
 
       - name: Run msbuild restore
         run: msbuild -t:restore
       - name: Run msbuild
-        run: msbuild -p:Configuration=Release -p:VERSIONED_BUILD=$env:VERSION
+        run: msbuild -p:Configuration=Release -p:VERSIONED_BUILD=${{ steps.gitversion.outputs.semVer }}
       - name: Upload build artifact
         uses: actions/upload-artifact@v2
         with:
-          name: Blish HUD ${{ env.VERSION }}
+          name: Blish HUD ${{ steps.gitversion.outputs.semVer }}
           path: Blish HUD/bin/x64/Release/net472
 
       - name: Run dotnet pack
-        run: dotnet pack "Blish HUD" -c Release -p:VERSIONED_BUILD=$env:VERSION
+        run: dotnet pack "Blish HUD" -c Release -p:VERSIONED_BUILD=${{ steps.gitversion.outputs.semVer }}
       - name: Upload NuGet package artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: Blish HUD ${{ env.VERSION }} NuGet packages
-          path: Blish HUD/bin/Release/BlishHUD.${{ env.VERSION }}.*nupkg
+          name: Blish HUD ${{ steps.gitversion.outputs.semVer }} NuGet packages
+          path: Blish HUD/bin/Release/BlishHUD.${{ steps.gitversion.outputs.semVer }}.*nupkg

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,28 +8,32 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - run: git fetch --prune --unshallow
-      - uses: microsoft/setup-msbuild@v1.0.0
+        with:
+          fetch-depth: 0
+      - uses: microsoft/setup-msbuild@v1.0.2
 
-      - name: Patch PR build version
+      # GitVersion action doesn't support /ensureassemblyinfo, see https://github.com/GitTools/actions/issues/220
+      # So we need to create a new file to let GitVersion populate it
+      - name: Create assembly info file for GitVersion
         shell: powershell
         run: |
-          $version = GitVersion /output json /updateassemblyinfo "Blish HUD/Properties/AssemblyVersionInfo.cs" /ensureassemblyinfo
-          Write-Output $version
-          $version = $version | ConvertFrom-Json
-          $nuget = $version.SemVer
-          Write-Output "Assembly version: $($version.AssemblySemVer)"
-          Write-Output "Assembly file version: $($version.AssemblySemFileVer)"
-          Write-Output "Informational version: $($version.InformationalVersion)"
-          Write-Output "NuGet version: $nuget"
-          echo "::set-env name=VERSION::$nuget"
+          set-Content -Path 'Blish HUD/Properties/AssemblyVersionInfo.cs' -Value 'using System.Reflection;'
+      - uses: gittools/actions/gitversion/setup@v0.9.6
+        with:
+          versionSpec: '5.x'
+
+      - uses: gittools/actions/gitversion/execute@v0.9.6
+        id: gitversion
+        with:
+          updateAssemblyInfo: true
+          updateAssemblyInfoFilename: Blish HUD/Properties/AssemblyVersionInfo.cs
 
       - name: Run msbuild restore
         run: msbuild -t:restore
       - name: Run msbuild
-        run: msbuild -p:Configuration=Release -p:VERSIONED_BUILD=$env:VERSION
+        run: msbuild -p:Configuration=Release -p:VERSIONED_BUILD=${{ steps.gitversion.outputs.semVer }}
       - name: Upload build artifact
         uses: actions/upload-artifact@v2
         with:
-          name: Blish HUD.${{ env.VERSION }}
+          name: Blish HUD.${{ steps.gitversion.outputs.semVer }}
           path: Blish HUD/bin/x64/Release/net472

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,35 +11,40 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - run: git fetch --prune --unshallow
-      - uses: microsoft/setup-msbuild@v1.0.0
+        with:
+          fetch-depth: 0
+      - uses: microsoft/setup-msbuild@v1.0.2
 
-      - name: Patch nightly version
+      # GitVersion action doesn't support /ensureassemblyinfo, see https://github.com/GitTools/actions/issues/220
+      # So we need to create a new file to let GitVersion populate it
+      - name: Create assembly info file for GitVersion
         shell: powershell
         run: |
-          $version = GitVersion /output json /updateassemblyinfo "Blish HUD/Properties/AssemblyVersionInfo.cs" /ensureassemblyinfo
-          Write-Output $version
-          $version = $version | ConvertFrom-Json
-          $nuget = $version.SemVer
-          Write-Output "Assembly version: $($version.AssemblySemVer)"
-          Write-Output "Assembly file version: $($version.AssemblySemFileVer)"
-          Write-Output "Informational version: $($version.InformationalVersion)"
-          Write-Output "NuGet version: $nuget"
-          echo "::set-env name=VERSION::$nuget"
+          set-Content -Path 'Blish HUD/Properties/AssemblyVersionInfo.cs' -Value 'using System.Reflection;'
+      - uses: gittools/actions/gitversion/setup@v0.9.6
+        with:
+          versionSpec: '5.x'
+
+      - uses: gittools/actions/gitversion/execute@v0.9.6
+        id: gitversion
+        with:
+          updateAssemblyInfo: true
+          updateAssemblyInfoFilename: Blish HUD/Properties/AssemblyVersionInfo.cs
+
       - name: Run msbuild restore
         run: msbuild -t:restore
       - name: Run msbuild
-        run: msbuild -p:Configuration=Release -p:VERSIONED_BUILD=$env:VERSION
+        run: msbuild -p:Configuration=Release -p:VERSIONED_BUILD=${{ steps.gitversion.outputs.semVer }}
       - name: Upload build artifact
         uses: actions/upload-artifact@v2
         with:
-          name: Blish HUD ${{ env.VERSION }}
+          name: Blish HUD ${{ steps.gitversion.outputs.semVer }}
           path: Blish HUD/bin/x64/Release/net472
 
       - name: Run dotnet pack
-        run: dotnet pack "Blish HUD" -c Release -p:VERSIONED_BUILD=$env:VERSION
+        run: dotnet pack "Blish HUD" -c Release -p:VERSIONED_BUILD=${{ steps.gitversion.outputs.semVer }}
       - name: Upload NuGet package artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: Blish HUD ${{ env.VERSION }} NuGet packages
-          path: Blish HUD/bin/Release/BlishHUD.${{ env.VERSION }}.*nupkg
+          name: Blish HUD ${{ steps.gitversion.outputs.semVer }} NuGet packages
+          path: Blish HUD/bin/Release/BlishHUD.${{ steps.gitversion.outputs.semVer }}.*nupkg


### PR DESCRIPTION
Because [GitHub started deprecating set-env in actions](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/), let's try out using the dedicated GitVersion action instead of using a custom PowerShell script to version Blish HUD.

This cleans up the workflow yaml files a bit and makes it more readable.

Update: Because msbuild also used add-path, I also had to update this action to v1.0.2 in order to fix that too.