### PR TITLE
Fix for crash while gw2 is closing

### DIFF
--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -171,8 +171,12 @@ namespace Blish_HUD.GameIntegration {
 
                 var envs = newProcess.ReadEnvironmentVariables();
 
-                if (envs.ContainsKey(APPDATA_ENVKEY)) {
-                    this.AppDataPath = envs[APPDATA_ENVKEY];
+                try {
+                    if (envs.ContainsKey(APPDATA_ENVKEY)) {
+                        this.AppDataPath = envs[APPDATA_ENVKEY];
+                    }
+                } catch (NullReferenceException e) {
+                    Logger.Warn(e, "Failed to grab Guild Wars 2 env variable.  It is likely exiting.");
                 }
             }
 


### PR DESCRIPTION
Prevent a crash while already planning to close when trying to grab the env var right as the gw2 process is exiting.