### PR TITLE
Temp audio fix for 0.7.1

### DIFF
--- a/Blish HUD/Controls/Dropdown.cs
+++ b/Blish HUD/Controls/Dropdown.cs
@@ -277,7 +277,7 @@ namespace Blish_HUD.Controls {
             
             // Draw dropdown arrow
             spriteBatch.DrawOnCtrl(this,
-                                   this.MouseOver ? _textureArrowActive : _textureArrow,
+                                   (this.Enabled && this.MouseOver) ? _textureArrowActive : _textureArrow,
                                    new Rectangle(_size.X - _textureArrow.Width - 5,
                                                  _size.Y / 2                 - _textureArrow.Height / 2,
                                                  _textureArrow.Width,
@@ -290,7 +290,9 @@ namespace Blish_HUD.Controls {
                                          new Rectangle(5, 0,
                                                        _size.X - 10 - _textureArrow.Width,
                                                        _size.Y),
-                                         Color.FromNonPremultiplied(239, 240, 239, 255));
+                                         (this.Enabled
+                                              ? Color.FromNonPremultiplied(239, 240, 239, 255)
+                                              : Control.StandardColors.DisabledText));
         }
 
     }

--- a/Blish HUD/GameServices/ContentService.cs
+++ b/Blish HUD/GameServices/ContentService.cs
@@ -120,30 +120,46 @@ namespace Blish_HUD {
             _audioDataReader = zipArchiveReader.GetSubPath("audio");
         }
 
