### PR TITLE
Corrected multiple mouse capture issues

### DIFF
--- a/Blish HUD/Controls/Checkbox.cs
+++ b/Blish HUD/Controls/Checkbox.cs
@@ -63,10 +63,6 @@ namespace Blish_HUD.Controls {
             base.OnLeftMouseButtonReleased(e);
         }
 
-        protected override CaptureType CapturesInput() {
-            return CaptureType.Mouse;
-        }
-
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
             string state = "-unchecked";
             state = this.Checked ? "-checked" : state;

--- a/Blish HUD/Controls/ColorBox.cs
+++ b/Blish HUD/Controls/ColorBox.cs
@@ -80,10 +80,6 @@ namespace Blish_HUD.Controls {
             this.BasicTooltipText = this.Color?.Name ?? "None";
         }
 
-        protected override CaptureType CapturesInput() {
-            return CaptureType.Mouse;
-        }
-
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
             spriteBatch.DrawOnCtrl(this, _possibleDrawVariations[drawVariation], bounds, this.Color?.Cloth?.ToXnaColor() ?? Microsoft.Xna.Framework.Color.White);
 

--- a/Blish HUD/Controls/Container.cs
+++ b/Blish HUD/Controls/Container.cs
@@ -118,6 +118,8 @@ namespace Blish_HUD.Controls {
             set => SetProperty(ref _autoSizePadding, value);
         }
 
+        protected override CaptureType CapturesInput() => CaptureType.Mouse | CaptureType.MouseWheel;
+
         public List<Control> GetDescendants() {
             var allDescendants = _children.ToList();
 
@@ -189,7 +191,12 @@ namespace Blish_HUD.Controls {
                     childResult = childControl.TriggerMouseInput(mouseEventType, ms);
 
                     if (childResult != null) {
-                        break;
+                        if (!childResult.Captures.HasFlag(CaptureType.Filter)) {
+                            break;
+                        }
+
+                        // Child has Filter flag so we have to pretend we didn't see it
+                        childResult = null;
                     }
                 }
             }

--- a/Blish HUD/Controls/ContextMenuStripItem.cs
+++ b/Blish HUD/Controls/ContextMenuStripItem.cs
@@ -97,10 +97,6 @@ namespace Blish_HUD.Controls {
             base.OnMouseLeft(e);
         }
 
-        protected override CaptureType CapturesInput() {
-            return CaptureType.Mouse;
-        }
-
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
             var modifierTint = this.Enabled 
                                    ? this.MouseOver

