### PR TITLE
Allow setting private properties through Glide

### DIFF
--- a/Blish HUD/Library/Glide/MemberAccessor.cs
+++ b/Blish HUD/Library/Glide/MemberAccessor.cs
@@ -41,7 +41,7 @@ namespace Glide
                     var argument = Expression.Parameter(typeof(object));
                     var setterCall = Expression.Call(
                         Expression.Convert(param, propInfo.DeclaringType),
-                        propInfo.GetSetMethod(),
+                        propInfo.GetSetMethod(true),
                         Expression.Convert(argument, propInfo.PropertyType));
 
                     setMethod = Expression.Lambda<Action<object, object>>(setterCall, param, argument).Compile();


### PR DESCRIPTION
Fix for https://github.com/blish-hud/Blish-HUD/issues/308 - just need to pass `true` for [GetSetMethod(bool)](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.propertyinfo.getsetmethod?view=netframework-4.7.2)