### PR TITLE
WIP: Self Update Support

### DIFF
--- a/Blish HUD/ApplicationSettings.cs
+++ b/Blish HUD/ApplicationSettings.cs
@@ -23,7 +23,7 @@ namespace Blish_HUD {
         }
 
         public override void OnUserFacingException(UserFacingException e, string message) {
-            MessageBox.Show("Invalid launch option(s) specified.  See --help for available options.", "Failed to launch Blish HUD", MessageBoxButtons.OK);
+            MessageBox.Show($"Invalid launch option(s) specified.  See --help for available options.\r\n\r\n{e.Message}", "Failed to launch Blish HUD", MessageBoxButtons.OK);
         }
 
         public override void OnHelpInvoked(string helpText) {
@@ -48,6 +48,7 @@ namespace Blish_HUD {
          * w, window    - The name of the window to overlay.
          *
          * restartskipmutex - Forces Blish HUD to allow multiple instances.  Used internally to prevent race condition issues when Blish HUD is restarted.
+         * handleupdate     - Blish HUD checks and unpacks a provided zip file 
          */
 
         #region Game Integration

--- a/Blish HUD/ApplicationSettings.cs
+++ b/Blish HUD/ApplicationSettings.cs
@@ -48,7 +48,7 @@ namespace Blish_HUD {
          * w, window    - The name of the window to overlay.
          *
          * restartskipmutex - Forces Blish HUD to allow multiple instances.  Used internally to prevent race condition issues when Blish HUD is restarted.
-         * handleupdate     - Blish HUD checks and unpacks a provided zip file 
+         * parentpid        - Reference for restarts to check the parent process ID.
          */
 
         #region Game Integration
@@ -175,6 +175,13 @@ namespace Blish_HUD {
             Help("Forces Blish HUD to allow multiple instances.  Used internally to prevent race condition issues when Blish HUD is restarted.")
         ]
         public bool RestartSkipMutex { get; private set; }
+
+        public const string OPTION_PARENTPID = "parentpid";
+        [
+            OptionParameter(OPTION_PARENTPID),
+            Help("Forces the new instance to wait for the specified PID to exit before loading.  Used internally to prevent race conditions when Blish HUD is updating.")
+        ]
+        public int ParentPid { get; private set; }
 
         #endregion
 

--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -44,7 +44,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DebugType>full</DebugType>
+    <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants>DEBUG;NOMOUSEHOOK;NOKEYBOARDHOOK</DefineConstants>
   </PropertyGroup>

--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -53,6 +53,11 @@
     <DefineConstants>WINDOWS</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DebugType>embedded</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- Make sure that content files are only included through MonoGame and nothing else -->
     <Compile Remove="Content\**" />

--- a/Blish HUD/Controls/CornerIcon.cs
+++ b/Blish HUD/Controls/CornerIcon.cs
@@ -30,7 +30,7 @@ namespace Blish_HUD.Controls {
         
         private float _hoverTrans = ICON_TRANS;
         public float HoverTrans {
-            get => _hoverTrans;
+            get => this.Enabled ? _hoverTrans : ICON_TRANS;
             set => SetProperty(ref _hoverTrans, value);
         }
 
@@ -183,10 +183,10 @@ namespace Blish_HUD.Controls {
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
             if (_icon == null) return;
 
-            if (this.MouseOver && this.RelativeMousePosition.Y <= _standardIconBounds.Bottom) {
+            if (this.MouseOver && this.RelativeMousePosition.Y <= _standardIconBounds.Bottom && this.Enabled) {
                 spriteBatch.DrawOnCtrl(this, _hoverIcon ?? _icon, _standardIconBounds);
             } else {
-                spriteBatch.DrawOnCtrl(this, _icon, _standardIconBounds, Color.White * _hoverTrans);
+                spriteBatch.DrawOnCtrl(this, _icon, _standardIconBounds, Color.White * this.HoverTrans);
             }
 
             if (_isLoading) {

--- a/Blish HUD/GameServices/Input/DebugHelperHookManager.cs
+++ b/Blish HUD/GameServices/Input/DebugHelperHookManager.cs
@@ -44,6 +44,8 @@ namespace Blish_HUD.Input {
         }
 
         public void Unload() {
+            if (process == null || debugHelperMessageService == null) return;
+
             Logger.Debug("Unloading DebugHelper input hooks");
             debugHelperMessageService.Stop();
             pingTimer.Stop();

--- a/Blish HUD/GameServices/ModuleService.cs
+++ b/Blish HUD/GameServices/ModuleService.cs
@@ -269,7 +269,10 @@ namespace Blish_HUD {
         }
 
         protected override void Unload() {
-            foreach (var module in _modules) {
+            var moduleSet = _modules.ToArray();
+            _modules.Clear();
+
+            foreach (var module in moduleSet) {
                 if (module.Enabled) {
                     try {
                         Logger.Info("Unloading module {module}.", module.Manifest.GetDetailedName());

--- a/Blish HUD/GameServices/Overlay/SelfUpdater/CoreReleaseVersionsProvider.cs
+++ b/Blish HUD/GameServices/Overlay/SelfUpdater/CoreReleaseVersionsProvider.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+using Flurl.Http;
+
+namespace Blish_HUD.Overlay.SelfUpdater {
+    public static class CoreReleaseVersionsProvider {
+
+        private static readonly Logger Logger = Logger.GetLogger(typeof(CoreReleaseVersionsProvider));
+
+        public static async Task<(CoreVersionManifest[] Releases, Exception Exception)> GetAvailableReleases(string versionsUrl) {
+            try {
+                return (await versionsUrl.GetJsonAsync<CoreVersionManifest[]>(), null);
+            } catch (Exception ex) {
+                Logger.Warn(ex, $"Failed to load list of release versions from '{versionsUrl}'.");
+                return (Array.Empty<CoreVersionManifest>(), ex);
+            }
+        }
+
+    }
+}

--- a/Blish HUD/GameServices/Overlay/SelfUpdater/CoreVersionManifest.cs
+++ b/Blish HUD/GameServices/Overlay/SelfUpdater/CoreVersionManifest.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using Version = SemVer.Version;
+
+namespace Blish_HUD.Overlay.SelfUpdater {
+    public struct CoreVersionManifest {
+
+        [JsonProperty("url", Required = Required.Always)]
+        public string Url { get; private set; }
+
+
+        [JsonProperty("checksum", Required = Required.Always)]
+        public string Checksum { get; private set; }
+
+
+        [JsonProperty("version", Required = Required.Always), JsonConverter(typeof(Content.Serialization.SemVerConverter))]
+        public Version Version { get; private set; }
+
+        [JsonProperty("is_prerelease", Required = Required.DisallowNull)]
+        public bool IsPrerelease { get; private set; }
+
+        [JsonProperty("changelog_url", Required = Required.DisallowNull)]
+        public string ChangelogUrl { get; private set; }
+
+    }
+}

--- a/Blish HUD/GameServices/Overlay/UI/Presenters/CoreUpdatePresenter.cs
+++ b/Blish HUD/GameServices/Overlay/UI/Presenters/CoreUpdatePresenter.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Blish_HUD.Graphics.UI;
+using Blish_HUD.Overlay.SelfUpdater;
+using Blish_HUD.Overlay.UI.Views;
+using Blish_HUD.Settings;
+using Version = SemVer.Version;
+
+namespace Blish_HUD.Overlay.UI.Presenters {
+    public class CoreUpdatePresenter : Presenter<CoreUpdateView, string> {
+
+        private static readonly Logger Logger = Logger.GetLogger<CoreUpdatePresenter>();
+
+        private const string CORERELEASE_SETTINGS    = "CoreReleaseConfiguration";
+        private const string CORERELEASE_URL_SETTING = "AllUrl";
+        private const string SHOWPRERELEASES_SETTING = "ShowPrereleases";
+
+        private const string DEFAULT_CORERELEASE_URL = "https://versions.blishhud.com/all.json";
+        
+        private CoreVersionManifest[] _releases;
+
+        private readonly SettingEntry<bool>   _showPrereleases;
+        private readonly SettingEntry<string> _versionsUrl;
+
+        private CoreVersionManifest _selectedRelease;
+
+        public CoreUpdatePresenter(CoreUpdateView view, string model) : base(view, model) {
+            var settings = GameService.Settings.RegisterRootSettingCollection(CORERELEASE_SETTINGS);
+
+            _versionsUrl     = settings.DefineSetting(CORERELEASE_URL_SETTING, DEFAULT_CORERELEASE_URL);
+            _showPrereleases = settings.DefineSetting(SHOWPRERELEASES_SETTING, false);
+        }
+
+        protected override async Task<bool> Load(IProgress<string> progress) {
+            progress.Report("Loading release versions...");
+            (CoreVersionManifest[] releases, var releaseRequestException) = await CoreReleaseVersionsProvider.GetAvailableReleases(_versionsUrl.Value); 
+
+            if (releaseRequestException == null && releases.Any()) {
+                _releases = releases;
+            }
+
+            return true;
+        }
+
+        private Version[] GetApplicableVersions() {
+            return _releases.Where(release => !release.IsPrerelease || _showPrereleases.Value)
+                            .Select(release => release.Version).ToArray();
+        }
+
+        private void SetActiveVersion(Version version) {
+            _selectedRelease = _releases.FirstOrDefault(release => release.Version == version);
+
+            UpdateVersionsView();
+        }
+
+        private void UpdateVersionsView() {
+            this.View.SelectedVersion = _selectedRelease.Version;
+
+            UpdateViewForVersion();
+        }
+
+        protected override void UpdateView() {
+            if (_releases != null) {
+                this.View.ActionClicked          += OnActionClicked;
+                this.View.VersionSelected        += OnVersionSelected;
+                this.View.ShowPrereleasesChanged += OnPrereleasesChanged;
+            }
+
+            SetUi();
+        }
+
+        private void UpdateViewForVersion() {
+            var actionDetails = GetVersionAction(_selectedRelease.Version);
+
+            this.View.PackageActionEnabled = actionDetails.CanInstall;
+            this.View.PackageActionText    = actionDetails.ActionText;
+        }
+
+        private void OnPrereleasesChanged(object sender, ValueEventArgs<bool> e) {
+            _showPrereleases.Value = e.Value;
+        }
+
+        private void OnVersionSelected(object sender, ValueEventArgs<Version> e) {
+            SetActiveVersion(e.Value);
+        }
+
+        private async void OnActionClicked(object sender, EventArgs e) {
+            await GameService.Overlay.SelfUpdate(_selectedRelease);
+        }
+
+        private (bool CanInstall, string ActionText) GetVersionAction(Version selectedVersion) {
+            if (Program.OverlayVersion < selectedVersion) {
+                // A new version of Blish HUD is selected
+                return (true, Strings.GameServices.ModulesService.PkgManagement_Update);
+            } else if (Program.OverlayVersion > selectedVersion) {
+                // An older version of Blish HUD is selected
+                return (true, Strings.GameServices.ModulesService.PkgManagement_Downgrade);
+            }
+
+            // The selected version is the current version
+            return (false, Strings.GameServices.ModulesService.PkgManagement_CurrentVersion);
+        }
+
+        private void SetUi() {
+            if (_releases == null) {
+                this.View.CoreVersions      = null;
+                this.View.PackageActionText = "Unavailable";
+                return;
+            }
+
+            this.View.CoreVersions = GetApplicableVersions().OrderByDescending(version => version);
+
+            SetActiveVersion(this.View.CoreVersions.First());
+        }
+
+    }
+}

--- a/Blish HUD/GameServices/Overlay/UI/Views/AboutView.cs
+++ b/Blish HUD/GameServices/Overlay/UI/Views/AboutView.cs
@@ -10,59 +10,69 @@ namespace Blish_HUD.Overlay.UI.Views {
         protected override void Build(Panel buildPanel) {
             _ = new Image(GameService.Content.GetTexture("1025164")) {
                 SpriteEffects = SpriteEffects.FlipHorizontally | SpriteEffects.FlipVertically,
-                Location = new Point(buildPanel.Width - 1024 + 100 - 45, buildPanel.Height - 256 + 100 - 63 + 15),
-                ClipsBounds = false,
-                Parent = buildPanel
+                Location      = new Point(buildPanel.Width - 1024 + 100 - 45, buildPanel.Height - 256 + 100 - 63 + 15),
+                ClipsBounds   = false,
+                Parent        = buildPanel
             };
 
             var gw2CopyrightStatement = new Label() {
                 Font = GameService.Content.DefaultFont16,
-                Text = string.Format(Strings.GameServices.OverlayService.AboutAnetNotice, DateTime.Now.Year),
-                AutoSizeHeight = true,
-                Width = buildPanel.Width,
-                StrokeText = true,
+                Text = Strings.GameServices.OverlayService.AboutAnetNotAffiliatedNotice
+                     + "\n\n"
+                     + string.Format(Strings.GameServices.OverlayService.AboutAnetNotice, DateTime.Now.Year),
+                AutoSizeHeight      = true,
+                Width               = buildPanel.Width,
+                StrokeText          = true,
                 HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Top,
-                Parent = buildPanel
+                VerticalAlignment   = VerticalAlignment.Top,
+                Parent              = buildPanel
             };
 
             gw2CopyrightStatement.Location = new Point(0, buildPanel.Height - gw2CopyrightStatement.Height - 48);
 
             var lovePanel = new Panel() {
-                Size = new Point(buildPanel.Width - 128, 128),
-                Left = 64,
-                Top = gw2CopyrightStatement.Top - 128 - 12,
+                Size   = new Point(buildPanel.Width - 128, 128),
+                Left   = 64,
+                Top    = gw2CopyrightStatement.Top - 128 - 12,
                 Parent = buildPanel
             };
 
             var heart = new Image(GameService.Content.GetTexture("156127")) {
-                Size = new Point(64, 64),
-                Location = new Point(0, lovePanel.Height / 2 - 32),
-                Parent = lovePanel
+                Size     = new Point(64, 64),
+                Location = new Point(0,  lovePanel.Height / 2 - 32),
+                Parent   = lovePanel
             };
 
             _ = new Label() {
-                Font = GameService.Content.DefaultFont16,
-                Text = Strings.GameServices.OverlayService.AboutLoveMessage,
-                AutoSizeWidth = true,
-                Height = lovePanel.Height,
-                Left = heart.Right,
+                Font              = GameService.Content.DefaultFont16,
+                Text              = Strings.GameServices.OverlayService.AboutLoveMessage,
+                AutoSizeWidth     = true,
+                Height            = lovePanel.Height,
+                Left              = heart.Right,
                 VerticalAlignment = VerticalAlignment.Middle,
-                StrokeText = true,
-                Parent = lovePanel
+                StrokeText        = true,
+                Parent            = lovePanel
             };
 
-            var version = new Label() {
-                AutoSizeHeight = true,
-                AutoSizeWidth = true,
-                Text = $"Blish HUD v{Program.OverlayVersion}",
-                Font = GameService.Content.DefaultFont14,
-                StrokeText = true,
-                ClipsBounds = false,
-                Parent = buildPanel
+            //var version = new Label() {
+            //    AutoSizeHeight = true,
+            //    AutoSizeWidth = true,
+            //    Text = $"Blish HUD v{Program.OverlayVersion}",
+            //    Font = GameService.Content.DefaultFont14,
+            //    StrokeText = true,
+            //    ClipsBounds = false,
+            //    Parent = buildPanel
+            //};
+
+            //version.Location = new Point(/*buildPanel.Width - version.Width + 8*/ 8, buildPanel.Height - version.Height + 24);
+
+            var upgradeViewPanel = new ViewContainer() {
+                Location        = new Point(8, buildPanel.Height - 30),
+                Size            = new Point(buildPanel.Width - 16, 30),
+                Parent          = buildPanel
             };
 
-            version.Location = new Point(buildPanel.Width - version.Width + 8, buildPanel.Height - version.Height + 24);
+            upgradeViewPanel.Show(new CoreUpdateView());
         }
 
     }

--- a/Blish HUD/GameServices/Overlay/UI/Views/CoreUpdateView.cs
+++ b/Blish HUD/GameServices/Overlay/UI/Views/CoreUpdateView.cs
@@ -72,9 +72,6 @@ namespace Blish_HUD.Overlay.UI.Views {
         public CoreUpdateView() : this(null) { /* NOOP */ }
 
         protected override void Build(Panel buildPanel) {
-            //buildPanel.BackgroundColor = Color.Magenta;
-            //buildPanel.ClipsBounds = false;
-
             var version = new Label {
                 AutoSizeWidth     = true,
                 VerticalAlignment = VerticalAlignment.Middle,
@@ -96,6 +93,11 @@ namespace Blish_HUD.Overlay.UI.Views {
                 BasicTooltipText = Strings.Common.Options,
                 Parent           = buildPanel
             };
+
+            var settingsContextMenu   = new ContextMenuStrip();
+            var openChangeLog         = settingsContextMenu.AddMenuItem("View Changelog");
+            var toggleShowPrereleases = settingsContextMenu.AddMenuItem("Show Prereleases");
+            toggleShowPrereleases.CanCheck = true;
 
             _versionDropdown = new Dropdown() {
                 Width  = 128,

--- a/Blish HUD/GameServices/Overlay/UI/Views/CoreUpdateView.cs
+++ b/Blish HUD/GameServices/Overlay/UI/Views/CoreUpdateView.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Blish_HUD.Controls;
+using Blish_HUD.Graphics.UI;
+using Blish_HUD.Graphics.UI.Exceptions;
+using Blish_HUD.Input;
+using Blish_HUD.Overlay.UI.Presenters;
+using Microsoft.Scripting.Utils;
+using Microsoft.Xna.Framework;
+using Version = SemVer.Version;
+
+namespace Blish_HUD.Overlay.UI.Views {
+    public class CoreUpdateView : View {
+
+        public event EventHandler<ValueEventArgs<Version>> VersionSelected;
+        public event EventHandler<EventArgs>               ActionClicked;
+        public event EventHandler<ValueEventArgs<bool>>    ShowPrereleasesChanged;
+
+        private StandardButton _actionButton;
+        private Dropdown       _versionDropdown;
+        private Label          _failedLabel;
+
+        private IEnumerable<Version> _coreVersions;
+        private Version              _selectedVersion;
+
+        public string PackageActionText {
+            get => _actionButton?.Text ?? throw new ViewNotBuiltException();
+            set => (_actionButton ?? throw new ViewNotBuiltException()).Text = value;
+        }
+
+        public bool PackageActionEnabled {
+            get => _actionButton?.Enabled ?? throw new ViewNotBuiltException();
+            set => (_actionButton ?? throw new ViewNotBuiltException()).Enabled = value;
+        }
+
+        public IEnumerable<Version> CoreVersions {
+            get =>
+                _versionDropdown != null
+                    ? _coreVersions
+                    : throw new ViewNotBuiltException();
+            set {
+                if (_versionDropdown == null) throw new ViewNotBuiltException();
+
+                _coreVersions = value;
+
+                _failedLabel.Visible = !(_actionButton.Enabled = _versionDropdown.Enabled = value.Any());
+                
+                _versionDropdown.Items.Clear();
+                _versionDropdown.Items.AddRange(_coreVersions?.Select<string>(v => v.ToString()) ?? Array.Empty<string>());
+            }
+        }
+
+        public Version SelectedVersion {
+            get =>
+                _versionDropdown != null
+                    ? _selectedVersion
+                    : throw new ViewNotBuiltException();
+            set {
+                if (_versionDropdown == null) throw new ViewNotBuiltException();
+
+                _selectedVersion = value;
+
+                _versionDropdown.SelectedItem = _selectedVersion.ToString();
+            }
+        }
+
+        public CoreUpdateView(string versionsUrl) {
+            this.WithPresenter(new CoreUpdatePresenter(this, versionsUrl));
+        }
+
+        public CoreUpdateView() : this(null) { /* NOOP */ }
+
+        protected override void Build(Panel buildPanel) {
+            //buildPanel.BackgroundColor = Color.Magenta;
+            //buildPanel.ClipsBounds = false;
+
+            var version = new Label {
+                AutoSizeWidth     = true,
+                VerticalAlignment = VerticalAlignment.Middle,
+                Height            = buildPanel.Height,
+                Text              = $"{Strings.Common.BlishHUD} v{Program.OverlayVersion.BaseVersion()}",
+                BasicTooltipText  = $"{Strings.Common.BlishHUD} v{Program.OverlayVersion}",
+                Font              = GameService.Content.DefaultFont14,
+                StrokeText        = true,
+                ClipsBounds       = false,
+                Location          = new Point(8, 0),
+                Parent            = buildPanel
+            };
+
+            var settingsButton = new GlowButton {
+                Right = buildPanel.Width - 8,
+                Icon             = GameService.Content.GetTexture("common/157109"),
+                ActiveIcon       = GameService.Content.GetTexture("common/157110"),
+                Visible          = true,
+                BasicTooltipText = Strings.Common.Options,
+                Parent           = buildPanel
+            };
+
+            _versionDropdown = new Dropdown() {
+                Width  = 128,
+                Right  = settingsButton.Left - 8,
+                Parent = buildPanel
+            };
+
+            _actionButton = new StandardButton() {
+                Text   = "Update",
+                Width  = 128,
+                Right  = _versionDropdown.Left - 8,
+                Parent = buildPanel
+            };
+
+            _failedLabel = new Label() {
+                AutoSizeWidth = true,
+                Text          = "Error while checking for new version!",
+                Height        = buildPanel.Height,
+                TextColor     = Control.StandardColors.Yellow,
+                Visible       = false,
+                Right         = _actionButton.Left - 8,
+                Parent        = buildPanel
+            };
+
+            settingsButton.Top   = buildPanel.Height / 2 - _actionButton.Height    / 2 - 2;
+            _actionButton.Top    = buildPanel.Height / 2 - _actionButton.Height    / 2;
+            _versionDropdown.Top = buildPanel.Height / 2 - _versionDropdown.Height / 2;
+
+            _actionButton.Click += OnActionClicked;
+            _versionDropdown.ValueChanged += OnVersionSelected;
+        }
+
+        private void OnVersionSelected(object sender, ValueChangedEventArgs e) {
+            this.VersionSelected?.Invoke(sender, new ValueEventArgs<Version>(new Version(e.CurrentValue)));
+        }
+
+        private void OnActionClicked(object sender, MouseEventArgs e) {
+            this.ActionClicked?.Invoke(sender, e);
+        }
+
+    }
+}

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -245,7 +245,7 @@ namespace Blish_HUD {
 
             this.BlishContextMenu                                                                                          =  this.BlishMenuIcon.Menu;
             this.BlishContextMenu.AddMenuItem(string.Format(Strings.Common.Action_Restart, Strings.Common.BlishHUD)).Click += delegate { Restart(); };
-            this.BlishContextMenu.AddMenuItem(string.Format(Strings.Common.Action_Exit,    Strings.Common.BlishHUD)).Click += delegate { Exit(); };;
+            this.BlishContextMenu.AddMenuItem(string.Format(Strings.Common.Action_Exit,    Strings.Common.BlishHUD)).Click += delegate { Exit(); };
 
             this.BlishMenuIcon.Click += delegate {
                 this.BlishHudWindow.ToggleWindow();

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -151,13 +151,15 @@ namespace Blish_HUD {
 
             var arguments = Environment.GetCommandLineArgs()
                                        .Skip(1)
-                                       .Where(arg => !string.Equals(arg, $"--{ApplicationSettings.OPTION_RESTARTSKIPMUTEX}", StringComparison.OrdinalIgnoreCase))
+                                       .Where(arg => 
+                                                  !string.Equals(arg, $"--{ApplicationSettings.OPTION_RESTARTSKIPMUTEX}", StringComparison.OrdinalIgnoreCase)
+                                               && !arg.StartsWith($"--{ApplicationSettings.OPTION_PARENTPID}", StringComparison.OrdinalIgnoreCase))
                                        .Append($"--{ApplicationSettings.OPTION_RESTARTSKIPMUTEX}")
                                        .Select(arg => arg.Contains("\"") ? arg : $"\"{arg}\"");
 
             var currentStartInfo = Process.GetCurrentProcess().StartInfo;
             currentStartInfo.FileName  = Application.ExecutablePath;
-            currentStartInfo.Arguments = string.Join(" ", arguments.Concat(additionalArgs.Select(arg => arg.Contains("\"") ? arg : $"\"{arg}\"")));
+            currentStartInfo.Arguments = string.Join(" ", arguments.Concat(additionalArgs /*.Select(arg => arg.Contains("\"") ? arg : $"\"{arg}\"") */));
 
             Logger.Info($"Restarting with launch args: {currentStartInfo.Arguments}");
 
@@ -208,6 +210,7 @@ namespace Blish_HUD {
         internal async Task SelfUpdate(CoreVersionManifest coreVersionManifest) {
             this.BlishMenuIcon.LoadingMessage = "Unloading modules...";
             GameService.Module.DoUnload();
+            GameService.Input.DoUnload();
             this.BlishHudWindow.Hide();
             this.BlishMenuIcon.Enabled = false;
             this.BlishMenuIcon.LoadingMessage = "Downloading Blish HUD for install...";

--- a/Blish HUD/Program.cs
+++ b/Blish HUD/Program.cs
@@ -16,7 +16,7 @@ namespace Blish_HUD {
 
         private const string APP_GUID = "{5802208e-71ca-4745-ab1b-d851bc17a460}";
 
-        public static SemVer.Version OverlayVersion { get; } = new SemVer.Version(typeof(BlishHud).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion, true);
+        public static SemVer.Version OverlayVersion { get; } = new SemVer.Version("0.8.0");  //new SemVer.Version(typeof(BlishHud).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion, true);
 
         private static void EnableLogging() {
             // Make sure logging and logging services are available as soon as possible
@@ -46,6 +46,8 @@ namespace Blish_HUD {
 
             Logger.Debug("Launched from {launchDirectory} with args {launchOptions}.", Directory.GetCurrentDirectory(), string.Join(" ", args));
             
+            SelfUpdateUtil.TryHandleUpdate();
+
             if (!ApplicationSettings.Instance.RestartSkipMutex) {
                 // Single instance handling
                 _singleInstanceMutex = new Mutex(true, ApplicationSettings.Instance.MumbleMapName != null

--- a/Blish HUD/Program.cs
+++ b/Blish HUD/Program.cs
@@ -16,7 +16,7 @@ namespace Blish_HUD {
 
         private const string APP_GUID = "{5802208e-71ca-4745-ab1b-d851bc17a460}";
 
-        public static SemVer.Version OverlayVersion { get; } = new SemVer.Version("0.8.0");  //new SemVer.Version(typeof(BlishHud).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion, true);
+        public static SemVer.Version OverlayVersion { get; } = new SemVer.Version(typeof(BlishHud).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion, true);
 
         private static void EnableLogging() {
             // Make sure logging and logging services are available as soon as possible
@@ -45,8 +45,10 @@ namespace Blish_HUD {
             EnableLogging();
 
             Logger.Debug("Launched from {launchDirectory} with args {launchOptions}.", Directory.GetCurrentDirectory(), string.Join(" ", args));
-            
-            SelfUpdateUtil.TryHandleUpdate();
+
+            if (!SelfUpdateUtil.TryHandleUpdate()) {
+                Logger.Fatal("Update failed.  Blish HUD is exiting!");
+            }
 
             if (!ApplicationSettings.Instance.RestartSkipMutex) {
                 // Single instance handling

--- a/Blish HUD/Strings/GameServices/OverlayService.Designer.cs
+++ b/Blish HUD/Strings/GameServices/OverlayService.Designer.cs
@@ -61,6 +61,15 @@ namespace Blish_HUD.Strings.GameServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This application is not affiliated with ArenaNet, Guild Wars 2, or any of their partners..
+        /// </summary>
+        internal static string AboutAnetNotAffiliatedNotice {
+            get {
+                return ResourceManager.GetString("AboutAnetNotAffiliatedNotice", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ©2010-{0} ArenaNet, LLC. All rights reserved. Guild Wars, Guild Wars 2, Heart of Thorns,
         ///Guild Wars 2: Path of Fire, ArenaNet, NCSOFT, the Interlocking NC Logo, and all associated
         ///logos and designs are trademarks or registered trademarks of NCSOFT Corporation. All other

--- a/Blish HUD/Strings/GameServices/OverlayService.resx
+++ b/Blish HUD/Strings/GameServices/OverlayService.resx
@@ -156,4 +156,7 @@ trademarks are the property of their respective owners.</value>
   <data name="Setting_AudioDevice_Description" xml:space="preserve">
     <value>This determines the Audio output device used by Blish HUD. The Gw2OutputDevice adjusts itself to whatever GW2 is using.</value>
   </data>
+  <data name="AboutAnetNotAffiliatedNotice" xml:space="preserve">
+    <value>This application is not affiliated with ArenaNet, Guild Wars 2, or any of their partners.</value>
+  </data>
 </root>

--- a/Blish HUD/_Utils/SelfUpdateUtil.cs
+++ b/Blish HUD/_Utils/SelfUpdateUtil.cs
@@ -36,6 +36,7 @@ namespace Blish_HUD {
                 HandleUpdate(unpackPath);
             } catch (Exception ex) {
                 MessageBox.Show($"Failed to complete update!  Launch Blish HUD again to try to complete the update again.\r\n\r\n{ex.Message}", "", MessageBoxButtons.OK);
+                Logger.Fatal(ex, "Failed to complete update!");
                 return false;
             }
 

--- a/Blish HUD/_Utils/SelfUpdateUtil.cs
+++ b/Blish HUD/_Utils/SelfUpdateUtil.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Blish_HUD.Controls;
+using Blish_HUD.Overlay.SelfUpdater;
+using Flurl.Http;
+
+namespace Blish_HUD {
+    public static class SelfUpdateUtil {
+
+        private static readonly Logger Logger = Logger.GetLogger(typeof(SelfUpdateUtil));
+
+        private const string FILE_UNPACKZIP = "unpack.zip";
+        private const string FILE_EXE       = "Blish HUD.exe";
+        private const string FILE_EXEBACKUP = FILE_EXE + "__bak";
+
+        public static void TryHandleUpdate() {
+            string unpackPath = Path.Combine(Path.GetDirectoryName(Application.ExecutablePath), FILE_UNPACKZIP);
+            
+            if (!File.Exists(unpackPath)) {
+                return;
+            }
+
+            // Try to make sure parent process has closed so none of the
+            // files are still locked - there are better ways to do this
+            System.Threading.Thread.Sleep(TimeSpan.FromSeconds(2));
+
+            try {
+                HandleUpdate(unpackPath);
+            } catch (Exception ex) {
+                MessageBox.Show($"Failed to complete update!\r\n\r\n{ex.Message}", "", MessageBoxButtons.OK);
+                // TODO: Bubble up to exit Blish HUD immediately.
+            }
+        }
+
+        private static void HandleUpdate(string unpackPath) {
+            var unpackStream = File.OpenRead(unpackPath);
+            var unpacker     = new ZipArchive(unpackStream);
+
+            var applicationDir = Directory.GetCurrentDirectory();
+            
+            var rootDirs  = unpacker.Entries.Where(entry => string.IsNullOrWhiteSpace(entry.Name)  && entry.FullName.IndexOf('/') == entry.FullName.Length - 1);
+            var allFiles  = unpacker.Entries.Where(entry => !string.IsNullOrWhiteSpace(entry.Name) && !string.Equals(entry.Name, FILE_EXE));
+            var rootFiles = allFiles.Where(entry => !entry.FullName.Contains("/"));
+
+            foreach (var dir in rootDirs) {
+                string dirPath = Path.Combine(applicationDir, dir.FullName);
+
+                if (Directory.Exists(dirPath)) {
+                    Directory.Delete(dirPath, true);
+                }
+            }
+            
+            foreach (var file in rootFiles) {
+                string filePath = Path.Combine(applicationDir, file.FullName);
+
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+            
+            foreach (var file in allFiles) {
+                string dir = Path.GetDirectoryName(file.FullName);
+
+                Directory.CreateDirectory(Path.Combine(applicationDir, dir));
+                file.ExtractToFile(Path.Combine(applicationDir, file.FullName));
+            }
+
+            if (File.Exists(Path.Combine(applicationDir, FILE_EXEBACKUP))) {
+                File.Delete(Path.Combine(applicationDir, FILE_EXEBACKUP));
+            }
+
+            unpacker.Dispose();
+            unpackStream.Dispose();
+
+            File.Delete(unpackPath);
+        }
+
+        public static async Task BeginUpdate(CoreVersionManifest coreVersionManifest) {
+            Logger.Info($"Downloading version v{coreVersionManifest.Version}...");
+            string unpackDestination = await coreVersionManifest.Url.DownloadFileAsync(Path.GetDirectoryName(Application.ExecutablePath), FILE_UNPACKZIP);
+            Logger.Info($"Finished downloading {unpackDestination}.");
+
+            using var dataSha256 = System.Security.Cryptography.SHA256.Create();
+            using var unpackFile = File.OpenRead(unpackDestination);
+            byte[] rawChecksum = dataSha256.ComputeHash(unpackFile);
+            string checksum = BitConverter.ToString(rawChecksum).Replace("-", string.Empty);
+
+            if (string.Equals(coreVersionManifest.Checksum, checksum, StringComparison.InvariantCultureIgnoreCase)) {
+                ScreenNotification.ShowNotification("Update failed!  Download was invalid (checksum failed).  Blish HUD will restart.  No changes were made.", ScreenNotification.NotificationType.Error, null, 8);
+                unpackFile.Dispose();
+                File.Delete(unpackDestination);
+
+                await Task.Delay(TimeSpan.FromSeconds(8));
+
+                GameService.Overlay.Restart();
+                return;
+            } else {
+                Logger.Info($"Found the expected checksum '{coreVersionManifest.Checksum}'.");
+
+                string currentPath = Path.GetDirectoryName(Application.ExecutablePath);
+                string currentName = Path.GetFileName(Application.ExecutablePath);
+
+                string exeBackupPath = Path.Combine(currentPath, FILE_EXEBACKUP);
+
+                if (File.Exists(exeBackupPath)) {
+                    File.Delete(exeBackupPath);
+                }
+
+                File.Move(Path.Combine(currentPath, currentName), exeBackupPath);
+
+                var unpacker = new ZipArchive(unpackFile);
+                unpacker.Entries.First(entry => entry.Name == FILE_EXE).ExtractToFile(Path.Combine(currentPath, currentName));
+
+                unpackFile.Dispose();
+
+                GameService.Overlay.Restart();
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Introduces support for a self updater:
- About page shows the option to select a version (this means that users can downgrade their version if they would like).
- Available versions are pulled from `https://versions.blishhud.com/all.json`.
- Option to open changelog and to toggle showing prerelease versions (WIP).

Self update process works as follows:
- When a version is selected, Blish HUD unloads the module (so that modules can cleanly unload) and input service (so that the hooks are disabled and the debug hook application closed, if in a debug session).
- Blish HUD window is closed and made unavailable.  A loading spinner is shown in the top left for the duration of the package download.
- The package is downloaded to "unpack.zip" in the application directory.
- Once downloaded, the checksum is compared to what was listed in the original manifest.
  - If checksum is invalid then the user is told the update failed and Blish HUD restarts automatically.
- Blish HUD moves its own exe to rename it in the same folder to `Blish HUD.exe__bak`.
- The new `Blish HUD.exe` is extracted from `unpack.zip` and placed in the folder.
- Blish HUD restarts passing the `--parentpid <current pid>` to the new Blish HUD executable.

When Blish HUD launches:
- If `unpack.zip` is found in the same directory, it is assumed that we are mid-upgrade.
- We delete the `Blish HUD.exe__bak`.
- We wait a max of 10 seconds for the previous Blish HUD instance to finish exiting (we do not force close it, we want it to exit cleanly) by checking for parentpid to stop existing.
  - If after 10 seconds the parentpid is still running, we will notify the user and the application exits.
  - Any future attempts to launch Blish HUD will attempt to complete the update so it is able to usually recover.
- We remove the old content, language dlls, hook helper exe, ref.dat, etc.
- We begin exporting the files found in `unpack.zip` to the directory.
- We delete `unpack.zip`.
- Blish HUD continues launching as it normally would from this point forward.

Remaining items:
- [ ] Finalize settings context menu with "Open changelogs" and "Toggle prerequisites" support.
- [ ] Enable filtering of prerequisites in version dropdown.
- [ ] Show update arrow on the settings tab if an update is available.