### PR TITLE
Ignore mutex when restarting Blish HUD.

### DIFF
--- a/Blish HUD/ApplicationSettings.cs
+++ b/Blish HUD/ApplicationSettings.cs
@@ -34,28 +34,59 @@ namespace Blish_HUD {
             this.DebugEnabled = true;
         }
 
+        /*
+         * d, debug     - Launches Blish HUD in debug mode.
+         * f, maxfps    - The frame rate Blish HUD should target when rendering.
+         * F, unlockfps - Unlocks the frame limit allowing Blish HUD to render as fast as possible.  This will cause higher CPU and GPU utilization.
+         * m, mumble    - The MumbleLink map name to be used.
+         * M, module    - The path to a module (*.bhm) that will be force loaded when Blish HUD launches.
+         * p, process   - The name of the process to overlay (without '.exe').
+         * P, pid       - The PID of the process to overlay.
+         * r, ref       - The path to the ref.dat file.
+         * s, settings  - The path where Blish HUD will save settings and other files.
+         * w, window    - The name of the window to overlay.
+         *
+         * restartskipmutex - Forces Blish HUD to allow multiple instances.  Used internally to prevent race condition issues when Blish HUD is restarted.
+         */
+
         #region Game Integration
 
+        public const string OPTION_PROCESSID = "pid";
+        /// <summary>
+        /// The PID of the process to overlay.
+        /// </summary>
         [
-            OptionParameter("pid", 'P'),
+            OptionParameter(OPTION_PROCESSID, 'P'),
             Help("The PID of the process to overlay.")
         ]
         public int ProcessId { get; private set; } = 0;
 
+        public const string OPTION_PROCESSNAME = "process";
+        /// <summary>
+        /// The name of the process to overlay (without '.exe').
+        /// </summary>
         [
-            OptionParameter("process", 'p'),
+            OptionParameter(OPTION_PROCESSNAME, 'p'),
             Help("The name of the process to overlay (without '.exe').")
         ]
         public string ProcessName { get; private set; }
 
+        public const string OPTION_WINDOWNAME = "window";
+        /// <summary>
+        /// The name of the window to overlay.
+        /// </summary>
         [
-            OptionParameter("window", 'w'),
+            OptionParameter(OPTION_WINDOWNAME, 'w'),
             Help("The name of the window to overlay.")
         ]
         public string WindowName { get; private set; }
 
+        public const string MUMBLEMAPNAME = "mumble";
+        /// <summary>
+        /// The MumbleLink map name to be used.
+        /// </summary>
         [
-            OptionParameter("mumble", 'm'),
+            OptionParameter(MUMBLEMAPNAME, 'm'),
             Help("The MumbleLink map name to be used.")
         ]
         public string MumbleMapName { get; private set; }
