### PR TITLE
Tooltip refresh

### DIFF
--- a/Blish HUD/Common/UI/Views/BasicTooltipView.cs
+++ b/Blish HUD/Common/UI/Views/BasicTooltipView.cs
@@ -1,0 +1,31 @@
+﻿using Blish_HUD.Controls;
+using Blish_HUD.Graphics.UI;
+
+namespace Blish_HUD.Common.UI.Views {
+    public class BasicTooltipView : View, ITooltipView {
+        
+        private readonly Label _tooltipLabel;
+
+        public string Text {
+            get => _tooltipLabel.Text;
+            set => _tooltipLabel.Text = value;
+        }
+
+        public BasicTooltipView(string text) {
+            _tooltipLabel = new Label() {
+                ShowShadow     = true,
+                AutoSizeHeight = true,
+                AutoSizeWidth  = true
+            };
+
+            this.Text = text;
+        }
+
+        protected override void Build(Panel buildPanel) {
+            _tooltipLabel.Parent = buildPanel;
+
+            buildPanel.Hidden += (sender, args) => buildPanel.Dispose();
+        }
+
+    }
+}

--- a/Blish HUD/Common/UI/Views/ITooltipView.cs
+++ b/Blish HUD/Common/UI/Views/ITooltipView.cs
@@ -1,0 +1,6 @@
+﻿using Blish_HUD.Graphics.UI;
+
+namespace Blish_HUD.Common.UI.Views {
+    public interface ITooltipView : IView {
+    }
+}

