### PR TITLE
Ensure compliance is applied prior to values.

### DIFF
--- a/Blish HUD/GameServices/Settings/UI/Presenters/SettingPresenter.cs
+++ b/Blish HUD/GameServices/Settings/UI/Presenters/SettingPresenter.cs
@@ -31,8 +31,8 @@ namespace Blish_HUD.Settings.UI.Presenters {
         }
 
         protected override void UpdateView() {
-            UpdateViewDetails();
             UpdateViewComplianceRequisite();
+            UpdateViewDetails();
 
             _changeReady = true;
         }


### PR DESCRIPTION
Ensure compliance is applied to setting views before the value is applied (to avoid clamping prior to expanding the range).

This fixes the bug seen in the pathing module which shows the view distance clamped to one side.

Closes #430 