### PR TITLE
Render service now fails gracefully

### DIFF
--- a/Blish HUD/GameServices/Content/AsyncTexture2D.cs
+++ b/Blish HUD/GameServices/Content/AsyncTexture2D.cs
@@ -1,12 +1,7 @@
-using Blish_HUD;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Octokit;
 
 namespace Blish_HUD.Content {
     /// <summary>

--- a/Blish HUD/GameServices/ContentService.cs
+++ b/Blish HUD/GameServices/ContentService.cs
@@ -253,19 +253,25 @@ namespace Blish_HUD {
 
             Gw2WebApi.AnonymousConnection.Client.Render.DownloadToByteArrayAsync(requestUrl)
                      .ContinueWith((textureDataResponse) => {
-                        if (textureDataResponse.Exception != null) {
-                            Logger.Warn(textureDataResponse.Exception, "Request to render service for {textureUrl} failed.", requestUrl);
-                            return;
-                        }
+                                       if (textureDataResponse.Exception != null) {
+                                           Logger.Warn(textureDataResponse.Exception, "Request to render service for {textureUrl} failed.", requestUrl);
+                                           return;
+                                       }
 
-                        var textureData = textureDataResponse.Result;
+                                       try {
+                                           var textureData = textureDataResponse.Result;
 
-                        using (var textureStream = new MemoryStream(textureData)) {
-                            var loadedTexture = TextureUtil.FromStreamPremultiplied(Graphics.GraphicsDevice, textureStream);
+                                           using (var textureStream = new MemoryStream(textureData)) {
+                                               var loadedTexture = TextureUtil.FromStreamPremultiplied(Graphics.GraphicsDevice, textureStream);
 
-                            returnedTexture.SwapTexture(loadedTexture);
-                        }
-                     });
+                                               returnedTexture.SwapTexture(loadedTexture);
+                                           }
+                                       } catch (Exception ex) {
+                                           Logger.Warn(ex, $"Render service texture {requestUrl} failed to load.");
+
+                                           returnedTexture.SwapTexture(Textures.Error);
+                                       }
+                                   });
 
             return returnedTexture;
         }


### PR DESCRIPTION
Currently the render service can be down and we end up attempting to send either garbled data or no data to our texture loader which then crashes Blish HUD.

This PR instead catches that and just returns the error texture instead.