@@ -64,27 +95,43 @@ namespace Blish_HUD {
 
         #region Utility
 
+        public const string OPTION_USERSETTINGSPATH = "settings";
+        /// <summary>
+        /// The path where Blish HUD will save settings and other files.
+        /// </summary>
         [
-            OptionParameter("settings", 's'),
+            OptionParameter(OPTION_USERSETTINGSPATH, 's'),
             Help("The path where Blish HUD will save settings and other files.")
         ]
         public string UserSettingsPath { get; private set; }
 
+        public const string OPTION_REFPATH = "ref";
+        /// <summary>
+        /// The path to the ref.dat file.
+        /// </summary>
         [
             OptionParameter("ref", 'r'),
             Help("The path to the ref.dat file.")
         ]
         public string RefPath { get; private set; }
 
+        public const string OPTION_TARGETFRAMERATE = "maxfps";
+        /// <summary>
+        /// The frame rate Blish HUD should target when rendering.
+        /// </summary>
         [
-            OptionParameter("maxfps", 'f'),
+            OptionParameter(OPTION_TARGETFRAMERATE, 'f'),
             Help("The frame rate Blish HUD should target when rendering.")
         ]
         public double TargetFramerate { get; private set; } = 60d;
 
+        public const string OPTION_UNLOCKFPS = "unlockfps";
+        /// <summary>
+        /// Unlocks the frame limit allowing Blish HUD to render as fast as possible.  This will cause higher CPU and GPU utilization.
+        /// </summary>
         [
-            Option("unlockfps", 'F'),
-            Help("Unlocks the frame limit allowing Blish HUD to render as fast as possible.  This will cause high CPU utilization.")
+            Option(OPTION_UNLOCKFPS, 'F'),
+            Help("Unlocks the frame limit allowing Blish HUD to render as fast as possible.  This will cause higher CPU and GPU utilization.")
         ]
         public bool UnlockFps { get; private set; }
 
@@ -92,17 +139,39 @@ namespace Blish_HUD {
 
         #region Debug
 
+        public const string OPTION_DEBUGENABLED = "debug";
+        /// <summary>
+        /// Launches Blish HUD in debug mode.
+        /// </summary>
         [
-            Option("debug", 'd'),
+            Option(OPTION_DEBUGENABLED, 'd'),
             Help("Launches Blish HUD in debug mode.")
         ]
         public bool DebugEnabled { get; private set; }
 
+        public const string OPTION_DEBUGMODULEPATH = "module";
+        /// <summary>
+        /// The path to a module (*.bhm) that will be force loaded when Blish HUD launches.
+        /// </summary>
         [
-            OptionParameter("module", 'M'),
+            OptionParameter(OPTION_DEBUGMODULEPATH, 'M'),
             Help("The path to a module (*.bhm) that will be force loaded when Blish HUD launches.")
         ]
         public string DebugModulePath { get; private set; }
+
+        #endregion
+
+        #region Internal
+        
+        public const string OPTION_RESTARTSKIPMUTEX = "restartskipmutex";
+        /// <summary>
+        /// Forces Blish HUD to allow multiple instances.  Used internally to prevent race condition issues when Blish HUD is restarted.
+        /// </summary>
+        [
+            Option(OPTION_RESTARTSKIPMUTEX),
+            Help("Forces Blish HUD to allow multiple instances.  Used internally to prevent race condition issues when Blish HUD is restarted.")
+        ]
+        public bool RestartSkipMutex { get; private set; }
 
         #endregion
 

--- a/Blish HUD/GameServices/GraphicsService.cs
+++ b/Blish HUD/GameServices/GraphicsService.cs
@@ -95,7 +95,7 @@ namespace Blish_HUD {
         protected override void Initialize() {
             // If for some reason we lose the rendering device, just restart the application
             // Might do better error handling later on
-            ActiveBlishHud.GraphicsDevice.DeviceLost += delegate { System.Windows.Forms.Application.Restart(); };
+            ActiveBlishHud.GraphicsDevice.DeviceLost += delegate { GameService.Overlay.Restart(); };
 
             _uiScaleMultiplier = GetScaleRatio(UiSize.Normal);
             _uiScaleTransform  = Matrix.CreateScale(Graphics.UIScaleMultiplier);

--- a/Blish HUD/Program.cs
+++ b/Blish HUD/Program.cs
@@ -52,7 +52,7 @@ namespace Blish_HUD {
                                                            ? $"{APP_GUID}:{ApplicationSettings.Instance.MumbleMapName}"
                                                            : $"{APP_GUID}");
 
-                if (!_singleInstanceMutex?.WaitOne(TimeSpan.Zero, true) ?? false) {
+                if (!_singleInstanceMutex.WaitOne(TimeSpan.Zero, true)) {
                     Logger.Warn("Blish HUD is already running!");
                     return;
                 }
@@ -65,7 +65,7 @@ namespace Blish_HUD {
             }
 
             if (!ApplicationSettings.Instance.RestartSkipMutex) {
-                _singleInstanceMutex?.ReleaseMutex();
+                _singleInstanceMutex.ReleaseMutex();
             }
         }
 


### PR DESCRIPTION
Restarting Blish HUD now passes an additional launch arg which skips the mutex.  This fixes the intermittent issues with trying to restart Blish HUD that would cause the new instance to instantly close.