### PR TITLE
re-add trail resolution

### DIFF
--- a/Blish HUD/GameServices/Pathing/Entities/ScrollingTrailSection.cs
+++ b/Blish HUD/GameServices/Pathing/Entities/ScrollingTrailSection.cs
@@ -84,7 +84,7 @@ namespace Blish_HUD.Pathing.Entities {
 
         public ScrollingTrailSection() : base(null) { /* NOOP */ }
 
-        public ScrollingTrailSection(List<Vector3> trailPoints) : base(trailPoints) { /* NOOP */ }
+        public ScrollingTrailSection(List<Vector3> trailPoints) : base(trailPoints.SetResolution(30f)) { /* NOOP */ }
 
 
         protected override List<Vector3> PostProcess() {

--- a/Blish HUD/_Extensions/Vector3Extensions.cs
+++ b/Blish HUD/_Extensions/Vector3Extensions.cs
@@ -21,6 +21,10 @@ namespace Blish_HUD {
         }
 
         public static List<Vector3> SetResolution(this List<Vector3> points, float pointResolution) {
+            if (!points.Any()) {
+                return new List<Vector3>(0);
+            }
+
             List<Vector3> tempPoints = new List<Vector3>();
      
             var lstPoint = points[0];


### PR DESCRIPTION
Fixes regression which occurred when the new post processing methods were added.  Since we'll be moving most of this functionality to the new pathing module, I've re-added the SetResolution alg manually for the v0.7.1 release.

REF: https://discord.com/channels/531175899588984842/534492173362528287/811893107884163073