### PR TITLE
Only let the submenu open if the control is enabled.

### DIFF
--- a/Blish HUD/Controls/ContextMenuStripItem.cs
+++ b/Blish HUD/Controls/ContextMenuStripItem.cs
@@ -85,7 +85,9 @@ namespace Blish_HUD.Controls {
         }
 
         protected override void OnMouseEntered(MouseEventArgs e) {
-            this.Submenu?.Show(this);
+            if (this.Enabled) {
+                this.Submenu?.Show(this);
+            }
 
             base.OnMouseEntered(e);
         }


### PR DESCRIPTION
Prevent submenus from showing if the menu item is not enabled.