--- a/Blish HUD/Controls/Control.cs
+++ b/Blish HUD/Controls/Control.cs
@@ -21,7 +21,7 @@ namespace Blish_HUD.Controls {
         None = 0x0,
 
         /// <summary>
-        /// Mouse input (moves and clicks) are intercepted but this control will not block input from passing to Guild Wars 2 or to other Blish HUD controls.
+        /// Mouse and mouse wheel inputs are intercepted but this control will not block input from passing to Guild Wars 2 or to other Blish HUD controls.
         /// </summary>
         Filter = 0x1,
 

--- a/Blish HUD/Controls/CornerIcon.cs
+++ b/Blish HUD/Controls/CornerIcon.cs
@@ -148,11 +148,6 @@ namespace Blish_HUD.Controls {
         }
 
         /// <inheritdoc />
-        protected override CaptureType CapturesInput() {
-            return CaptureType.Mouse;
-        }
-
-        /// <inheritdoc />
         protected override void OnClick(MouseEventArgs e) {
             Content.PlaySoundEffectByName(@"button-click");
 

--- a/Blish HUD/Controls/DetailsButton.cs
+++ b/Blish HUD/Controls/DetailsButton.cs
@@ -245,10 +245,6 @@ namespace Blish_HUD.Controls {
             this.EffectBehind = _scrollEffect;
         }
 
-        protected override CaptureType CapturesInput() {
-            return CaptureType.Mouse | CaptureType.Filter;
-        }
-
         protected override void OnMouseMoved(MouseEventArgs e) {
             _scrollEffect.SetEnableState(
                                          _highlightType == DetailsHighlightType.ScrollingHighlight

--- a/Blish HUD/Controls/Dropdown.cs
+++ b/Blish HUD/Controls/Dropdown.cs
@@ -248,11 +248,6 @@ namespace Blish_HUD.Controls {
             _hadPanel = false;
         }
 
-        /// <inheritdoc />
-        protected override CaptureType CapturesInput() {
-            return CaptureType.Mouse;
-        }
-
         protected override void OnClick(MouseEventArgs e) {
             base.OnClick(e);
 

--- a/Blish HUD/Controls/GlowButton.cs
+++ b/Blish HUD/Controls/GlowButton.cs
@@ -77,10 +77,6 @@ namespace Blish_HUD.Controls {
             return _glowEffect;
         }
 
-        protected override CaptureType CapturesInput() {
-            return CaptureType.Mouse;
-        }
-
         public GlowButton() {
             _spriteBatchParameters = new SpriteBatchParameters(SpriteSortMode.Immediate, BlendState.AlphaBlend);
             this.Size = new Point(BUTTON_WIDTH, BUTTON_HEIGHT);

--- a/Blish HUD/Controls/HealthPoolButton.cs
+++ b/Blish HUD/Controls/HealthPoolButton.cs
@@ -35,10 +35,6 @@ namespace Blish_HUD.Controls {
             base.OnLeftMouseButtonReleased(e);
         }
 
-        protected override CaptureType CapturesInput() {
-            return CaptureType.Mouse;
-        }
-
         private void UpdateLocation(object sender, EventArgs e) {
             this.Location = new Point((Graphics.SpriteScreen.Width / 2 - this.Width / 2), (Graphics.SpriteScreen.Height - this.Height) - BOTTOMEDGE_GAP);
         }

--- a/Blish HUD/Controls/KeybindingAssigner.cs
+++ b/Blish HUD/Controls/KeybindingAssigner.cs
@@ -106,8 +106,6 @@ namespace Blish_HUD.Controls {
             newHkAssign.Show();
         }
 
-        protected override CaptureType CapturesInput() { return CaptureType.Filter | CaptureType.Mouse; }
-
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
             // Draw white panel for keybinding name
             spriteBatch.DrawOnCtrl(this,

--- a/Blish HUD/Controls/LabelBase.cs
+++ b/Blish HUD/Controls/LabelBase.cs
@@ -25,10 +25,6 @@ namespace Blish_HUD.Controls {
             _font = Content.DefaultFont14;
         }
 
-        protected override CaptureType CapturesInput() {
-            return CaptureType.Filter;
-        }
-
         /// <summary>
         /// If either <see cref="_autoSizeWidth"/> or <see cref="_autoSizeHeight"/> is enabled,
         /// this will indicate the size of the label region after <see cref="RecalculateLayout"/>

--- a/Blish HUD/Controls/MenuItem.cs
+++ b/Blish HUD/Controls/MenuItem.cs
@@ -296,8 +296,6 @@ namespace Blish_HUD.Controls {
             base.OnMouseLeft(e);
         }
 
-        protected override CaptureType CapturesInput() => CaptureType.Mouse;
-
         protected override void OnChildAdded(ChildChangedEventArgs e) { 
             if (!(e.ChangedChild is MenuItem newChild)) {
                 e.Cancel = true;

--- a/Blish HUD/Controls/Screen.cs
+++ b/Blish HUD/Controls/Screen.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Xna.Framework.Input;
-
-namespace Blish_HUD.Controls {
+﻿namespace Blish_HUD.Controls {
     public class Screen:Container {
 
         public const int MENUUI_BASEINDEX      = 30; // Skillbox

--- a/Blish HUD/Controls/Screen.cs
+++ b/Blish HUD/Controls/Screen.cs
@@ -13,22 +13,10 @@ namespace Blish_HUD.Controls {
         public const int CONTEXTMENU_BASEINDEX = 50;
         public const int DROPDOWN_BASEINDEX    = int.MaxValue - 64;
         public const int TOOLTIP_BASEZINDEX    = int.MaxValue - 32;
-
-        /// <inheritdoc />
+        
         protected override CaptureType CapturesInput() {
             return CaptureType.None;
         }
-
-        //public override Control TriggerMouseInput(MouseEventType mouseEventType, MouseState ms) {
-        //    List<Control> ZSortedChildren = _children.OrderByDescending(i => i.ZIndex).ToList();
-
-        //    foreach (var childControl in ZSortedChildren) {
-        //        if (childControl.AbsoluteBounds.Contains(ms.Position) && childControl.Visible)
-        //            return childControl.TriggerMouseInput(mouseEventType, ms);
-        //    }
-
-        //    return null;
-        //}
 
     }
 }

--- a/Blish HUD/Controls/ScreenNotification.cs
+++ b/Blish HUD/Controls/ScreenNotification.cs
@@ -93,13 +93,11 @@ namespace Blish_HUD.Controls {
 
             _targetTop = this.Top;
         }
-
-        /// <inheritdoc />
+        
         protected override CaptureType CapturesInput() {
-            return CaptureType.ForceNone;
+            return CaptureType.Filter;
         }
-
-        /// <inheritdoc />
+        
         public override void RecalculateLayout() {
             switch (_type) {
                 case NotificationType.Info:

--- a/Blish HUD/Controls/StandardButton.cs
+++ b/Blish HUD/Controls/StandardButton.cs
@@ -61,10 +61,6 @@ namespace Blish_HUD.Controls {
             set => SetProperty(ref _resizeIcon, value, true);
         }
 
-        protected override CaptureType CapturesInput() {
-            return CaptureType.Mouse;
-        }
-
         /// <summary>
         /// Do not directly manipulate this property.  It is only public because the animation library requires it to be public.
         /// </summary>

--- a/Blish HUD/Controls/TabbedWindow.cs
+++ b/Blish HUD/Controls/TabbedWindow.cs
@@ -99,10 +99,6 @@ namespace Blish_HUD.Controls {
             this.TabChanged?.Invoke(this, e);
         }
 
-        protected override CaptureType CapturesInput() {
-            return CaptureType.Mouse | CaptureType.MouseWheel | CaptureType.Filter;
-        }
-
         protected override void OnMouseLeft(MouseEventArgs e) {
             this.HoveredTabIndex = -1;
 

--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -723,8 +723,6 @@ namespace Blish_HUD.Controls {
             HandleMouseUpdatedCursorIndex(GetCursorIndexFromPosition(this.RelativeMousePosition), e.IsDoubleClick);
         }
 
-        protected override CaptureType CapturesInput() { return CaptureType.Mouse; }
-
         protected void PaintText(SpriteBatch spriteBatch, Rectangle textRegion) {
             // Draw the placeholder text
             if (!_focused && _text.Length == 0) {

--- a/Blish HUD/Controls/TrackBar.cs
+++ b/Blish HUD/Controls/TrackBar.cs
@@ -107,10 +107,6 @@ namespace Blish_HUD.Controls {
             }
         }
 
-        protected override CaptureType CapturesInput() {
-            return CaptureType.Mouse;
-        }
-
         private Rectangle _layoutNubBounds;
         private Rectangle _layoutLeftBumper;
         private Rectangle _layoutRightBumper;

--- a/Blish HUD/Controls/WindowBase.cs
+++ b/Blish HUD/Controls/WindowBase.cs
@@ -271,10 +271,6 @@ namespace Blish_HUD.Controls {
             base.OnMouseLeft(e);
         }
 
-        protected override CaptureType CapturesInput() {
-            return CaptureType.Mouse | CaptureType.MouseWheel | CaptureType.Filter;
-        }
-
         protected override void OnLeftMouseButtonPressed(MouseEventArgs e) {
             if (MouseOverTitleBar) {
                 Dragging  = true;


### PR DESCRIPTION
CaptureTypes are now all implemented.  Revised the implementation of some.

Updated MouseHandler to simplify the hook overriding logic (DoNotBlock CaptureType) and corrected implementation in Control class. Updated defaults and removed unnecessary overrides from the other controls.

Added debounce to context menus to prevent them mistakenly closing if a click is registered just after they're opened (within 100ms).

Removed duplicate event firings from mouse handling now that more event types are captured and handled by the hook correctly.

Fixes #130 
Fixed some right-click events not firing.

CaptureType.ForceNone was renamed to `DoNotBlock` to better describe it's purpose and swapped it with the `Filter` capture type to avoid breaking changes.  Existing modules will not break but, the capture type will need to be renamed to match the enum when they are next rebuilt.