--- a/Blish HUD/Controls/Tooltip.cs
+++ b/Blish HUD/Controls/Tooltip.cs
@@ -1,12 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using Blish_HUD.Common.UI.Views;
+using Blish_HUD.Graphics.UI;
 using Blish_HUD.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Blish_HUD.Controls {
-   public class Tooltip : Container {
+   public class Tooltip : Panel, IViewContainer {
         
         internal const int MOUSE_VERTICAL_MARGIN = 18;
 
@@ -14,13 +17,13 @@ namespace Blish_HUD.Controls {
 
         #region Load Static
 
-        private static readonly Thickness _contentEdgeBuffer;
+        private static Thickness _contentEdgeBuffer;
 
-        private static readonly List<Tooltip> _allTooltips;
+        private static List<Tooltip> _allTooltips;
 
-        private static readonly Texture2D _textureTooltip;
+        private static Texture2D _textureTooltip;
 
-        static Tooltip() {
+        internal static void EnableTooltips() {
             _contentEdgeBuffer = new Thickness(4, 4, 3, 6);
 
             _textureTooltip = Content.GetTexture("tooltip");
@@ -82,6 +85,10 @@ namespace Blish_HUD.Controls {
 
         #endregion
 
+        public ViewState ViewState   { get; private set; } = ViewState.None;
+
+        public IView CurrentView { get; private set; }
+
         public Control CurrentControl { get; set; }
 
         private Glide.Tween _animFadeLifecycle;
@@ -90,8 +97,38 @@ namespace Blish_HUD.Controls {
             this.ZIndex = Screen.TOOLTIP_BASEZINDEX;
 
             this.Padding = new Thickness(PADDING);
+            this.Visible = false;
 
             _allTooltips.Add(this);
+        }
+
+        public Tooltip(ITooltipView tooltipView) : this() {
+            ShowView(tooltipView);
+        }
+
+        private void ShowView(ITooltipView newView) {
+            if (newView == null) return;
+
+            this.ViewState = ViewState.Loading;
+
+            this.CurrentView = newView;
+
+            var progressIndicator = new Progress<string>((progressReport) => { /* NOOP */ });
+
+            newView.Loaded += OnViewBuilt;
+            newView.DoLoad(progressIndicator).ContinueWith(BuildView);
+        }
+
+        private void OnViewBuilt(object sender, EventArgs e) {
+            this.CurrentView.Loaded -= OnViewBuilt;
+
+            ViewState = ViewState.Loaded;
+        }
+
+        private void BuildView(Task<bool> loadResult) {
+            if (loadResult.Result) {
+                this.CurrentView.DoBuild(this);
+            }
         }
 
         protected override void OnChildAdded(ChildChangedEventArgs e) {
@@ -123,8 +160,10 @@ namespace Blish_HUD.Controls {
 
         public override void UpdateContainer(GameTime gameTime) {
             if (this.CurrentControl != null && !this.CurrentControl.Visible) {
-                this.Visible        = false;
+                this.Hide();
                 this.CurrentControl = null;
+            } else if (this.Visible) {
+                UpdateTooltipPosition(this);
             }
         }
 
@@ -207,5 +246,11 @@ namespace Blish_HUD.Controls {
             spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, 1, 1, _size.Y - 2).Add(-PADDING, -PADDING, 0, PADDING * 2), Color.Black * 0.6f);
         }
 
-    }
+        protected override void DisposeControl() {
+            this.CurrentView?.DoUnload();
+
+            base.DisposeControl();
+        }
+
+   }
 }

--- a/Blish HUD/Controls/ViewContainer.cs
+++ b/Blish HUD/Controls/ViewContainer.cs
@@ -9,13 +9,10 @@ namespace Blish_HUD.Controls {
     /// <summary>
     /// Acts as a container to build and house the lifecycle of any provided <see cref="IView"/>.
     /// </summary>
-    public class ViewContainer : Panel {
+    public class ViewContainer : Panel, IViewContainer {
 
         private const float FADE_DURATION = 0.35f;
 
-        /// <summary>
-        /// The current state of the view.
-        /// </summary>
         public ViewState ViewState { get; private set; } = ViewState.None;
 
         private bool _fadeView = false;
@@ -28,10 +25,7 @@ namespace Blish_HUD.Controls {
             get => _fadeView;
             set => SetProperty(ref _fadeView, value);
         }
-
-        /// <summary>
-        /// The <see cref="IView"/> this container is currently displaying.
-        /// </summary>
+        
         public IView CurrentView { get; private set; }
 
         private Tween _fadeInAnimation;

--- a/Blish HUD/Controls/_Types/IViewContainer.cs
+++ b/Blish HUD/Controls/_Types/IViewContainer.cs
@@ -1,0 +1,17 @@
+﻿using Blish_HUD.Graphics.UI;
+
+namespace Blish_HUD.Controls {
+    public interface IViewContainer {
+
+        /// <summary>
+        /// The current state of the view.
+        /// </summary>
+        ViewState ViewState { get; }
+
+        /// <summary>
+        /// The <see cref="IView"/> this container is currently displaying.
+        /// </summary>
+        IView CurrentView { get; }
+
+    }
+}

--- a/Blish HUD/GameServices/Graphics/UI/View.cs
+++ b/Blish HUD/GameServices/Graphics/UI/View.cs
@@ -15,7 +15,7 @@ namespace Blish_HUD.Graphics.UI {
 
         public IPresenter Presenter { get; private set; } = _sharedNullPresenter;
 
-        protected ViewContainer ViewTarget { get; private set; }
+        protected Panel ViewTarget { get; private set; }
 
         protected View() { /* NOOP */ }
 
@@ -26,8 +26,6 @@ namespace Blish_HUD.Graphics.UI {
         public View WithPresenter(IPresenter presenter) {
             Presenter = presenter
                       ?? throw new ArgumentNullException(nameof(presenter));
-
-            this.ViewTarget?.Show(this);
 
             return this;
         }
@@ -43,7 +41,7 @@ namespace Blish_HUD.Graphics.UI {
         }
 
         public void DoBuild(Panel buildPanel) {
-            this.ViewTarget = (ViewContainer)buildPanel;
+            this.ViewTarget = buildPanel;
 
             Build(buildPanel);
 


### PR DESCRIPTION
- Improved tooltips to better support views.
- Also fixed a bug that would prevent tooltips from showing if changed while they were showing. (Closes #408)
- Removed the sharedtooltip used by all controls. This is now created on the spot which is far easier to manage.
- Pulls some members of `ViewContainer` out into `IViewContainer` as we further abstract out more of the older concrete implementations.

Tooltip ctors now have a new overload which can accept an `IToolTipView` to automatically be displayed within the Tooltip.