### PR TITLE
Ensure we don't render on desktop if game is minimized

### DIFF
--- a/Blish HUD/GameServices/GameIntegrationService.cs
+++ b/Blish HUD/GameServices/GameIntegrationService.cs
@@ -305,6 +305,8 @@ namespace Blish_HUD {
                         }
                         break;
                 }
+
+                BlishHud.Instance.Form.Visible = !updateResult.Minimized;
             } else {
                 TryAttachToGw2();
             }


### PR DESCRIPTION
Instead of relying on focus order, we just detect if the game is minimized and set our parent form visibility to match as appropriate. 

Fixes #428 