### PR TITLE
Fix for alt-tabbing out of input controls

### DIFF
--- a/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
@@ -64,7 +64,8 @@ namespace Blish_HUD.Input {
             Keys.LeftAlt,
             Keys.RightAlt,
             Keys.LeftShift,
-            Keys.RightShift
+            Keys.RightShift,
+            Keys.Tab
         };
 
         /// <summary>

--- a/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
@@ -54,6 +54,7 @@ namespace Blish_HUD.Input {
         private readonly List<Keys> _keysDown = new List<Keys>();
 
         // Keys which, when pressed, should never be captured exclusively by the keyboard hook
+        // TODO: implement a more elegant way to not capture global hotkeys
         private readonly HashSet<Keys> _hookIgnoredKeys = new HashSet<Keys>() {
             Keys.NumLock,
             Keys.CapsLock,


### PR DESCRIPTION
Tab is no longer considered to be captured exclusively because of global ALT-Tab hotkey:

https://discord.com/channels/531175899588984842/534492173362528287/882301824349122620