### PR TITLE
Random Blish crash during typing in textbox

### DIFF
--- a/Blish HUD/Controls/Control.cs
+++ b/Blish HUD/Controls/Control.cs
@@ -411,7 +411,7 @@ namespace Blish_HUD.Controls {
                 // Clean this up
                 // This is really the absolute bounds of the ContentRegion currently because mouse
                 // input is currently using this to determine if the click was within the region
-                return new Rectangle(_parent.AbsoluteBounds.X + _parent.ContentRegion.X + _location.X - _parent.HorizontalScrollOffset,
+                else return new Rectangle(_parent.AbsoluteBounds.X + _parent.ContentRegion.X + _location.X - _parent.HorizontalScrollOffset,
                                      _parent.AbsoluteBounds.Y + _parent.ContentRegion.Y + _location.Y - _parent.VerticalScrollOffset,
                                      _size.X,
                                      _size.Y);

--- a/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
@@ -126,7 +126,7 @@ namespace Blish_HUD.Input {
 
         private bool ShouldBlockKeyEvent(Keys key) {
             // Prevent blocking shift for input capitalization
-            // if (key == Keys.LeftShift || key == Keys.RightShift) return false; // "SHIFT" support temporarily disabled
+            if (_keysDown.Contains(Keys.LeftShift) || _keysDown.Contains(Keys.RightShift)) return false; // "SHIFT" support temporarily disabled
 
             // Skip keys that we wish to explicitly ignore
             if (_hookIgnoredKeys.Contains(key)) return false;
@@ -141,7 +141,7 @@ namespace Blish_HUD.Input {
             _inputBuffer.Enqueue(new KeyboardEventArgs(eventType, key));
 
             if (_textInputDelegate != null) {
-                string chars = TypedInputUtil.VkCodeToString((uint)key, eventType == KeyboardEventType.KeyDown);
+                string chars = TypedInputUtil.VkCodeToString((uint)key, eventType == KeyboardEventType.KeyDown, _keysDown.Contains(Keys.LeftShift) || _keysDown.Contains(Keys.RightShift));
                 _textInputDelegate?.BeginInvoke(chars, EndTextInputAsyncInvoke, null);
                 return ShouldBlockKeyEvent(key);
             }

--- a/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
@@ -126,7 +126,7 @@ namespace Blish_HUD.Input {
 
         private bool ShouldBlockKeyEvent(Keys key) {
             // Prevent blocking shift for input capitalization
-            if (_keysDown.Contains(Keys.LeftShift) || _keysDown.Contains(Keys.RightShift)) return false; // "SHIFT" support temporarily disabled
+            //if (_keysDown.Contains(Keys.LeftShift) || _keysDown.Contains(Keys.RightShift)) return false; // "SHIFT" support temporarily disabled
 
             // Skip keys that we wish to explicitly ignore
             if (_hookIgnoredKeys.Contains(key)) return false;

--- a/Blish HUD/GameServices/Input/Keyboard/TypedInputUtil.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/TypedInputUtil.cs
@@ -49,7 +49,7 @@ namespace Blish_HUD.Input {
         /// <param name="vkCode">VKCode</param>
         /// <param name="isKeyDown">Is the key down event?</param>
         /// <returns>String representing single unicode character.</returns>
-        public static string VkCodeToString(uint vkCode, bool isKeyDown) {
+        public static string VkCodeToString(uint vkCode, bool isKeyDown, bool shift) {
             // ToUnicodeEx needs StringBuilder, it populates that during execution.
             System.Text.StringBuilder sbString = new System.Text.StringBuilder(5);
 
@@ -110,6 +110,9 @@ namespace Blish_HUD.Input {
                 // Single character in buffer
                 case 1:
                     ret = sbString[0].ToString();
+                    if (shift) {
+                        ret = ret.ToUpper();
+                    }
                     break;
 
                 // Two or more (only two of them is relevant)


### PR DESCRIPTION
I noticed random crashes because of a `NullRefernceException` in `public Rectangle AbsoluteBounds`. I think it's because in rare cases there could be a race condition for `_parent` which then would be `null` before the last `return` statement.

Adding `else` seems to help with that issue, preventing change of `_parent` before the `return` is executed.