### PR TITLE
Fix NullReferenceException on gw2 process exit

### DIFF
--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -164,6 +164,7 @@ namespace Blish_HUD.GameIntegration {
                 BlishHud.Instance.Form.Invoke((MethodInvoker)(() => { BlishHud.Instance.Form.Visible = false; }));
 
                 _gw2Process = null;
+                this.Gw2IsRunning = false;
             } else {
                 if (_gw2Process.MainModule != null) {
                     _gw2ExecutablePath.Value = _gw2Process.MainModule.FileName;
@@ -174,15 +175,14 @@ namespace Blish_HUD.GameIntegration {
                 if (envs.ContainsKey(APPDATA_ENVKEY)) {
                     this.AppDataPath = envs[APPDATA_ENVKEY];
                 }
+
+                // GW2 is running if the "_gw2Process" isn't null and the class name of process' 
+                // window is the game window name (so we know we are passed the login screen)
+                string windowClass = WindowUtil.GetClassNameOfWindow(_gw2Process.MainWindowHandle);
+
+                this.Gw2IsRunning = windowClass == ApplicationSettings.Instance.WindowName
+                                 || windowClass != GW2_PATCHWINDOW_CLASS;
             }
-
-            // GW2 is running if the "_gw2Process" isn't null and the class name of process' 
-            // window is the game window name (so we know we are passed the login screen)
-            string windowClass = WindowUtil.GetClassNameOfWindow(this.Gw2Process.MainWindowHandle);
-
-            this.Gw2IsRunning = _gw2Process != null
-                             && windowClass == ApplicationSettings.Instance.WindowName
-                             || windowClass != GW2_PATCHWINDOW_CLASS;
         }
 
         private void OnGameFocusChanged(object sender, ValueEventArgs<bool> e) {


### PR DESCRIPTION
I was reliably hitting a NullReferenceException on exit as GW2Process was null when calling WindowUtil.GetClassNameOfWindow, this change early-out's when the new process is null.