### PR TITLE
Disable inactive sleep time.  

### DIFF
--- a/Blish HUD/BlishHud.cs
+++ b/Blish HUD/BlishHud.cs
@@ -60,6 +60,7 @@ namespace Blish_HUD {
 
             this.Window.IsBorderless = true;
             this.Window.AllowAltF4   = false;
+            this.InactiveSleepTime   = TimeSpan.Zero;
 
             // Initialize all game services
             foreach (var service in GameService.All) {


### PR DESCRIPTION
Monogame will attempt to sleep a little longer between frames because it thinks the window is inactive.  This drives FPS down to 32 FPS until the windows focus is toggled out and on.  Since we're an overlay, we should not split the scenario.

https://github.com/MonoGame/MonoGame/blob/f2ee0def3690e1c95273623f60fe47ddc8c12c68/MonoGame.Framework/Game.cs#L524-L532