### PR TITLE
Nicer smoothed player position

### DIFF
--- a/Blish HUD/GameServices/Debug/RingBuffer[T].cs
+++ b/Blish HUD/GameServices/Debug/RingBuffer[T].cs
@@ -5,7 +5,7 @@
     /// <typeparam name="T">The <c>Type</c> the <see cref="RingBuffer{T}"/> contains.</typeparam>
     public class RingBuffer<T> {
 
-        protected int _ringIndex;
+        protected int _ringIndex = 0;
 
         /// <summary>
         /// The array backing this buffer.

--- a/Blish HUD/GameServices/Gw2Mumble/PlayerCharacter.cs
+++ b/Blish HUD/GameServices/Gw2Mumble/PlayerCharacter.cs
@@ -58,11 +58,11 @@ namespace Blish_HUD.Gw2Mumble {
 
         #endregion
 
-        private Logger logger = Logger.GetLogger<PlayerCharacter>();
-
         private Vector3 _position = Vector3.Zero;
         private Vector3 _forward  = Vector3.Forward;
         private Vector3? _lastCamDirection = null;
+
+        private const float _flushEpsilon = 0.0001f;
 
         /// <inheritdoc cref="IGw2MumbleClien t.AvatarPosition"/>
         public Vector3 Position => _position;
@@ -110,7 +110,7 @@ namespace Blish_HUD.Gw2Mumble {
             Matrix cam = Matrix.CreateLookAt(camPosition, camPosition + camDirection, new Vector3(0.0f, 1.0f, 0.0f));
             Matrix cami = Matrix.Invert(cam);
 
-            if (_lastCamDirection.HasValue && Vector3.DistanceSquared(_lastCamDirection.Value, camDirection) >= 0.00001f) {
+            if (_lastCamDirection.HasValue && Vector3.DistanceSquared(_lastCamDirection.Value, camDirection) >= _flushEpsilon) {
                 _positionBuffer.flush();
             }
 

--- a/Blish HUD/GameServices/Gw2Mumble/PlayerCharacter.cs
+++ b/Blish HUD/GameServices/Gw2Mumble/PlayerCharacter.cs
@@ -58,10 +58,13 @@ namespace Blish_HUD.Gw2Mumble {
 
         #endregion
 
+        private Logger logger = Logger.GetLogger<PlayerCharacter>();
+
         private Vector3 _position = Vector3.Zero;
         private Vector3 _forward  = Vector3.Forward;
+        private Vector3? _lastCamDirection = null;
 
-        /// <inheritdoc cref="IGw2MumbleClient.AvatarPosition"/>
+        /// <inheritdoc cref="IGw2MumbleClien t.AvatarPosition"/>
         public Vector3 Position => _position;
 
         /// <inheritdoc cref="IGw2MumbleClient.AvatarFront"/>
@@ -91,20 +94,35 @@ namespace Blish_HUD.Gw2Mumble {
         /// <inheritdoc cref="IGw2MumbleClient.Mount"/>
         public MountType CurrentMount => _service.RawClient.Mount;
 
-        private const int POSITIONBUFFER_MAXSIZE  = 12;
-        private const int POSITIONBUFFER_CURRSIZE = 8;
+        private const int POSITIONBUFFER_MAXSIZE  = 6;
 
-        private readonly DynamicallySmoothedValue<Vector3> _positionBuffer = new DynamicallySmoothedValue<Vector3>(POSITIONBUFFER_MAXSIZE, () => POSITIONBUFFER_CURRSIZE);
+        private readonly DynamicallySmoothedValue<Vector4> _positionBuffer = new DynamicallySmoothedValue<Vector4>(POSITIONBUFFER_MAXSIZE);
 
         internal PlayerCharacter(Gw2MumbleService service) {
             _service = service;
         }
 
         internal void Update(GameTime gameTime) {
-            _positionBuffer.PushValue(_service.RawClient.AvatarPosition.ToXnaVector3());
+            Vector3 camPosition = _service.RawClient.CameraPosition.ToXnaVector3();
+            Vector3 camDirection = _service.RawClient.CameraFront.ToXnaVector3();
+            Vector3 charPosition = _service.RawClient.AvatarPosition.ToXnaVector3();
+
+            Matrix cam = Matrix.CreateLookAt(camPosition, camPosition + camDirection, new Vector3(0.0f, 1.0f, 0.0f));
+            Matrix cami = Matrix.Invert(cam);
+
+            if (_lastCamDirection.HasValue && Vector3.DistanceSquared(_lastCamDirection.Value, camDirection) >= 0.00001f) {
+                _positionBuffer.flush();
+            }
+
+            _lastCamDirection = camDirection;
+
+            _positionBuffer.PushValue(Vector4.Transform(new Vector4(charPosition, 1.0f), cam));
+
+            Vector4 averagedCharPosition = Vector4.Transform(_positionBuffer.Value, cami);
+            averagedCharPosition = Vector4.Divide(averagedCharPosition, averagedCharPosition.W);
 
             _position = GameService.Graphics.SmoothCharacterPosition
-                            ? _positionBuffer.Value
+                            ? new Vector3(averagedCharPosition.X, averagedCharPosition.Y, averagedCharPosition.Z)
                             : _service.RawClient.AvatarPosition.ToXnaVector3();
             
             _forward  = _service.RawClient.AvatarFront.ToXnaVector3();


### PR DESCRIPTION
I changed the smoothing of the player position to be relative to the camera position as already done by gw2Taco.
This should result in a much smoother player position unless you rotate the camera and move at the same time.