### PR TITLE
Multiple minor window improvements

### DIFF
--- a/Blish HUD/Controls/TabbedWindow.cs
+++ b/Blish HUD/Controls/TabbedWindow.cs
@@ -45,7 +45,7 @@ namespace Blish_HUD.Controls {
         public int SelectedTabIndex {
             get => _selectedTabIndex;
             set {
-                if (SetProperty(ref _selectedTabIndex, value)) {
+                if (SetProperty(ref _selectedTabIndex, value, true)) {
                     OnTabChanged(EventArgs.Empty);
                 }
             }

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -195,18 +195,12 @@ namespace Blish_HUD {
 
         private void BuildMainWindow() {
             this.BlishHudWindow = new TabbedWindow() {
-                Parent = Graphics.SpriteScreen,
-                Title  = Strings.Common.BlishHUD,
-                Emblem = Content.GetTexture("blishhud-emblem")
-            };
-
-            // Center the window so that you don't have to drag it over every single time (which is really annoying)
-            // TODO: Save window positions to settings so that they remember where they were last
-            Graphics.SpriteScreen.Resized += delegate {
-                if (!this.BlishHudWindow.Visible) {
-                    this.BlishHudWindow.Location = new Point(Graphics.WindowWidth / 2 - this.BlishHudWindow.Width / 2,
-                                                             Graphics.WindowHeight / 2 - this.BlishHudWindow.Height / 2);
-                }
+                Parent        = Graphics.SpriteScreen,
+                Title         = Strings.Common.BlishHUD,
+                Emblem        = Content.GetTexture("blishhud-emblem"),
+                Location      = new Point(256, 256),
+                SavesPosition = true,
+                Id            = $"{nameof(OverlayService)}_BlishHUD_38d37290-b5f9-447d-97ea-45b0b50e5f55"
             };
 
             BuildSettingTab();

--- a/Blish HUD/GameServices/Settings/SettingCollection.cs
+++ b/Blish HUD/GameServices/Settings/SettingCollection.cs
@@ -128,6 +128,16 @@ namespace Blish_HUD.Settings {
             return DefineSetting(collectionKey, new SettingCollection(lazyLoaded) { RenderInUi = renderInUi }).Value;
         }
 
+        public bool ContainsSetting(string entryKey) {
+            return (this.Entries.Any(entry => string.Equals(entry.EntryKey, entryKey, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        public bool TryGetSetting(string entryKey, out SettingEntry settingEntry) {
+            settingEntry = this[entryKey];
+
+            return settingEntry != null;
+        }
+
         private void Load() {
             if (_entryTokens == null) return;
 


### PR DESCRIPTION
**Fixed #377** 
- Ensures that `TabbedWindow` now invalidates when the tab index is changed.  This resolves a graphical issue where the tabs below the first do not hide the white divider.

**Closes #378** 
- Windows which inherit from `WindowBase` can now have their position automatically saved between launches by defining their own unique `Id` and by enabling `SavesPosition`.

**Other**
- Removed event handler when windows are disposed to ensure the reference isn't mistakenly kept.
- Ensured the main Blish HUD window now remembers its position.
- Improved window position clamping to ensure it doesn't go too far off screen in _any_ direction.
- Added `TryGetSetting` and `ContainsSetting` to SettingCollection.