### PR TITLE
Make Blish portable by creating a Settings directory in path

### DIFF
--- a/Blish HUD/_Utils/DirectoryUtil.cs
+++ b/Blish HUD/_Utils/DirectoryUtil.cs
@@ -39,9 +39,12 @@ namespace Blish_HUD {
             // Check if current working directory contains "Settings" folder
             // in that case override MyDocuments location as default for portability
             // --settings cli argument has still priority
-            if (Directory.Exists(Path.Combine(Directory.GetCurrentDirectory(), @"Settings"))) {
+            string BlishExeFilePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
+
+
+            if (Directory.Exists(Path.Combine(Path.GetDirectoryName(BlishExeFilePath), @"Settings"))) {
                 BasePath = ApplicationSettings.Instance.UserSettingsPath
-                        ?? Path.Combine(Directory.GetCurrentDirectory(), @"Settings");
+                        ?? Path.Combine(Path.GetDirectoryName(BlishExeFilePath), @"Settings");
             }
             else {
                 BasePath = ApplicationSettings.Instance.UserSettingsPath

--- a/Blish HUD/_Utils/DirectoryUtil.cs
+++ b/Blish HUD/_Utils/DirectoryUtil.cs
@@ -36,17 +36,13 @@ namespace Blish_HUD {
 
         static DirectoryUtil() {
             // Prepare user documents directory
-            // Check if current working directory contains "Settings" folder
+            // Check if Blish directory contains "Settings" folder
             // in that case override MyDocuments location as default for portability
             // --settings cli argument has still priority
-            string BlishExeFilePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
-
-
-            if (Directory.Exists(Path.Combine(Path.GetDirectoryName(BlishExeFilePath), @"Settings"))) {
+            if (Directory.Exists(Path.Combine(Directory.GetCurrentDirectory(), "Settings"))) {
                 BasePath = ApplicationSettings.Instance.UserSettingsPath
-                        ?? Path.Combine(Path.GetDirectoryName(BlishExeFilePath), @"Settings");
-            }
-            else {
+                        ?? Path.Combine(Directory.GetCurrentDirectory(), "Settings");
+            } else {
                 BasePath = ApplicationSettings.Instance.UserSettingsPath
                         ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments,
                                                                    Environment.SpecialFolderOption.DoNotVerify),

--- a/Blish HUD/_Utils/DirectoryUtil.cs
+++ b/Blish HUD/_Utils/DirectoryUtil.cs
@@ -36,10 +36,19 @@ namespace Blish_HUD {
 
         static DirectoryUtil() {
             // Prepare user documents directory
-            BasePath = ApplicationSettings.Instance.UserSettingsPath
-                    ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments,
-                                                               Environment.SpecialFolderOption.DoNotVerify), 
-                                    ADDON_DIR);
+            // Check if current working directory contains "Settings" folder
+            // in that case override MyDocuments location as default for portability
+            // --settings cli argument has still priority
+            if (Directory.Exists(Path.Combine(Directory.GetCurrentDirectory(), @"Settings"))) {
+                BasePath = ApplicationSettings.Instance.UserSettingsPath
+                        ?? Path.Combine(Directory.GetCurrentDirectory(), @"Settings");
+            }
+            else {
+                BasePath = ApplicationSettings.Instance.UserSettingsPath
+                        ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments,
+                                                                   Environment.SpecialFolderOption.DoNotVerify),
+                                        ADDON_DIR);
+            }
 
             Directory.CreateDirectory(BasePath);
 


### PR DESCRIPTION
Creating a 'Settings' directory in Blish will shift all settings to be defaulted to there instead of 'My Documents'.

This helps with easy portable deployment without using `--setting` parameter.

`--settings` is still honored if set as parameter.