### PR TITLE
Add extended key support to Keyboard

### DIFF
--- a/Blish HUD/Controls/Extern/ScanCodeShort.cs
+++ b/Blish HUD/Controls/Extern/ScanCodeShort.cs
@@ -174,5 +174,6 @@ namespace Blish_HUD.Controls.Extern
         NONAME = 0,
         PA1 = 0,
         OEM_CLEAR = 0,
+        EXTENDEDKEY = 224
     }
 }

--- a/Blish HUD/Controls/Intern/Keyboard.cs
+++ b/Blish HUD/Controls/Intern/Keyboard.cs
@@ -14,6 +14,14 @@ namespace Blish_HUD.Controls.Intern
         private const uint MAPVK_VSC_TO_VK_EX = 0x03;
         private const uint MAPVK_VK_TO_VSC_EX = 0x04;
 
+        private static List<VirtualKeyShort> ExtendedKeys = new List<VirtualKeyShort> {
+            VirtualKeyShort.INSERT,  VirtualKeyShort.HOME,   VirtualKeyShort.NEXT, 
+            VirtualKeyShort.DELETE,  VirtualKeyShort.END,    VirtualKeyShort.PRIOR,
+            VirtualKeyShort.RMENU,   VirtualKeyShort.RSHIFT, VirtualKeyShort.RCONTROL,
+            VirtualKeyShort.UP,      VirtualKeyShort.DOWN,   VirtualKeyShort.LEFT,     VirtualKeyShort.RIGHT,
+            VirtualKeyShort.NUMLOCK, VirtualKeyShort.PRINT
+        };
+
         /// <summary>
         /// Presses a key.
         /// </summary>
@@ -23,29 +31,64 @@ namespace Blish_HUD.Controls.Intern
         {
             if (!GameService.GameIntegration.Gw2Proc.Gw2IsRunning || sendToSystem)
             {
-                var nInputs = new[]
-                {
-                    new Extern.Input
+                Extern.Input[] nInputs;
+                if (ExtendedKeys.Contains(key)) {
+                    nInputs = new[]
                     {
-                        type = InputType.KEYBOARD,
-                        U = new InputUnion
+                        new Extern.Input
                         {
-                            ki = new KeybdInput
+                            type = InputType.KEYBOARD,
+                            U = new InputUnion
                             {
-                                wScan = (ScanCodeShort)PInvoke.MapVirtualKey((uint)key, MAPVK_VK_TO_VSC),
-                                wVk = key
+                                ki = new KeybdInput
+                                {
+                                    wScan = ScanCodeShort.EXTENDEDKEY,
+                                    wVk = 0,
+                                    dwFlags = 0
+                                }
+                            }
+                        },
+                        new Extern.Input
+                        {
+                            type = InputType.KEYBOARD,
+                            U = new InputUnion
+                            {
+                                ki = new KeybdInput
+                                {
+                                    wScan = (ScanCodeShort)PInvoke.MapVirtualKey((uint)key, MAPVK_VK_TO_VSC),
+                                    wVk = key,
+                                    dwFlags = KeyEventF.EXTENDEDKEY
+                                }
                             }
                         }
-                    }
-                };
+                    };
+                } else {
+                    nInputs = new[]
+                    {
+                        new Extern.Input
+                        {
+                            type = InputType.KEYBOARD,
+                            U = new InputUnion
+                            {
+                                ki = new KeybdInput
+                                {
+                                    wScan = (ScanCodeShort)PInvoke.MapVirtualKey((uint)key, MAPVK_VK_TO_VSC),
+                                    wVk = key
+                                }
+                            }
+                        }
+                    };
+                }
                 PInvoke.SendInput((uint)nInputs.Length, nInputs, Extern.Input.Size);
             }
             else
             {
                 uint vkCode = (uint)key;
-                ExtraKeyInfo lParam = new ExtraKeyInfo(){
+                ExtraKeyInfo lParam = new ExtraKeyInfo() {
                     scanCode = (char)PInvoke.MapVirtualKey(vkCode, MAPVK_VK_TO_VSC)
                 };
+                if (ExtendedKeys.Contains(key))
+                    lParam.extendedKey = 1;
                 PInvoke.PostMessage(GameService.GameIntegration.Gw2Proc.Gw2WindowHandle, WM_KEYDOWN, vkCode, lParam.GetInt());
             }
         }
