### PR TITLE
Allow setting displaynames and descriptions to update when language is changed

### DIFF
--- a/Blish HUD/GameServices/GameIntegration/AudioIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/AudioIntegration.cs
@@ -56,11 +56,11 @@ namespace Blish_HUD.GameIntegration {
 
         public AudioIntegration(GameIntegrationService service) : base(service) {
             var audioSettings = GameService.Settings.RegisterRootSettingCollection(APPLICATION_SETTINGS);
-            _useGameVolume = audioSettings.DefineSetting(USEGAMEVOLUME_SETTINGS, true, Strings.GameServices.OverlayService.Setting_UseGameVolume_DisplayName, Strings.GameServices.OverlayService.Setting_UseGameVolume_Description);
-            _volumeSetting = audioSettings.DefineSetting(VOLUME_SETTINGS, MAX_VOLUME / 2, Strings.GameServices.OverlayService.Setting_Volume_DisplayName, Strings.GameServices.OverlayService.Setting_Volume_Description);
+            _useGameVolume = audioSettings.DefineSetting(USEGAMEVOLUME_SETTINGS, true, () => Strings.GameServices.OverlayService.Setting_UseGameVolume_DisplayName, () => Strings.GameServices.OverlayService.Setting_UseGameVolume_Description);
+            _volumeSetting = audioSettings.DefineSetting(VOLUME_SETTINGS, MAX_VOLUME / 2, () => Strings.GameServices.OverlayService.Setting_Volume_DisplayName, () => Strings.GameServices.OverlayService.Setting_Volume_Description);
             _volumeSetting.SetRange(0.0f, MAX_VOLUME);
 
-            _deviceSetting = audioSettings.DefineSetting(DEVICE_SETTINGS, Devices.Gw2OutputDevice, Strings.GameServices.OverlayService.Setting_AudioDevice_DisplayName, Strings.GameServices.OverlayService.Setting_AudioDevice_Description + " (This setting is temporarily disabled in this version)");
+            _deviceSetting = audioSettings.DefineSetting(DEVICE_SETTINGS, Devices.Gw2OutputDevice, () => Strings.GameServices.OverlayService.Setting_AudioDevice_DisplayName, () => Strings.GameServices.OverlayService.Setting_AudioDevice_Description + " (This setting is temporarily disabled in this version)");
             // This setting is disabled (so we force it to show "default")
             // See https://github.com/blish-hud/Blish-HUD/issues/355#issuecomment-787713586
             _deviceSetting.Value = Devices.DefaultDevice;

--- a/Blish HUD/GameServices/GameIntegrationService.cs
+++ b/Blish HUD/GameServices/GameIntegrationService.cs
@@ -136,7 +136,7 @@ namespace Blish_HUD {
         private void DefineSettings(SettingCollection settings) {
             const string UNDEFINED_EXECPATH = "NotDetected";
 
-            _gw2ExecutablePath = settings.DefineSetting("Gw2ExecutablePath", UNDEFINED_EXECPATH, "Gw2-64.exe Path", "The path to the game's executable. This is auto-detected, so don't change this unless you know what you're doing.");
+            _gw2ExecutablePath = settings.DefineSetting("Gw2ExecutablePath", UNDEFINED_EXECPATH, () => "Gw2-64.exe Path", () => "The path to the game's executable. This is auto-detected, so don't change this unless you know what you're doing.");
 
             // We do this to avoid trying to detect in the registry
             // unless we have never detected the true path

--- a/Blish HUD/GameServices/GraphicsService.cs
+++ b/Blish HUD/GameServices/GraphicsService.cs
@@ -138,18 +138,18 @@ namespace Blish_HUD {
         private void DefineSettings(SettingCollection settings) {
             _frameLimiterSetting = settings.DefineSetting("FramerateLimiter",
                                                           FramerateMethod.SyncWithGame,
-                                                          Strings.GameServices.GraphicsService.Setting_FramerateLimiter_DisplayName,
-                                                          Strings.GameServices.GraphicsService.Setting_FramerateLimiter_Description);
+                                                          () => Strings.GameServices.GraphicsService.Setting_FramerateLimiter_DisplayName,
+                                                          () => Strings.GameServices.GraphicsService.Setting_FramerateLimiter_Description);
 
             _enableVsyncSetting = settings.DefineSetting("EnableVsync",
                                                          true,
-                                                         Strings.GameServices.GraphicsService.Setting_Vsync_DisplayName,
-                                                         Strings.GameServices.GraphicsService.Setting_Vsync_Description);
+                                                         () => Strings.GameServices.GraphicsService.Setting_Vsync_DisplayName,
+                                                         () => Strings.GameServices.GraphicsService.Setting_Vsync_Description);
 
             _smoothCharacterPositionSetting = settings.DefineSetting("EnableCharacterPositionBuffer",
                                                                      true,
-                                                                     Strings.GameServices.GraphicsService.Setting_SmoothCharacterPosition_DisplayName,
-                                                                     Strings.GameServices.GraphicsService.Setting_SmoothCharacterPosition_Description);
+                                                                     () => Strings.GameServices.GraphicsService.Setting_SmoothCharacterPosition_DisplayName,
+                                                                     () => Strings.GameServices.GraphicsService.Setting_SmoothCharacterPosition_Description);
 
             _frameLimiterSetting.SettingChanged += FrameLimiterSettingMethodChanged;
             _enableVsyncSetting.SettingChanged  += EnableVsyncChanged;
@@ -162,7 +162,7 @@ namespace Blish_HUD {
             if (ApplicationSettings.Instance.TargetFramerate > 0) {
                 // Disable frame limiter setting and update description - user has manually specified via launch arg
                 _frameLimiterSetting.SetDisabled();
-                _frameLimiterSetting.Description += Strings.GameServices.GraphicsService.Setting_FramerateLimiter_Locked_Description;
+                _frameLimiterSetting.GetDescriptionFunc = () => Strings.GameServices.GraphicsService.Setting_FramerateLimiter_Description + Strings.GameServices.GraphicsService.Setting_FramerateLimiter_Locked_Description;
 
                 FrameLimiterSettingMethodChanged(_enableVsyncSetting, new ValueChangedEventArgs<FramerateMethod>(FramerateMethod.Custom, FramerateMethod.Custom));
             }

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -75,9 +75,9 @@ namespace Blish_HUD {
         }
 
         private void DefineSettings(SettingCollection settings) {
-            this.UserLocale    = settings.DefineSetting("AppCulture",    GetGw2LocaleFromCurrentUICulture(), Strings.GameServices.OverlayService.Setting_AppCulture_DisplayName,    Strings.GameServices.OverlayService.Setting_AppCulture_Description);
-            this.StayInTray    = settings.DefineSetting("StayInTray",    true,                               Strings.GameServices.OverlayService.Setting_StayInTray_DisplayName,    Strings.GameServices.OverlayService.Setting_StayInTray_Description);
-            this.ShowInTaskbar = settings.DefineSetting("ShowInTaskbar", false,                              Strings.GameServices.OverlayService.Setting_ShowInTaskbar_DisplayName, Strings.GameServices.OverlayService.Setting_ShowInTaskbar_Description);
+            this.UserLocale    = settings.DefineSetting("AppCulture",    GetGw2LocaleFromCurrentUICulture(), () => Strings.GameServices.OverlayService.Setting_AppCulture_DisplayName,    () => Strings.GameServices.OverlayService.Setting_AppCulture_Description);
+            this.StayInTray    = settings.DefineSetting("StayInTray",    true,                               () => Strings.GameServices.OverlayService.Setting_StayInTray_DisplayName,    () => Strings.GameServices.OverlayService.Setting_StayInTray_Description);
+            this.ShowInTaskbar = settings.DefineSetting("ShowInTaskbar", false,                              () => Strings.GameServices.OverlayService.Setting_ShowInTaskbar_DisplayName, () => Strings.GameServices.OverlayService.Setting_ShowInTaskbar_Description);
 
             // TODO: See https://github.com/blish-hud/Blish-HUD/issues/282
             this.UserLocale.SetExcluded(Locale.Chinese);

--- a/Blish HUD/GameServices/Settings/SettingCollection.cs
+++ b/Blish HUD/GameServices/Settings/SettingCollection.cs
@@ -98,7 +98,7 @@ namespace Blish_HUD.Settings {
             }
         }
 
-        public SettingEntry<TEntry> DefineSetting<TEntry>(string entryKey, TEntry defaultValue, string displayName = null, string description = null, SettingsService.SettingTypeRendererDelegate renderer = null) {
+        public SettingEntry<TEntry> DefineSetting<TEntry>(string entryKey, TEntry defaultValue, Func<string> displayNameFunc = null, Func<string> descriptionFunc = null) {
             // We don't need to check if we've loaded because the first check uses this[key] which
             // will load if we haven't already since it references this.Entries instead of _entries
             if (!(this[entryKey] is SettingEntry<TEntry> definedEntry)) {
@@ -106,12 +106,16 @@ namespace Blish_HUD.Settings {
                 _entries.Add(definedEntry);
             }
 
-            definedEntry.DisplayName    = displayName;
-            definedEntry.Description    = description;
-            definedEntry.Renderer       = renderer;
-            definedEntry.SessionDefined = true;
+            definedEntry.GetDisplayNameFunc = displayNameFunc ?? (() => null);
+            definedEntry.GetDescriptionFunc = descriptionFunc ?? (() => null);
+            definedEntry.SessionDefined     = true;
 
             return definedEntry;
+        }
+
+        [Obsolete("This function does not produce a localization friendly SettingEntry.")]
+        public SettingEntry<TEntry> DefineSetting<TEntry>(string entryKey, TEntry defaultValue, string displayName, string description, SettingsService.SettingTypeRendererDelegate renderer = null) {
+            return DefineSetting(entryKey, defaultValue, () => displayName, () => description);
         }
 
         public void UndefineSetting(string entryKey) {

--- a/Blish HUD/GameServices/Settings/SettingEntry.cs
+++ b/Blish HUD/GameServices/Settings/SettingEntry.cs
@@ -50,13 +50,17 @@ namespace Blish_HUD.Settings {
         }
 
         [JsonIgnore]
-        public string Description { get; set; }
+        public Func<string> GetDescriptionFunc { get; set; } = () => null;
 
         [JsonIgnore]
-        public string DisplayName { get; set; }
+        public Func<string> GetDisplayNameFunc { get; set; } = () => null;
 
-        [JsonIgnore, Obsolete]
-        public SettingsService.SettingTypeRendererDelegate Renderer { get; set; }
+
+        [JsonIgnore]
+        public string Description => this.GetDescriptionFunc();
+
+        [JsonIgnore]
+        public string DisplayName => this.GetDisplayNameFunc();
 
         /// <summary>
         /// The unique key used to identify the <see cref="SettingEntry"/> in the <see cref="SettingCollection"/>.


### PR DESCRIPTION
Introduced `func<string>` based delegates for `SettingEntry` display name and description.  These can be called by UI when views are built to get the proper string translation.

Also removes most of the old setting renderer methods.  Obsolete delegate left only to keep backwards compatibility with modules still calling the old `DefineSetting` function.  Technically a breaking change, but nothing should be left using the items which were removed.