+        // Temporary failsafe until all audio bugs are resolved
+        private int _playRemainingAttempts = 3;
+
         public void PlaySoundEffectByName(string soundName) {
+            if (_playRemainingAttempts <= 0) {
+                // We keep failing to play sound effects - don't even bother
+                return;
+            }
+
             if (GameService.GameIntegration.Audio.AudioDevice == null) {
                 // No device is set yet or there isn't one to use
                 return;
             }
 
-            const string SOUND_EFFECT_FILE_EXTENSION = ".wav";
-            var filePath = soundName + SOUND_EFFECT_FILE_EXTENSION;
-            if (_audioDataReader.FileExists(filePath)) {
-                var soundEffect = _audioDataReader.GetFileStream(filePath);
-                var waveSource = new WaveFileReader(soundEffect);
-                
-                var soundOutput = new WasapiOut() { Device = GameService.GameIntegration.Audio.AudioDevice, };
-                soundOutput.Initialize(waveSource);
-                soundOutput.Volume = GameService.GameIntegration.Audio.Volume;
+            try {
+                const string SOUND_EFFECT_FILE_EXTENSION = ".wav";
+                var          filePath                    = soundName + SOUND_EFFECT_FILE_EXTENSION;
 
-                Task.Run(() => {
-                    soundOutput.Play();
-                    soundOutput.WaitForStopped();
+                if (_audioDataReader.FileExists(filePath)) {
+                    var soundEffect = _audioDataReader.GetFileStream(filePath);
+                    var waveSource  = new WaveFileReader(soundEffect);
 
-                    // This will dispose the sound effect stream and the wave source too
-                    soundOutput.Dispose();
-                });
+                    var soundOutput = new WasapiOut() {Device = GameService.GameIntegration.Audio.AudioDevice,};
+                    soundOutput.Initialize(waveSource);
+                    soundOutput.Volume = GameService.GameIntegration.Audio.Volume;
 
+                    Task.Run(() => {
+                                 soundOutput.Play();
+                                 soundOutput.WaitForStopped();
+
+                                 // This will dispose the sound effect stream and the wave source too
+                                 soundOutput.Dispose();
+                             });
+
+                }
+
+                _playRemainingAttempts = 3;
+            } catch (Exception ex) {
+                _playRemainingAttempts--;
+                Logger.Warn(ex, "Failed to play sound effect.");
             }
         }
 

--- a/Blish HUD/GameServices/ContentService.cs
+++ b/Blish HUD/GameServices/ContentService.cs
@@ -8,6 +8,7 @@ using Blish_HUD.Content;
 using CSCore;
 using CSCore.Codecs;
 using CSCore.Codecs.WAV;
+using CSCore.CoreAudioAPI;
 using CSCore.SoundOut;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
@@ -137,23 +138,9 @@ namespace Blish_HUD {
             try {
                 const string SOUND_EFFECT_FILE_EXTENSION = ".wav";
                 var          filePath                    = soundName + SOUND_EFFECT_FILE_EXTENSION;
-
+            
                 if (_audioDataReader.FileExists(filePath)) {
-                    var soundEffect = _audioDataReader.GetFileStream(filePath);
-                    var waveSource  = new WaveFileReader(soundEffect);
-
-                    var soundOutput = new WasapiOut() {Device = GameService.GameIntegration.Audio.AudioDevice,};
-                    soundOutput.Initialize(waveSource);
-                    soundOutput.Volume = GameService.GameIntegration.Audio.Volume;
-
-                    Task.Run(() => {
-                                 soundOutput.Play();
-                                 soundOutput.WaitForStopped();
-
-                                 // This will dispose the sound effect stream and the wave source too
-                                 soundOutput.Dispose();
-                             });
-
+                    SoundEffect.FromStream(_audioDataReader.GetFileStream(filePath)).Play(GameService.GameIntegration.Audio.Volume, 0, 0);
                 }
 
                 _playRemainingAttempts = 3;
@@ -161,7 +148,7 @@ namespace Blish_HUD {
                 _playRemainingAttempts--;
                 Logger.Warn(ex, "Failed to play sound effect.");
             }
-        }
+}
 
         private static string RefPath => ApplicationSettings.Instance.RefPath ?? REF_FILE;
 

--- a/Blish HUD/GameServices/GameIntegration/AudioIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/AudioIntegration.cs
@@ -58,7 +58,7 @@ namespace Blish_HUD.GameIntegration {
             _volumeSetting = audioSettings.DefineSetting(VOLUME_SETTINGS, MAX_VOLUME / 2, Strings.GameServices.OverlayService.Setting_Volume_DisplayName, Strings.GameServices.OverlayService.Setting_Volume_Description);
             _volumeSetting.SetRange(0.0f, MAX_VOLUME);
 
-            _deviceSetting = audioSettings.DefineSetting(DEVICE_SETTINGS, Devices.Gw2OutputDevice, Strings.GameServices.OverlayService.Setting_AudioDevice_DisplayName, Strings.GameServices.OverlayService.Setting_AudioDevice_Description);
+            _deviceSetting = audioSettings.DefineSetting(DEVICE_SETTINGS, Devices.Gw2OutputDevice, Strings.GameServices.OverlayService.Setting_AudioDevice_DisplayName, Strings.GameServices.OverlayService.Setting_AudioDevice_Description + " (This setting is temporarily disabled in this version)");
             // This setting is disabled (so we force it to show "default")
             // See https://github.com/blish-hud/Blish-HUD/issues/355#issuecomment-787713586
             _deviceSetting.Value = Devices.DefaultDevice;

--- a/Blish HUD/GameServices/GameIntegration/AudioIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/AudioIntegration.cs
@@ -33,7 +33,7 @@ namespace Blish_HUD.GameIntegration {
 
         private readonly List<(MMDevice AudioDevice, AudioMeterInformation MeterInformation)> _gw2AudioDevices = new List<(MMDevice AudioDevice, AudioMeterInformation MeterInformation)>();
 
-        private double _timeSinceCheck = 0;
+        private double _timeSinceCheck             = 0;
         private double _timeSinceAudioDeviceUpdate = 0;
 
         private float? _volume;
@@ -57,7 +57,13 @@ namespace Blish_HUD.GameIntegration {
             _useGameVolume = audioSettings.DefineSetting(USEGAMEVOLUME_SETTINGS, true, Strings.GameServices.OverlayService.Setting_UseGameVolume_DisplayName, Strings.GameServices.OverlayService.Setting_UseGameVolume_Description);
             _volumeSetting = audioSettings.DefineSetting(VOLUME_SETTINGS, MAX_VOLUME / 2, Strings.GameServices.OverlayService.Setting_Volume_DisplayName, Strings.GameServices.OverlayService.Setting_Volume_Description);
             _volumeSetting.SetRange(0.0f, MAX_VOLUME);
+
             _deviceSetting = audioSettings.DefineSetting(DEVICE_SETTINGS, Devices.Gw2OutputDevice, Strings.GameServices.OverlayService.Setting_AudioDevice_DisplayName, Strings.GameServices.OverlayService.Setting_AudioDevice_Description);
+            // This setting is disabled (so we force it to show "default")
+            // See https://github.com/blish-hud/Blish-HUD/issues/355#issuecomment-787713586
+            _deviceSetting.Value = Devices.DefaultDevice;
+            _deviceSetting.SetDisabled();
+
             _deviceEnumerator = new MMDeviceEnumerator();
 
             if (_deviceSetting.Value == Devices.DefaultDevice) {
@@ -71,9 +77,12 @@ namespace Blish_HUD.GameIntegration {
             UpdateActiveAudioDeviceManager();
 
             _deviceEnumerator.DefaultDeviceChanged += delegate { UpdateActiveAudioDeviceManager(); };
-            _service.Gw2Started += delegate { UpdateActiveAudioDeviceManager(); };
+            _service.Gw2Started                    += delegate { UpdateActiveAudioDeviceManager(); };
+
             _deviceSetting.SettingChanged += delegate {
-                if (_deviceSetting.Value == Devices.DefaultDevice) AudioDevice = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                if (_deviceSetting.Value == Devices.DefaultDevice) {
+                    this.AudioDevice = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                }
             };
         }
 

--- a/Blish HUD/GameServices/Settings/UI/Presenters/SettingPresenter.cs
+++ b/Blish HUD/GameServices/Settings/UI/Presenters/SettingPresenter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Blish_HUD.Graphics.UI;
 using Blish_HUD.Settings.UI.Views;
@@ -37,10 +38,12 @@ namespace Blish_HUD.Settings.UI.Presenters {
         }
 
         private void UpdateViewComplianceRequisite() {
-            var complianceRequisite = this.Model.GetComplianceRequisite();
+            IEnumerable<IComplianceRequisite> complianceRequisites = this.Model.GetComplianceRequisite();
 
-            if (complianceRequisite != null) {
-                this.View.SetComplianceRequisite(complianceRequisite);
+            foreach (var complianceRequisite in complianceRequisites) {
+                if (!this.View.HandleComplianceRequisite(complianceRequisite)) {
+                    this.View.HandleBaseComplianceRequisite(complianceRequisite);
+                }
             }
         }
 

--- a/Blish HUD/GameServices/Settings/UI/Views/BoolSettingView.cs
+++ b/Blish HUD/GameServices/Settings/UI/Views/BoolSettingView.cs
@@ -10,6 +10,18 @@ namespace Blish_HUD.Settings.UI.Views {
 
         public BoolSettingView(SettingEntry<bool> setting, int definedWidth = -1) : base(setting, definedWidth) { /* NOOP */ }
 
+        public override bool HandleComplianceRequisite(IComplianceRequisite complianceRequisite) {
+            switch (complianceRequisite) {
+                case SettingDisabledComplianceRequisite disabledRequisite:
+                    _boolCheckbox.Enabled = !disabledRequisite.Disabled;
+                    break;
+                default:
+                    return false;
+            }
+
+            return true;
+        }
+
         protected override void BuildSetting(Panel buildPanel) {
             _boolCheckbox = new Checkbox() {
                 Location = new Point(CONTROL_PADDING),

--- a/Blish HUD/GameServices/Settings/UI/Views/EnumSettingView[T].cs
+++ b/Blish HUD/GameServices/Settings/UI/Views/EnumSettingView[T].cs
@@ -47,14 +47,25 @@ namespace Blish_HUD.Settings.UI.Views {
             _enumDropdown.ValueChanged += EnumDropdownOnValueChanged;
         }
 
-        public override void SetComplianceRequisite(IComplianceRequisite complianceRequisite) {
-            if (complianceRequisite is EnumComplianceRequisite<TEnum> enumRequisite) {
-                IEnumerable<TEnum> toRemove = _enumValues.Except(enumRequisite.IncludedValues);
+        public override bool HandleComplianceRequisite(IComplianceRequisite complianceRequisite) {
+            switch (complianceRequisite) {
+                case EnumInclusionComplianceRequisite<TEnum> enumInclusionRequisite:
+                    IEnumerable<TEnum> toRemove = _enumValues.Except(enumInclusionRequisite.IncludedValues);
 
-                foreach (var value in toRemove) {
-                    _enumDropdown.Items.Remove(value.ToString());
-                }
+                    foreach (var value in toRemove) {
+                        _enumDropdown.Items.Remove(value.ToString());
+                    }
+
+                    break;
+                case SettingDisabledComplianceRequisite disabledRequisite:
+                    _displayNameLabel.Enabled = !disabledRequisite.Disabled;
+                    _enumDropdown.Enabled     = !disabledRequisite.Disabled;
+                    break;
+                default:
+                    return false;
             }
+
+            return true;
         }
 
         private void EnumDropdownOnValueChanged(object sender, ValueChangedEventArgs e) {

--- a/Blish HUD/GameServices/Settings/UI/Views/FloatSettingView.cs
+++ b/Blish HUD/GameServices/Settings/UI/Views/FloatSettingView.cs
@@ -11,11 +11,21 @@ namespace Blish_HUD.Settings.UI.Views {
             _valueTrackBar.SmallStep = true;
         }
 
-        public override void SetComplianceRequisite(IComplianceRequisite complianceRequisite) {
-            if (complianceRequisite is FloatComplianceRequisite floatRequisite) {
-                _valueTrackBar.MinValue = floatRequisite.MinValue;
-                _valueTrackBar.MaxValue = floatRequisite.MaxValue;
+        public override bool HandleComplianceRequisite(IComplianceRequisite complianceRequisite) {
+            switch (complianceRequisite) {
+                case FloatRangeRangeComplianceRequisite intRangeRequisite:
+                    _valueTrackBar.MinValue = intRangeRequisite.MinValue;
+                    _valueTrackBar.MaxValue = intRangeRequisite.MaxValue;
+                    break;
+                case SettingDisabledComplianceRequisite disabledRequisite:
+                    _displayNameLabel.Enabled = !disabledRequisite.Disabled;
+                    _valueTrackBar.Enabled    = !disabledRequisite.Disabled;
+                    break;
+                default:
+                    return false;
             }
+
+            return true;
         }
         
         protected override void HandleTrackBarChanged(object sender, ValueEventArgs<float> e) {

--- a/Blish HUD/GameServices/Settings/UI/Views/IntSettingView.cs
+++ b/Blish HUD/GameServices/Settings/UI/Views/IntSettingView.cs
@@ -1,16 +1,23 @@
-﻿using System;
-using Blish_HUD.Controls;
-
-namespace Blish_HUD.Settings.UI.Views {
+﻿namespace Blish_HUD.Settings.UI.Views {
     public class IntSettingView : NumericSettingView<int> {
 
         public IntSettingView(SettingEntry<int> setting, int definedWidth = -1) : base(setting, definedWidth) { /* NOOP */ }
         
-        public override void SetComplianceRequisite(IComplianceRequisite complianceRequisite) {
-            if (complianceRequisite is IntComplianceRequisite intRequisite) {
-                _valueTrackBar.MinValue = intRequisite.MinValue;
-                _valueTrackBar.MaxValue = intRequisite.MaxValue;
+        public override bool HandleComplianceRequisite(IComplianceRequisite complianceRequisite) {
+            switch (complianceRequisite) {
+                case IntRangeRangeComplianceRequisite intRangeRequisite:
+                    _valueTrackBar.MinValue = intRangeRequisite.MinValue;
+                    _valueTrackBar.MaxValue = intRangeRequisite.MaxValue;
+                    break;
+                case SettingDisabledComplianceRequisite disabledRequisite:
+                    _displayNameLabel.Enabled = !disabledRequisite.Disabled;
+                    _valueTrackBar.Enabled    = !disabledRequisite.Disabled;
+                    break;
+                default:
+                    return false;
             }
+
+            return true;
         }
 
         protected override void HandleTrackBarChanged(object sender, ValueEventArgs<float> e) {

--- a/Blish HUD/GameServices/Settings/UI/Views/KeybindingSettingView.cs
+++ b/Blish HUD/GameServices/Settings/UI/Views/KeybindingSettingView.cs
@@ -9,6 +9,18 @@ namespace Blish_HUD.Settings.UI.Views {
 
         public KeybindingSettingView(SettingEntry<KeyBinding> setting, int definedWidth = -1) : base(setting, definedWidth) { /* NOOP */ }
 
+        public override bool HandleComplianceRequisite(IComplianceRequisite complianceRequisite) {
+            switch (complianceRequisite) {
+                case SettingDisabledComplianceRequisite disabledRequisite:
+                    _keybindingAssigner.Enabled = !disabledRequisite.Disabled;
+                    break;
+                default:
+                    return false;
+            }
+
+            return true;
+        }
+
         protected override void BuildSetting(Panel buildPanel) {
             _keybindingAssigner = new KeybindingAssigner() {
                 Parent = buildPanel

--- a/Blish HUD/GameServices/Settings/UI/Views/SettingView[T].cs
+++ b/Blish HUD/GameServices/Settings/UI/Views/SettingView[T].cs
@@ -63,7 +63,13 @@ namespace Blish_HUD.Settings.UI.Views {
 
         protected abstract void BuildSetting(Panel buildPanel);
 
-        public virtual void SetComplianceRequisite(IComplianceRequisite complianceRequisite) { /* NOOP */ }
+        public virtual bool HandleComplianceRequisite(IComplianceRequisite complianceRequisite) {
+            return false;
+        }
+
+        public void HandleBaseComplianceRequisite(IComplianceRequisite complianceRequisite) {
+            /* Currently none - NOOP */
+        }
 
         private void Refresh() {
             RefreshDisplayName(_displayName);

--- a/Blish HUD/GameServices/Settings/UI/Views/StringSettingView.cs
+++ b/Blish HUD/GameServices/Settings/UI/Views/StringSettingView.cs
@@ -14,6 +14,19 @@ namespace Blish_HUD.Settings.UI.Views {
 
         public StringSettingView(SettingEntry<string> setting, int definedWidth = -1) : base(setting, definedWidth) { /* NOOP */ }
 
+        public override bool HandleComplianceRequisite(IComplianceRequisite complianceRequisite) {
+            switch (complianceRequisite) {
+                case SettingDisabledComplianceRequisite disabledRequisite:
+                    _displayNameLabel.Enabled = !disabledRequisite.Disabled;
+                    _stringTextbox.Enabled    = !disabledRequisite.Disabled;
+                    break;
+                default:
+                    return false;
+            }
+
+            return true;
+        }
+
         protected override void BuildSetting(Panel buildPanel) {
             _displayNameLabel = new Label() {
                 AutoSizeWidth = true,

--- a/Blish HUD/GameServices/Settings/_Compliance/EnumInclusionComplianceRequisite.cs
+++ b/Blish HUD/GameServices/Settings/_Compliance/EnumInclusionComplianceRequisite.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 
 namespace Blish_HUD.Settings {
-    public struct EnumComplianceRequisite<T> : IComplianceRequisite
+    public readonly struct EnumInclusionComplianceRequisite<T> : IComplianceRequisite
         where T : Enum {
 
         public T[] IncludedValues { get; }
 
-        public EnumComplianceRequisite(params T[] includedValues) {
+        public EnumInclusionComplianceRequisite(params T[] includedValues) {
             this.IncludedValues = includedValues;
         }
 

--- a/Blish HUD/GameServices/Settings/_Compliance/FloatRangeRangeComplianceRequisite.cs
+++ b/Blish HUD/GameServices/Settings/_Compliance/FloatRangeRangeComplianceRequisite.cs
@@ -1,10 +1,10 @@
 ﻿namespace Blish_HUD.Settings {
-    public struct FloatComplianceRequisite : INumericComplianceRequisite<float> {
+    public readonly struct FloatRangeRangeComplianceRequisite : INumericRangeComplianceRequisite<float> {
         
         public float MinValue { get; }
         public float MaxValue { get; }
 
-        public FloatComplianceRequisite(float minValue, float maxValue) {
+        public FloatRangeRangeComplianceRequisite(float minValue, float maxValue) {
             this.MinValue = minValue;
             this.MaxValue = maxValue;
         }

--- a/Blish HUD/GameServices/Settings/_Compliance/INumericRangeComplianceRequisite.cs
+++ b/Blish HUD/GameServices/Settings/_Compliance/INumericRangeComplianceRequisite.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 
 namespace Blish_HUD.Settings {
-    public interface INumericComplianceRequisite<T> : IComplianceRequisite
+    public interface INumericRangeComplianceRequisite<T> : IComplianceRequisite
         where T : IComparable<T> {
 
         T MinValue { get; }

--- a/Blish HUD/GameServices/Settings/_Compliance/IntRangeRangeComplianceRequisite.cs
+++ b/Blish HUD/GameServices/Settings/_Compliance/IntRangeRangeComplianceRequisite.cs
@@ -1,10 +1,10 @@
 ﻿namespace Blish_HUD.Settings {
-    public struct IntComplianceRequisite : INumericComplianceRequisite<int> {
+    public readonly struct IntRangeRangeComplianceRequisite : INumericRangeComplianceRequisite<int> {
 
         public int MinValue { get; }
         public int MaxValue { get; }
 
-        public IntComplianceRequisite(int minValue, int maxValue) {
+        public IntRangeRangeComplianceRequisite(int minValue, int maxValue) {
             this.MinValue = minValue;
             this.MaxValue = maxValue;
         }

--- a/Blish HUD/GameServices/Settings/_Compliance/SettingDisabledComplianceRequisite.cs
+++ b/Blish HUD/GameServices/Settings/_Compliance/SettingDisabledComplianceRequisite.cs
@@ -1,0 +1,11 @@
+﻿namespace Blish_HUD.Settings {
+    public readonly struct SettingDisabledComplianceRequisite : IComplianceRequisite {
+
+        public bool Disabled { get; }
+
+        public SettingDisabledComplianceRequisite(bool disabled) {
+            this.Disabled = disabled;
+        }
+
+    }
+}


### PR DESCRIPTION
1. Switches to using MonoGame's built in audio playback for basic sound effect playback (a temporary measure since that worked fine before but I would still like to switch to cscore once we get that stable).
2. Adds a temporary failsafe on audio playback that stops even trying to playback audio if it fails 3 times in a row.
3. Disabled the option to switch output device (since the MonoGame method does not appear to have support for anything other than the default device).

This also introduces improvements to the setting compliance system (to allow more than one compliance be applied). Currently the only new compliance that can overlap is the ability to disable the setting (which is what was needed for this PR).