### PR TITLE
Ensure we can resolve dependencies needed when a module is initially loaded

### DIFF
--- a/Blish HUD/GameServices/Modules/ModuleManager.cs
+++ b/Blish HUD/GameServices/Modules/ModuleManager.cs
@@ -21,7 +21,8 @@ namespace Blish_HUD.Modules {
 
         private Assembly _moduleAssembly;
 
-        private bool _enabled = false;
+        private bool _enabled              = false;
+        private bool _forceAllowDependency = false;
 
         public bool Enabled {
             get => _enabled;
@@ -124,7 +125,7 @@ namespace Blish_HUD.Modules {
         }
 
         private Assembly CurrentDomainOnAssemblyResolve(object sender, ResolveEventArgs args) {
-            if (_enabled) {
+            if (_enabled || _forceAllowDependency) {
                 var assemblyDetails = new AssemblyName(args.Name);
 
                 string assemblyPath = $"{assemblyDetails.Name}.dll";
@@ -185,6 +186,8 @@ namespace Blish_HUD.Modules {
 
             container.ComposeExportedValue("ModuleParameters", parameters);
 
+            _forceAllowDependency = true;
+
             try {
                 container.SatisfyImportsOnce(this);
             } catch (CompositionException ex) {
@@ -192,6 +195,8 @@ namespace Blish_HUD.Modules {
             } catch (FileNotFoundException ex) {
                 Logger.Warn(ex, "Module {module} failed to load a dependency.", _manifest.GetDetailedName());
             }
+
+            _forceAllowDependency = false;
         }
 
     }


### PR DESCRIPTION
Currently the assemblies within a module are not loadable until the main assembly has completed loading and is considered enabled.  This poses a problem for modules that depend on another assembly immediately for the main assembly to even load.  This change introduces an override for when the initial import is performed so that any dependencies can be allowed to load.