### PR TITLE
Rewrite ArcDps networking code for clarity

### DIFF
--- a/Blish HUD/GameServices/ArcDps/AsyncUserToken.cs
+++ b/Blish HUD/GameServices/ArcDps/AsyncUserToken.cs
@@ -1,36 +1,10 @@
-﻿using System;
-using System.Net.Sockets;
+﻿namespace Blish_HUD.ArcDps {
 
-namespace Blish_HUD.ArcDps {
+    public sealed class AsyncUserToken {
 
-    public sealed class AsyncUserToken : IDisposable {
-
-        public Socket Socket            { get; }
-        public int?   MessageSize       { get; set; }
-        public int    DataStartOffset   { get; set; }
-        public int    NextReceiveOffset { get; set; }
-
-        public AsyncUserToken(Socket socket) {
-            this.Socket = socket;
-        }
-
-        #region IDisposable Members
-
-        public void Dispose() {
-            try {
-                this.Socket.Shutdown(SocketShutdown.Send);
-            } catch (Exception) {
-                // ignored
-            }
-
-            try {
-                this.Socket.Close();
-            } catch (Exception) {
-                // ignored
-            }
-        }
-
-        #endregion
+        public int? MessageSize       { get; set; }
+        public int  DataStartOffset   { get; set; }
+        public int  NextReceiveOffset { get; set; }
 
     }
 

--- a/Blish HUD/GameServices/ArcDps/SocketListener/SocketListener.cs
+++ b/Blish HUD/GameServices/ArcDps/SocketListener/SocketListener.cs
@@ -115,10 +115,10 @@ namespace Blish_HUD.ArcDps {
                             token.NextReceiveOffset = 0;
 
                             if (token.DataStartOffset < e.Buffer.Length) {
-                                int notYesProcessDataSize = e.Buffer.Length - token.DataStartOffset;
-                                Buffer.BlockCopy(e.Buffer, token.DataStartOffset, e.Buffer, 0, notYesProcessDataSize);
+                                int notYetProcessed = e.Buffer.Length - token.DataStartOffset;
+                                Buffer.BlockCopy(e.Buffer, token.DataStartOffset, e.Buffer, 0, notYetProcessed);
 
-                                token.NextReceiveOffset = notYesProcessDataSize;
+                                token.NextReceiveOffset = notYetProcessed;
                             }
 
                             token.DataStartOffset = 0;


### PR DESCRIPTION
Prefer event arguments over same-instance fields for passing event state.

Use a CancellationToken to signal that we want to stop receiving ArcDps messages.

Do not allow SocketListener to dispose itself; raise an event in case of a network error and let the client code decide what to do with the socket.

Skip Shutdown() on sockets that are already disconnected.