### PR TITLE
Set default value in SettingView{T} ctor

### DIFF
--- a/Blish HUD/GameServices/Settings/UI/Views/SettingView[T].cs
+++ b/Blish HUD/GameServices/Settings/UI/Views/SettingView[T].cs
@@ -47,6 +47,7 @@ namespace Blish_HUD.Settings.UI.Views {
 
         protected SettingView(SettingEntry<TSetting> setting, int definedWidth) {
             _definedWidth = definedWidth;
+            _value = setting.Value;
 
             this.WithPresenter(new SettingPresenter<TSetting>(this, setting));
         }


### PR DESCRIPTION
Potentially a fix for https://github.com/blish-hud/Blish-HUD/issues/470

This sets the Value property of the SettingView<T> to the specified default of the underlying setting when constructed. Currently the Value property is initialised to the default value for <T> which causes issues with enum dropdowns.