### PR TITLE
Control improvements

### DIFF
--- a/Blish HUD/Controls/Container.cs
+++ b/Blish HUD/Controls/Container.cs
@@ -283,6 +283,14 @@ namespace Blish_HUD.Controls {
 
         public virtual void PaintAfterChildren(SpriteBatch spriteBatch, Rectangle bounds) { /* NOOP */ }
 
+        protected override void DisposeControl() {
+            foreach (var descendant in GetDescendants()) {
+                descendant.Dispose();
+            }
+
+            base.DisposeControl();
+        }
+
         #region IEnumerable Implementation
 
         public IEnumerator<Control> GetEnumerator() {

--- a/Blish HUD/Controls/ContextMenuStrip.cs
+++ b/Blish HUD/Controls/ContextMenuStrip.cs
@@ -117,7 +117,7 @@ namespace Blish_HUD.Controls {
             } else {
                 _targetPosition = activeControl.AbsoluteBounds.Location;
 
-                this.Location = new Point(activeControl.AbsoluteBounds.Location.X, GetVerticalOffset(activeControl.AbsoluteBounds.Location.Y, 0, activeControl.Height));
+                this.Location = new Point(_targetPosition.X, GetVerticalOffset(_targetPosition.Y, 0, activeControl.Height));
             }
 
             base.Show();


### PR DESCRIPTION
Containers should get rid of their child controls if explicitly disposed of.

Resolved CMS memory leak by centralizing the code used to close them when they're clicked off of.

Also allowed the menus to re-orient themselves when child items are dynamically added or removed from the menu while it is open.