### PR TITLE
Modification to frame limiter options

### DIFF
--- a/Blish HUD/BlishHud.cs
+++ b/Blish HUD/BlishHud.cs
@@ -135,7 +135,19 @@ namespace Blish_HUD {
 
         private float _drawLag;
 
+        private bool _skipDraw = false;
+
+        internal void SkipDraw() {
+            _skipDraw = true;
+        }
+
         protected override void Draw(GameTime gameTime) {
+            if (_skipDraw) {
+                Thread.Sleep(1);
+                _skipDraw = false;
+                return;
+            }
+
             GameService.Debug.TickFrameCounter(_drawLag);
             _drawLag = 0;
 

--- a/Blish HUD/GameServices/Graphics/FramerateMethod.cs
+++ b/Blish HUD/GameServices/Graphics/FramerateMethod.cs
@@ -1,9 +1,12 @@
 ﻿namespace Blish_HUD.Graphics {
+
     public enum FramerateMethod : int {
-        Custom        = -1,
-        SyncWithGame  = 0,
-        LockedTo30Fps = 1,
-        LockedTo60Fps = 2,
-        Unlimited     = 3,
+        Custom         = -1,
+        SyncWithGame   = 0,
+        LockedTo30Fps  = 1,
+        LockedTo60Fps  = 2,
+        LockedTo90Fps  = 3,
+        Unlimited      = 4,
     }
+
 }

--- a/Blish HUD/GameServices/GraphicsService.cs
+++ b/Blish HUD/GameServices/GraphicsService.cs
@@ -191,6 +191,10 @@ namespace Blish_HUD {
                     BlishHud.Instance.IsFixedTimeStep   = true;
                     BlishHud.Instance.TargetElapsedTime = TimeSpan.FromSeconds(1d / 60d);
                     break;
+                case FramerateMethod.LockedTo90Fps:
+                    BlishHud.Instance.IsFixedTimeStep   = true;
+                    BlishHud.Instance.TargetElapsedTime = TimeSpan.FromSeconds(1d / 90d);
+                    break;
                 case FramerateMethod.Unlimited:
                     BlishHud.Instance.IsFixedTimeStep   = false;
                     BlishHud.Instance.TargetElapsedTime = TimeSpan.FromMilliseconds(1);

--- a/Blish HUD/GameServices/Gw2MumbleService.cs
+++ b/Blish HUD/GameServices/Gw2MumbleService.cs
@@ -96,7 +96,7 @@ namespace Blish_HUD {
                     && GameService.GameIntegration.Gw2IsRunning
                     && this.TimeSinceTick.TotalSeconds < 0.5) {
 
-                    BlishHud.Instance.SuppressDraw();
+                    BlishHud.Instance.SkipDraw();
                 }
             }
         }


### PR DESCRIPTION
This addresses an issue with the sync with game frame limiter option.  Previously we would defer rendering which would result in the update loop essentially going as fast as it can causing CPU usage to increase often times up to 5% on some systems which is unreasonably high.

This change introduces a short sleep into the render call if sync with game is enabled and is asked to defer the render.  This prevents the update loop from spinning out of control.  This resolves the CPU utilization issue and brings us back down to the 1-2% range.

For flexibility's sake, this PR also adds a 90 FPS lock.  Anything higher than 110'ish starts running into sleep timer accuracy issues, so 90 seems like a decent place to stop.