### PR TITLE
Avoid crashing if we fail to pull env details from the gw2 process.

### DIFF
--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -185,15 +185,20 @@ namespace Blish_HUD.GameIntegration {
                     Logger.Warn(e, "A Win32Exception was encountered while trying to retrieve the process command line.");
                 }
 
-                var envs = newProcess.ReadEnvironmentVariables();
-
                 try {
+                    var envs = newProcess.ReadEnvironmentVariables();
+
                     if (envs.ContainsKey(APPDATA_ENVKEY)) {
                         this.AppDataPath = envs[APPDATA_ENVKEY];
                     }
+                } catch (EndOfStreamException) {
+                    // See: https://github.com/gapotchenko/Gapotchenko.FX/issues/2
+                    Logger.Warn("Failed to auto-detect Guild Wars 2 environment variables.  Restart Guild Wars 2 to try again.");
                 } catch (NullReferenceException e) {
                     Logger.Warn(e, "Failed to grab Guild Wars 2 env variable.  It is likely exiting.");
                 }
+
+
 
                 // GW2 is running if the "_gw2Process" isn't null and the class name of process' 
                 // window is the game window name (so we know we are passed the login screen)


### PR DESCRIPTION
Fixes #477.  Our dependency for pulling the env details has a rare chance of failing.  It does not appear to necessarily be an issue with the lib as re-attempting doesn't work until the process itself is restarted (or perhaps its a strange edge case with something).

We've begun communicating on https://github.com/gapotchenko/Gapotchenko.FX/issues/2 but this PR handles the exception cleanly so that we can just fallback on the default appdata path since this is just a QoL feature anyways.