### PR TITLE
Make sure that the cancellation token is not null

### DIFF
--- a/Blish HUD/GameServices/ArcDps/SocketListener/SocketListener.cs
+++ b/Blish HUD/GameServices/ArcDps/SocketListener/SocketListener.cs
@@ -54,7 +54,7 @@ namespace Blish_HUD.ArcDps {
         }
 
         public void Stop() {
-            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource?.Cancel();
         }
 
         public void Release(Socket listenSocket) {


### PR DESCRIPTION
When debugging, I occasionally get a NullReferenceException when closing Blish HUD. I've tracked it down to this line.