### PR TITLE
Allow using a custom Tooltip for CornerIcon

### DIFF
--- a/Blish HUD/Controls/CornerIcon.cs
+++ b/Blish HUD/Controls/CornerIcon.cs
@@ -166,8 +166,10 @@ namespace Blish_HUD.Controls {
         protected override void OnMouseMoved(MouseEventArgs e) {
             if (_isLoading && _mouseOver && this.RelativeMousePosition.Y >= _standardIconBounds.Bottom) {
                 this.BasicTooltipText = _loadingMessage;
-            } else {
+            } else if (this.Tooltip == null) {
                 this.BasicTooltipText = _iconName;
+            } else {
+                this.BasicTooltipText = null;
             }
 
             base.OnMouseMoved(e);


### PR DESCRIPTION
Hi! This is my first PR here! I am tinkering with creating a module for Blish HUD and I wanted to use a custom `Tooltip` for a `CornerIcon`. I saw that the code for `CornerIcon` is always setting `BasicTooltipText` so it is not really allowing that, as `Control` uses this field with more priority.

Does this look like a good approach? Feel free to change whatever or let me know if I need to make any changes!

BTW, I am Fogokhost#5194 on Discord 😄