### PR TITLE
Support custom setting panels

### DIFF
--- a/Blish HUD/GameServices/Modules/Module.cs
+++ b/Blish HUD/GameServices/Modules/Module.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
+using Blish_HUD.Graphics.UI;
 using Blish_HUD.Settings;
+using Blish_HUD.Settings.UI.Views;
 using Microsoft.Xna.Framework;
 
 namespace Blish_HUD.Modules {
@@ -164,12 +166,16 @@ namespace Blish_HUD.Modules {
         protected virtual void DefineSettings(SettingCollection settings) { /* NOOP */ }
 
         /// <summary>
-        /// Load content and more here. This call is asynchronous, so it is a good time to
-        /// run any long running steps for your module. Be careful when instancing
-        /// <see cref="Blish_HUD.Entities.Entity"/> and <see cref="Blish_HUD.Controls.Control"/>.
-        /// Setting their parent is not thread-safe and can cause the application to crash.
-        /// You will want to queue them to add later while on the main thread or in a delegate queued
-        /// with <see cref="OverlayService.QueueMainThreadUpdate(Action{GameTime})"/>.
+        /// The <see cref="IView"/> to display in the settings area of the module when it is enabled.
+        /// By default, this is a <see cref="SettingsView"/> of your module settings.
+        /// </summary>
+        public virtual IView GetSettingsView() {
+            return new SettingsView(this.ModuleParameters.SettingsManager.ModuleSettings);
+        }
+
+        /// <summary>
+        /// Load content and more here. This call is asynchronous, so it is a good time to run
+        /// any long running steps for your module including loading resources from file or ref.
         /// </summary>
         protected virtual async Task LoadAsync() { /* NOOP */ }
 

--- a/Blish HUD/GameServices/Modules/UI/Presenters/ManageModulePresenter.cs
+++ b/Blish HUD/GameServices/Modules/UI/Presenters/ManageModulePresenter.cs
@@ -13,6 +13,8 @@ using Humanizer;
 namespace Blish_HUD.Modules.UI.Presenters {
     public class ManageModulePresenter : Presenter<ManageModuleView, ModuleManager> {
 
+        private static readonly Logger Logger = Logger.GetLogger<ManageModulePresenter>();
+
         public ManageModulePresenter(ManageModuleView view, ModuleManager model) : base(view, model) { /* NOOP */ }
 
         private ModulePermissionView _permissionView;
@@ -130,10 +132,14 @@ namespace Blish_HUD.Modules.UI.Presenters {
         }
 
         private void DisplaySettingsView(bool enable) {
-            SettingsView toDisplay = null;
+            IView toDisplay = null;
 
             if (enable) {
-                toDisplay = new SettingsView(this.Model.State.Settings);
+                try {
+                    toDisplay = this.Model.ModuleInstance.GetSettingsView();
+                } catch (Exception ex) {
+                    Logger.Warn(ex, $"Failed to load settings view from module '{this.Model.Manifest.GetDetailedName()}'.");
+                }
             }
 
             this.View.SetSettingsView(toDisplay);

--- a/Blish HUD/GameServices/Modules/UI/Views/ManageModuleView.cs
+++ b/Blish HUD/GameServices/Modules/UI/Views/ManageModuleView.cs
@@ -269,7 +269,7 @@ namespace Blish_HUD.Modules.UI.Views {
             // Description
 
             _descriptionPanel = new Panel() {
-                Size       = new Point(_collapsePanel.ContentRegion.Width, 180),
+                Size       = new Point(_collapsePanel.ContentRegion.Width, 125),
                 Title      = Strings.GameServices.ModulesService.ModuleManagement_Description,
                 ShowBorder = true,
                 CanScroll  = true,
@@ -287,7 +287,7 @@ namespace Blish_HUD.Modules.UI.Views {
             // Permissions
 
             _permissionView = new ViewContainer() {
-                Size     = _descriptionPanel.Size - new Point(350, 40),
+                Size     = _descriptionPanel.Size - new Point(350, 0),
                 Location = new Point(0, _descriptionPanel.Bottom + Panel.MenuStandard.ControlOffset.Y),
                 Parent   = _collapsePanel
             };
@@ -306,7 +306,7 @@ namespace Blish_HUD.Modules.UI.Views {
                 CanScroll  = true,
                 ShowBorder = true,
                 Title      = Strings.GameServices.ModulesService.ModuleManagement_ModuleSettings,
-                Size       = new Point(_dependencyView.Right - _permissionView.Left - 10, 222),
+                Size       = new Point(_dependencyView.Right - _permissionView.Left - 10, 320),
                 Location   = new Point(_permissionView.Left,                         _permissionView.Bottom + Panel.MenuStandard.ControlOffset.Y),
                 Parent     = _collapsePanel
             };

--- a/Blish HUD/GameServices/Modules/UI/Views/ManageModuleView.cs
+++ b/Blish HUD/GameServices/Modules/UI/Views/ManageModuleView.cs
@@ -140,7 +140,7 @@ namespace Blish_HUD.Modules.UI.Views {
             _dependencyView.Show(view);
         }
 
-        public void SetSettingsView(SettingsView view) {
+        public void SetSettingsView(IView view) {
             _settingMessageLabel.Hide();
             _settingView.Show(view);
 

--- a/Blish HUD/GameServices/Overlay/UI/Views/AboutView.cs
+++ b/Blish HUD/GameServices/Overlay/UI/Views/AboutView.cs
@@ -10,23 +10,23 @@ namespace Blish_HUD.Overlay.UI.Views {
         protected override void Build(Container buildPanel) {
             _ = new Image(GameService.Content.GetTexture("1025164")) {
                 SpriteEffects = SpriteEffects.FlipHorizontally | SpriteEffects.FlipVertically,
-                Location = new Point(buildPanel.Width - 1024 + 100 - 45, buildPanel.Height - 256 + 100 - 63 + 15),
-                ClipsBounds = false,
-                Parent = buildPanel
+                Location      = new Point(buildPanel.Width - 969, buildPanel.Height - 220),
+                ClipsBounds   = false,
+                Parent        = buildPanel
             };
 
             var gw2CopyrightStatement = new Label() {
-                Font = GameService.Content.DefaultFont16,
-                Text = string.Format(Strings.GameServices.OverlayService.AboutAnetNotice, DateTime.Now.Year),
-                AutoSizeHeight = true,
-                Width = buildPanel.Width,
-                StrokeText = true,
+                Font                = GameService.Content.DefaultFont16,
+                Text                = string.Format(Strings.GameServices.OverlayService.AboutAnetNotice, DateTime.Now.Year),
+                AutoSizeHeight      = true,
+                Width               = buildPanel.Width,
+                StrokeText          = true,
                 HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Top,
-                Parent = buildPanel
+                VerticalAlignment   = VerticalAlignment.Top,
+                Parent              = buildPanel
             };
 
-            gw2CopyrightStatement.Location = new Point(0, buildPanel.Height - gw2CopyrightStatement.Height - 48);
+            gw2CopyrightStatement.Location = new Point(0, buildPanel.Height - gw2CopyrightStatement.Height - 64);
 
             var lovePanel = new Panel() {
                 Size = new Point(buildPanel.Width - 128, 128),
@@ -54,15 +54,15 @@ namespace Blish_HUD.Overlay.UI.Views {
 
             var version = new Label() {
                 AutoSizeHeight = true,
-                AutoSizeWidth = true,
-                Text = $"Blish HUD v{Program.OverlayVersion}",
-                Font = GameService.Content.DefaultFont14,
-                StrokeText = true,
-                ClipsBounds = false,
-                Parent = buildPanel
+                AutoSizeWidth  = true,
+                Text           = $"Blish HUD v{Program.OverlayVersion}",
+                Font           = GameService.Content.DefaultFont14,
+                StrokeText     = true,
+                ClipsBounds    = false,
+                Parent         = buildPanel
             };
 
-            version.Location = new Point(buildPanel.Width - version.Width + 8, buildPanel.Height - version.Height + 24);
+            version.Location = new Point(buildPanel.Width - version.Width + 8, buildPanel.Height - version.Height);
         }
 
     }

--- a/Blish HUD/GameServices/Settings/UI/Views/SettingsMenuView.cs
+++ b/Blish HUD/GameServices/Settings/UI/Views/SettingsMenuView.cs
@@ -46,8 +46,8 @@ namespace Blish_HUD.Settings.UI.Views {
 
             _settingViewContainer = new ViewContainer() {
                 FadeView = true,
-                Size     = new Point(718, buildPanel.Size.Y - 24 * 2),
-                Location = new Point(buildPanel.Width       - 740, 10),
+                Size     = new Point(718,                    settingsMenuSection.Height),
+                Location = new Point(buildPanel.Width - 740, 10),
                 Parent   = buildPanel
             };
         }


### PR DESCRIPTION
This PR introduces `GetSettingsView` to modules which can let them provide their own settings `IView` to be displayed on the manage module page.

If this function is not overridden, we simply default back to displaying the modules root setting collection as we were previously.

We also adjust the sizing of the different sections in the manage module view to give more visibility to settings and reduce some of the unnecessary white space most module descriptions have.