### PR TITLE
Fix for #468

### DIFF
--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -213,9 +213,16 @@ namespace Blish_HUD.GameIntegration {
         private void TryAttachToGw2() {
             // Get process from Mumble if it is defined
             // otherwise just get the first instance running
-            this.Gw2Process = GetMumbleSpecifiedGw2Process()
-                           ?? GetDefaultGw2ProcessById()
-                           ?? GetDefaultGw2ProcessByName();
+            if (ApplicationSettings.Instance.MumbleMapName != null) {
+                // User-set mumble link name - so don't fallback.
+                this.Gw2Process = GetMumbleSpecifiedGw2Process();
+            } else {
+                // No user-set mumble link name - so fallback,
+                // starting with default mumble data if found
+                this.Gw2Process = GetMumbleSpecifiedGw2Process()
+                               ?? GetDefaultGw2ProcessById()
+                               ?? GetDefaultGw2ProcessByName();
+            }
 
             if (this.Gw2IsRunning) {
                 try {


### PR DESCRIPTION
Fix for https://github.com/blish-hud/Blish-HUD/issues/468
This disables falling back to other methods of process detection when a mumble link file name has been specified - This should prevent attaching to undesired processes.