### PR TITLE
Gw2Sharp 1.3.0

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -221,7 +221,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Gapotchenko.FX.Diagnostics.Process" Version="2021.1.5" />
-    <PackageReference Include="Gw2Sharp" Version="[1.0.0]" />
+    <PackageReference Include="Gw2Sharp" Version="1.3.0" />
     <PackageReference Include="Humanizer.Core.de" Version="2.6.2" PrivateAssets="all" />
     <PackageReference Include="Humanizer.Core.es" Version="2.6.2" PrivateAssets="all" />
     <PackageReference Include="Humanizer.Core.fr" Version="2.6.2" PrivateAssets="all" />

--- a/Blish HUD/GameServices/Gw2WebApi/UI/Presenters/ApiTokenPresenter.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/UI/Presenters/ApiTokenPresenter.cs
@@ -20,6 +20,8 @@ namespace Blish_HUD.Gw2WebApi.UI.Presenters {
 
         public ApiTokenPresenter(ApiTokenView view, string apiKey) : base(view, apiKey) {
             _loadCancel = new CancellationTokenSource();
+
+            this.View.DeleteClicked += TokenDeleteClicked;
         }
 
         protected override async Task<bool> Load(IProgress<string> progress) {
@@ -52,6 +54,12 @@ namespace Blish_HUD.Gw2WebApi.UI.Presenters {
             }
 
             return true;
+        }
+
+        private void TokenDeleteClicked(object sender, EventArgs e) {
+            GameService.Gw2WebApi.UnregisterKey(this.Model);
+
+            this.View.RemoveTokenView();
         }
 
         private bool UpdateFromRequestTaskResult<T>(Task<T> infoTask, ref T field) {
@@ -87,6 +95,8 @@ namespace Blish_HUD.Gw2WebApi.UI.Presenters {
 
         protected override void Unload() {
             _loadCancel.Cancel();
+
+            this.View.DeleteClicked -= TokenDeleteClicked;
 
             base.Unload();
         }

--- a/Blish HUD/GameServices/Gw2WebApi/UI/Views/ApiTokenView.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/UI/Views/ApiTokenView.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Blish_HUD.Controls;
 using Blish_HUD.Graphics.UI;
 using Blish_HUD.Input;
@@ -18,6 +19,8 @@ namespace Blish_HUD.Gw2WebApi.UI.Views {
             {"22", ("Germany", GameService.Content.GetTexture(@"common/784342"))},
             {"23", ("Spain", GameService.Content.GetTexture(@"common/784344"))}
         };
+
+        public event EventHandler<EventArgs> DeleteClicked;
 
         private Label _accountNameLbl;
         private Label _tokenKeyLbl;
@@ -184,10 +187,12 @@ namespace Blish_HUD.Gw2WebApi.UI.Views {
             _deleteBttn.Click += DeleteRegisteredToken;
         }
 
-        private void DeleteRegisteredToken(object sender, MouseEventArgs e) {
-            GameService.Gw2WebApi.UnregisterKey(_tokenInfo.Id);
-
+        public void RemoveTokenView() {
             this.ViewTarget.Dispose();
+        }
+
+        private void DeleteRegisteredToken(object sender, MouseEventArgs e) {
+            this.DeleteClicked?.Invoke(this, EventArgs.Empty);
         }
 
     }

--- a/Blish HUD/GameServices/Gw2WebApiService.cs
+++ b/Blish HUD/GameServices/Gw2WebApiService.cs
@@ -143,7 +143,7 @@ namespace Blish_HUD {
 
         private void UpdateCharacterList(SettingEntry<string> definedKey) {
             GetCharacters(GetConnection(definedKey.Value)).ContinueWith((charactersResponse) => {
-                if (charactersResponse.Result != null) {
+                if (charactersResponse.Exception == null && charactersResponse.Result != null) {
                     foreach (string characterId in charactersResponse.Result) {
                         _characterRepository.AddOrUpdate(characterId, definedKey.Value, (k, o) => definedKey.Value);
                     }


### PR DESCRIPTION
Updated to Gw2Sharp 1.3.0 and fixed a bug that could occur if you revoked your token (which would then prevent you from deleting it in the UI).