### PR TITLE
Window bugs

### DIFF
--- a/Blish HUD/Controls/StandardWindow.cs
+++ b/Blish HUD/Controls/StandardWindow.cs
@@ -26,9 +26,9 @@ namespace Blish_HUD.Controls {
         /// </summary>
         public void ToggleWindow(IView view) {
             if (this.Visible) {
-                Show(view);
-            } else {
                 Hide();
+            } else {
+                Show(view);
             }
         }
 

--- a/Blish HUD/Controls/TabbedWindow2.cs
+++ b/Blish HUD/Controls/TabbedWindow2.cs
@@ -65,7 +65,7 @@ namespace Blish_HUD.Controls {
         }
 
         protected override void OnClick(MouseEventArgs e) {
-            if (this.HoveredTab != null && this.HoveredTab.Enabled) {
+            if (this.HoveredTab is { Enabled: true }) {
                 this.SelectedTab = this.HoveredTab;
             }
 
@@ -106,7 +106,7 @@ namespace Blish_HUD.Controls {
 
                     spriteBatch.DrawOnCtrl(this,
                                            this.WindowBackground,
-                                           tabBounds.OffsetBy(0, 0),
+                                           tabBounds,
                                            new Rectangle(this.WindowRegion.Left + tabBounds.X,
                                                          tabBounds.Y - (int)this.Padding.Top,
                                                          tabBounds.Width,

--- a/Blish HUD/Controls/TabbedWindow2.cs
+++ b/Blish HUD/Controls/TabbedWindow2.cs
@@ -106,8 +106,8 @@ namespace Blish_HUD.Controls {
 
                     spriteBatch.DrawOnCtrl(this,
                                            this.WindowBackground,
-                                           tabBounds.OffsetBy(2, 0),
-                                           new Rectangle(this.WindowRegion.Left + tabBounds.X + 2,
+                                           tabBounds.OffsetBy(0, 0),
+                                           new Rectangle(this.WindowRegion.Left + tabBounds.X,
                                                          tabBounds.Y - (int)this.Padding.Top,
                                                          tabBounds.Width,
                                                          tabBounds.Height));

--- a/Blish HUD/Controls/WindowBase2.cs
+++ b/Blish HUD/Controls/WindowBase2.cs
@@ -22,7 +22,8 @@ namespace Blish_HUD.Controls {
 
         private const int STANDARD_MARGIN = 16; // Standard margin used to space the "X" button, etc.
 
-        private const int SIDEBAR_WIDTH = 46;
+        private const int SIDEBAR_WIDTH  = 46;
+        private const int SIDEBAR_OFFSET = 3; // Used to account for the small edge of transparency at the bottom of the titlebar and between the sidebar and the window background
 
         #region Load Static
 
@@ -398,8 +399,8 @@ namespace Blish_HUD.Controls {
             int sideBarTop        = _leftTitleBarDrawBounds.Bottom - STANDARD_TITLEBAR_VERTICAL_OFFSET;
             int sideBarHeight     = this.WindowRegion.Height       + STANDARD_TITLEBAR_VERTICAL_OFFSET;
 
-            this.SidebarActiveBounds   = new Rectangle(_leftTitleBarDrawBounds.X, sideBarTop, SIDEBAR_WIDTH, this.SideBarHeight);
-            _sidebarInactiveDrawBounds = new Rectangle(_leftTitleBarDrawBounds.X, sideBarTop + this.SideBarHeight, SIDEBAR_WIDTH, sideBarHeight - this.SideBarHeight);
+            this.SidebarActiveBounds   = new Rectangle(_leftTitleBarDrawBounds.X + SIDEBAR_OFFSET, sideBarTop - SIDEBAR_OFFSET,                      SIDEBAR_WIDTH, this.SideBarHeight);
+            _sidebarInactiveDrawBounds = new Rectangle(_leftTitleBarDrawBounds.X + SIDEBAR_OFFSET, sideBarTop - SIDEBAR_OFFSET + this.SideBarHeight, SIDEBAR_WIDTH, sideBarHeight - this.SideBarHeight);
 
             // Corner bounds
             this.ResizeHandleBounds = new Rectangle(this.Width  - _textureWindowCorner.Width,

--- a/Blish HUD/Controls/WindowBase2.cs
+++ b/Blish HUD/Controls/WindowBase2.cs
@@ -240,9 +240,9 @@ namespace Blish_HUD.Controls {
         /// </summary>
         public void ToggleWindow() {
             if (this.Visible) {
-                Show();
-            } else {
                 Hide();
+            } else {
+                Show();
             }
         }
 

--- a/Blish HUD/Controls/_Types/Tab.cs
+++ b/Blish HUD/Controls/_Types/Tab.cs
@@ -42,7 +42,7 @@ namespace Blish_HUD.Controls {
         public Tab(AsyncTexture2D icon, Func<IView> view, string name = null, int? priority = null) {
             this.Icon          = icon;
             this.Name          = name;
-            this.OrderPriority = priority ?? icon.GetHashCode();
+            this.OrderPriority = priority ?? 0;
             this.View          = view;
         }
 

--- a/Blish HUD/Controls/_Types/TabCollection.cs
+++ b/Blish HUD/Controls/_Types/TabCollection.cs
@@ -25,7 +25,7 @@ namespace Blish_HUD.Controls {
         }
 
         public void Add(Tab item) {
-            _tabs = new List<Tab>(_tabs.Concat(new []{ item }).OrderByDescending(tab => tab.OrderPriority));
+            _tabs = new List<Tab>(_tabs.Concat(new []{ item }).OrderBy(tab => tab.OrderPriority));
 
             if (_tabs.Count == 1) {
                 _owner.SelectedTab = item;

--- a/Blish HUD/Controls/_Types/TabCollection.cs
+++ b/Blish HUD/Controls/_Types/TabCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -24,11 +25,17 @@ namespace Blish_HUD.Controls {
             return GetEnumerator();
         }
 
-        public void Add(Tab item) {
-            _tabs = new List<Tab>(_tabs.Concat(new []{ item }).OrderBy(tab => tab.OrderPriority));
+        public void Add(Tab tab) {
+            if (tab == null) throw new ArgumentNullException(nameof(tab));
+
+            if (tab.OrderPriority == 0) {
+                tab.OrderPriority = _tabs.Count;
+            }
+
+            _tabs = new List<Tab>(_tabs.Concat(new []{ tab }).OrderBy(t => t.OrderPriority));
 
             if (_tabs.Count == 1) {
-                _owner.SelectedTab = item;
+                _owner.SelectedTab = tab;
             }
         }
 
@@ -46,8 +53,8 @@ namespace Blish_HUD.Controls {
             _tabs.CopyTo(array, arrayIndex);
         }
 
-        public bool Remove(Tab item) {
-            return _tabs.Remove(item);
+        public bool Remove(Tab tab) {
+            return _tabs.Remove(tab);
         }
 
         /// <summary>

--- a/Blish HUD/GameServices/Settings/UI/Views/SettingsView.cs
+++ b/Blish HUD/GameServices/Settings/UI/Views/SettingsView.cs
@@ -36,8 +36,6 @@ namespace Blish_HUD.Settings.UI.Views {
 
             _settingFlowPanel.ShowBorder  = !locked;
             _settingFlowPanel.CanCollapse = !locked;
-
-            this.ViewTarget.HeightSizingMode = SizingMode.AutoSize;
         }
 
         protected override void BuildSetting(Container buildPanel) {


### PR DESCRIPTION
After working more to implement windows with the new WindowBase2, etc. controls, I noticed a few minor issues which have now been cleaned up:

- Gap between the sidebar and main window.
- Tab order is mistakenly reversed.
- ToggleWindow was mistakenly reversed.
- Default window tab order to the order that they're added instead of hash.
- SettingView was changing the sizing mode of the parent container.