### PR TITLE
Fix audio crashes

### DIFF
--- a/Blish HUD/GameServices/GameIntegration/AudioIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/AudioIntegration.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Blish_HUD.Debug;
 using Blish_HUD.GameServices;
 using Blish_HUD.Settings;
 using CSCore.CoreAudioAPI;
-using Humanizer.DateTimeHumanizeStrategy;
 using Microsoft.Xna.Framework;
-using SharpDX.MediaFoundation;
 
 namespace Blish_HUD.GameIntegration {
     public sealed class AudioIntegration : ServiceModule<GameIntegrationService> {


### PR DESCRIPTION
Fixes a crash that can occur when Blish HUD is configured to use the default device and not the audio device used by Guild Wars 2.  The Audio device was never set to use the default device unless the setting change was detected.