@@ -58,34 +101,68 @@ namespace Blish_HUD.Controls.Intern
         {
             if (!GameService.GameIntegration.Gw2Proc.Gw2IsRunning || sendToSystem)
             {
-                var nInputs = new[]
-                {
-                    new Extern.Input
+                Extern.Input[] nInputs;
+                if (ExtendedKeys.Contains(key)) {
+                    nInputs = new[]
                     {
-                        type = InputType.KEYBOARD,
-                        U = new InputUnion
+                        new Extern.Input
                         {
-                            ki = new KeybdInput
+                            type = InputType.KEYBOARD,
+                            U = new InputUnion
                             {
-                                wScan = (ScanCodeShort)PInvoke.MapVirtualKey((uint)key, MAPVK_VK_TO_VSC),
-                                wVk = key,
-                                dwFlags = KeyEventF.KEYUP
+                                ki = new KeybdInput
+                                {
+                                    wScan = ScanCodeShort.EXTENDEDKEY,
+                                    wVk = 0,
+                                    dwFlags = 0
+                                }
+                            }
+                        },
+                        new Extern.Input
+                        {
+                            type = InputType.KEYBOARD,
+                            U = new InputUnion
+                            {
+                                ki = new KeybdInput
+                                {
+                                    wScan = (ScanCodeShort)PInvoke.MapVirtualKey((uint)key, MAPVK_VK_TO_VSC),
+                                    wVk = key,
+                                    dwFlags = KeyEventF.EXTENDEDKEY | KeyEventF.KEYUP
+                                }
                             }
                         }
-                    }
-                };
+                    };
+                } else {
+                    nInputs = new[]
+                    {
+                        new Extern.Input
+                        {
+                            type = InputType.KEYBOARD,
+                            U = new InputUnion
+                            {
+                                ki = new KeybdInput
+                                {
+                                    wScan = (ScanCodeShort)PInvoke.MapVirtualKey((uint)key, MAPVK_VK_TO_VSC),
+                                    wVk = key,
+                                    dwFlags = KeyEventF.KEYUP 
+                                }
+                            }
+                        }
+                    };
+                }
                 PInvoke.SendInput((uint)nInputs.Length, nInputs, Extern.Input.Size);
             }
             else
             {
                 uint vkCode = (uint)key;
-                ExtraKeyInfo lParam = new ExtraKeyInfo
-                {
+                ExtraKeyInfo lParam = new ExtraKeyInfo() {
                     scanCode = (char)PInvoke.MapVirtualKey(vkCode, MAPVK_VK_TO_VSC),
                     repeatCount = 1,
                     prevKeyState = 1,
                     transitionState = 1
                 };
+                if (ExtendedKeys.Contains(key))
+                    lParam.extendedKey = 1;
                 PInvoke.PostMessage(GameService.GameIntegration.Gw2Proc.Gw2WindowHandle, WM_KEYUP, vkCode, lParam.GetInt());
             }
         }


### PR DESCRIPTION
There really isn't a lot of information about this, strangely.  I believe most people just use SendKeys instead, but I dont think that'd work great in game.   

MS has a note about it at https://docs.microsoft.com/en-us/windows/win32/inputdev/about-keyboard-input#extended-key-flag    It does work without the Extern.Input that has a wScan = ScanCodeShort.EXTENDEDKEY (0xe0), but since MS said it should be there and the other example I found had it, I left it in.  

About the only other "helpful" information I found was at https://www.michaelwda.com/post/scancodes , but he put me in the right direction.  
