### PR TITLE
Initial implementation of https://github.com/blish-hud/Blish-HUD/issues/452

### DIFF
--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Security.AccessControl;
 using System.Windows.Forms;
+using Blish_HUD._Utils;
 using Blish_HUD.GameServices;
 using Blish_HUD.Settings;
 using Gapotchenko.FX.Diagnostics;
@@ -120,6 +121,15 @@ namespace Blish_HUD.GameIntegration {
             private set => PropertyUtil.SetProperty(ref _appDataPath, value);
         }
 
+        private string _commandLine;
+        /// <summary>
+        /// The full command line of the current Guild Wars 2 process.
+        /// </summary>
+        public string CommandLine {
+            get => _commandLine;
+            private set => PropertyUtil.SetProperty(ref _commandLine, value);
+        }
+
         // Settings
         private SettingEntry<string> _gw2ExecutablePath;
 
@@ -167,6 +177,13 @@ namespace Blish_HUD.GameIntegration {
             } else {
                 if (_gw2Process.MainModule != null) {
                     _gw2ExecutablePath.Value = _gw2Process.MainModule.FileName;
+                }
+
+                try {
+                    this.CommandLine = newProcess.GetCommandLine();
+                } catch (Win32Exception e) {
+                    this.CommandLine = string.Empty;
+                    Logger.Warn(e, "A Win32Exception was encountered while trying to retrieve the process command line.");
                 }
 
                 var envs = newProcess.ReadEnvironmentVariables();

--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Security.AccessControl;
 using System.Windows.Forms;
-using Blish_HUD._Utils;
 using Blish_HUD.GameServices;
 using Blish_HUD.Settings;
 using Gapotchenko.FX.Diagnostics;

--- a/Blish HUD/GameServices/Gw2MumbleService.cs
+++ b/Blish HUD/GameServices/Gw2MumbleService.cs
@@ -4,18 +4,21 @@ using Blish_HUD.Gw2Mumble;
 using Gw2Sharp;
 using Microsoft.Xna.Framework;
 using Gw2Sharp.Mumble;
+using System.Text.RegularExpressions;
 namespace Blish_HUD {
 
     public class Gw2MumbleService : GameService {
 
         private const string DEFAULT_MUMBLEMAPNAME = "MumbleLink";
 
+        private static readonly Regex MUMBLE_LINK_REGEX = new Regex("^.+-mumble\\s+?\"(.+?)\".*$", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         private readonly TimeSpan _syncDelay = TimeSpan.FromMilliseconds(3);
 
-        private IGw2MumbleClient _rawClient;
+        private readonly IGw2Client _gw2Client;
 
         /// <inheritdoc cref="Gw2MumbleClient"/>
-        public IGw2MumbleClient RawClient => _rawClient;
+        public IGw2MumbleClient RawClient => GetRawClient();
 
         #region Categorized Mumble Data
 
@@ -47,17 +50,17 @@ namespace Blish_HUD {
         #endregion
 
         /// <inheritdoc cref="IGw2MumbleClient.IsAvailable"/>
-        public bool IsAvailable => _rawClient.IsAvailable;
+        public bool IsAvailable => RawClient.IsAvailable;
 
         public TimeSpan TimeSinceTick { get; private set; }
 
         private int _delayedTicks = 0;
         private int _prevTick = -1;
 
-        public int Tick => _rawClient.Tick;
+        public int Tick => RawClient.Tick;
 
         internal Gw2MumbleService() {
-            _rawClient = new Gw2Client().Mumble[ApplicationSettings.Instance.MumbleMapName ?? DEFAULT_MUMBLEMAPNAME];
+            _gw2Client = new Gw2Client();
 
             this.Info            = new Info(this);
             this.PlayerCharacter = new PlayerCharacter(this);
@@ -72,11 +75,11 @@ namespace Blish_HUD {
 
         protected override void Update(GameTime gameTime) {
             this.TimeSinceTick += gameTime.ElapsedGameTime;
-            
-            _rawClient.Update();
 
-            if (_rawClient.Tick > _prevTick) {
-                _prevTick = _rawClient.Tick;
+            RawClient.Update();
+
+            if (RawClient.Tick > _prevTick) {
+                _prevTick = RawClient.Tick;
 
                 this.TimeSinceTick = TimeSpan.Zero;
 
@@ -103,8 +106,34 @@ namespace Blish_HUD {
             this.UI.Update(gameTime);
         }
 
+        private IGw2MumbleClient GetRawClient() {
+            string linkName = GetLinkName();
+            return _gw2Client.Mumble[linkName];
+        }
+
+        private string GetLinkName() {
+            return ApplicationSettings.Instance.MumbleMapName ??
+                GetLinkNameFromCommandLine() ??
+                DEFAULT_MUMBLEMAPNAME;
+        }
+
+        private string GetLinkNameFromCommandLine() {
+            string commandLine = GameService.GameIntegration.Gw2Instance.CommandLine;
+
+            if (string.IsNullOrWhiteSpace(commandLine)) {
+                return null;
+            }
+
+            Match m = MUMBLE_LINK_REGEX.Match(commandLine);
+            if (m.Success) {
+                return m.Groups[1].Value;
+            } else {
+                return null;
+            }
+        }
+
         protected override void Unload() {
-            _rawClient.Dispose();
+            _gw2Client.Dispose();
         }
 
     }

--- a/Blish HUD/_Utils/ProcessUtil.cs
+++ b/Blish HUD/_Utils/ProcessUtil.cs
@@ -4,8 +4,8 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace Blish_HUD._Utils {
-    public static class ProcessUtil {
+namespace Blish_HUD {
+    internal static class ProcessUtil {
         #region PInvoke Methods
 
         [DllImport("ntdll.dll", SetLastError = true)]

--- a/Blish HUD/_Utils/ProcessUtil.cs
+++ b/Blish HUD/_Utils/ProcessUtil.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Blish_HUD._Utils {
+    public static class ProcessUtil {
+        #region PInvoke Methods
+
+        [DllImport("ntdll.dll", SetLastError = true)]
+        private static extern NTSTATUS NtQueryInformationProcess(IntPtr processHandle, PROCESSINFOCLASS processInformationClass, byte[] processInformation, int processInformationLength, out IntPtr returnLength);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool ReadProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress, [Out] byte[] lpBuffer, UIntPtr nSize, out UIntPtr lpNumberOfBytesRead);
+        #endregion PInvoke Methods
+
+        #region PInvoke Types
+        private enum PROCESSINFOCLASS : uint {
+            ProcessBasicInformation = 0x00,
+            ProcessCommandLineInformation = 0x3C,
+        }
+
+        private enum NTSTATUS : uint {
+            STATUS_SUCCESS = 0x00000000,
+            STATUS_INFO_LENGTH_MISMATCH = 0xC0000004,
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct UNICODE_STRING {
+            public ushort length;
+            public ushort maximumLength;
+            public IntPtr buffer;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct PROCESS_BASIC_INFORMATION {
+            private IntPtr Reserved1;
+            public IntPtr PebBaseAddress;
+            private IntPtr Reserved2_0;
+            private IntPtr Reserved2_1;
+            public IntPtr UniqueProcessId;
+            private IntPtr Reserved3;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct PEB {
+            // Some padding
+            private IntPtr Padding1_0;
+            private IntPtr Padding1_1;
+            private IntPtr Padding1_2;
+            private IntPtr Padding1_3;
+            public IntPtr ProcessParameters;
+            // not interested in anything further
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RtlUserProcessParameters {
+            public uint MaximumLength;
+            public uint Length;
+            public uint Flags;
+            public uint DebugFlags;
+            public IntPtr ConsoleHandle;
+            public uint ConsoleFlags;
+            public IntPtr StandardInput;
+            public IntPtr StandardOutput;
+            public IntPtr StandardError;
+            public UNICODE_STRING CurrentDirectory;
+            public IntPtr CurrentDirectoryHandle;
+            public UNICODE_STRING DllPath;
+            public UNICODE_STRING ImagePathName;
+            public UNICODE_STRING CommandLine;
+        }
+        #endregion PInvoke Types
+
+        public static string GetCommandLine(this Process process) {
+            // Only Winnt
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT) {
+                return string.Empty;
+            }
+
+            Version osVersion = Environment.OSVersion.Version;
+
+            switch (osVersion.Major, osVersion.Minor) {
+                case (6, 1):  // win7/2008r2
+                case (6, 2):  // win8
+                    return GetCommandLineInternalLegacy(process.Handle);
+
+                case (6, 3):  // win8.1
+                case (10, 0): // win10 & 11
+                    return GetCommandLineInternal(process.Handle);
+
+                default:
+                    return string.Empty;
+            }
+        }
+
+        private static string GetCommandLineInternal(IntPtr hProcess) {
+            byte[] buffer = Array.Empty<byte>();
+
+            // Pass 0 for length, required length is returned in bufSz
+            NTSTATUS status = NtQueryInformationProcess(hProcess, PROCESSINFOCLASS.ProcessCommandLineInformation, buffer, buffer.Length, out IntPtr bufSz);
+            if (status != NTSTATUS.STATUS_INFO_LENGTH_MISMATCH) {
+                throw new Win32Exception();
+            }
+
+            // Allocate a buffer
+            buffer = new byte[bufSz.ToInt32()];
+            status = NtQueryInformationProcess(hProcess, PROCESSINFOCLASS.ProcessCommandLineInformation, buffer, buffer.Length, out _);
+            if (status != NTSTATUS.STATUS_SUCCESS) {
+                throw new Win32Exception();
+            }
+
+            // The returned buffer is a UNICODE_STRING structure - the entire string is contained there.
+            int offset = Marshal.SizeOf<UNICODE_STRING>();
+            UNICODE_STRING str = MemoryMarshal.Read<UNICODE_STRING>(buffer);
+            return Encoding.Unicode.GetString(buffer, offset, str.length);
+        }
+
+        private static string GetCommandLineInternalLegacy(IntPtr hProcess) {
+            byte[] buffer = new byte[Marshal.SizeOf<PROCESS_BASIC_INFORMATION>()];
+
+            NTSTATUS status = NtQueryInformationProcess(hProcess, PROCESSINFOCLASS.ProcessBasicInformation, buffer, buffer.Length, out IntPtr _);
+            if (status != NTSTATUS.STATUS_SUCCESS) {
+                throw new Win32Exception();
+            }
+
+            PROCESS_BASIC_INFORMATION basicInformation = MemoryMarshal.Read<PROCESS_BASIC_INFORMATION>(buffer);
+
+            PEB peb = ReadStructFromProcessMemory<PEB>(hProcess, basicInformation.PebBaseAddress);
+            RtlUserProcessParameters userProcessParameters = ReadStructFromProcessMemory<RtlUserProcessParameters>(hProcess, peb.ProcessParameters);
+
+            return ReadUnicodeStringFromProcessMemory(hProcess, userProcessParameters.CommandLine);
+        }
+
+        private static string ReadUnicodeStringFromProcessMemory(IntPtr hProcess, in UNICODE_STRING unicodeString) {
+            byte[] buffer = new byte[unicodeString.length];
+            if (!ReadProcessMemory(hProcess, unicodeString.buffer, buffer, new UIntPtr((uint)buffer.Length), out UIntPtr _)) {
+                throw new Win32Exception();
+            }
+
+            return Encoding.Unicode.GetString(buffer);
+        }
+
+        private static TStruct ReadStructFromProcessMemory<TStruct>(IntPtr hProcess, IntPtr lpBaseAddress)
+            where TStruct : struct {
+
+            int size = Marshal.SizeOf<TStruct>();
+            byte[] buf = new byte[size];
+
+            if (!ReadProcessMemory(hProcess, lpBaseAddress, buf, new UIntPtr((uint)buf.Length), out UIntPtr _)) {
+                throw new Win32Exception();
+            }
+
+            return MemoryMarshal.Read<TStruct>(buf);
+        }
+    }
+}


### PR DESCRIPTION
Added the ability to get the current command line from `Gw2InstanceIntegration` and used that as the mumble link file name.

The mumble link file name will prefer the one defined in settings then fall back to the command line, then the default, though I'm not sure if the way I'm swapping between `IGw2MumbleClient` instances is best practice(?). They're not disposed immediately, but they should get disposed when the gw2 client is disposed or they get collected - it looks like there's a weakreference-based cache in gw2sharp.

I thought it may be nice to leverage the EntryPoint package to parse the command line for gw2, however it doesn't appear to support long-form args with a single `-` (as in `-mumble`), so this is using a regex to determine the mumble file from the command line.

P/Invoke is used to get the command line info, with a slightly different pinvoke fallback method for Windows 8.0 and 7 machines, as it it much faster than querying WMI.
