### PR TITLE
Keyboard not blocked

### DIFF
--- a/Blish HUD/Controls/KeybindingAssignmentWindow.cs
+++ b/Blish HUD/Controls/KeybindingAssignmentWindow.cs
@@ -9,7 +9,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 
 namespace Blish_HUD.Controls {
-    public class KeybindingAssignmentWindow : Container {
+    public class KeybindingAssignmentWindow : Container, IWindow {
 
         #region Load Static
 
@@ -78,6 +78,8 @@ namespace Blish_HUD.Controls {
         private string _assignmentDisplayString;
 
         public KeybindingAssignmentWindow(string assignmentName, ModifierKeys modifierKeys = ModifierKeys.None, Keys primaryKey = Keys.None) {
+            WindowBase2.RegisterWindow(this);
+
             _assignmentName = assignmentName;
             _modifierKeys   = modifierKeys;
             _primaryKey     = primaryKey;
@@ -95,8 +97,12 @@ namespace Blish_HUD.Controls {
         protected override void OnShown(EventArgs e) {
             Invalidate();
 
+            GameService.Input.Keyboard.SetTextInputListner(BlockGameInput);
+
             base.OnShown(e);
         }
+
+        private void BlockGameInput(string input) { /* NOOP */ }
 
         private void KeyboardOnKeyStateChanged(object sender, KeyboardEventArgs e) {
             if (e.Key == Keys.Escape) {
@@ -113,6 +119,8 @@ namespace Blish_HUD.Controls {
         }
 
         private void FinishAssignment() {
+            GameService.Input.Keyboard.UnsetTextInputListner(BlockGameInput);
+
             this.Dispose();
         }
 
@@ -203,8 +211,18 @@ namespace Blish_HUD.Controls {
         protected override void DisposeControl() {
             base.DisposeControl();
 
+            GameService.Input.Keyboard.UnsetTextInputListner(BlockGameInput);
+            WindowBase2.UnregisterWindow(this);
+
             Input.Keyboard.KeyStateChanged -= KeyboardOnKeyStateChanged;
         }
+
+        // We implement IWindow to avoid other windows from reacting to our ESC input
+
+        public bool   TopMost              => true;
+        public double LastInteraction      => double.MaxValue;
+        public bool   CanClose             => false;
+        public void   BringWindowToFront() { /* NOOP */ }
 
     }
 }

--- a/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
@@ -91,6 +91,8 @@ namespace Blish_HUD.Input {
         }
 
         private void CheckTrigger(ModifierKeys activeModifiers, IEnumerable<Keys> pressedKeys) {
+            if (GameService.Gw2Mumble.UI.IsTextInputFocused) return;
+
             if ((this.ModifierKeys & activeModifiers) == this.ModifierKeys && pressedKeys.Contains(this.PrimaryKey)) {
                 Fire();
             } else if (_isTriggering) {

--- a/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
@@ -155,7 +155,7 @@ namespace Blish_HUD.Input {
                     activeContextMenu.Hide();
                     return true;
                 } else {
-                    // If we found an active context menu item, close it
+                    // If we found an active window, close it
                     var activeWindow = WindowBase2.ActiveWindow;
 
                     if (activeWindow != null && activeWindow.CanClose) {


### PR DESCRIPTION
Fixes both #486 and #487.

1. We tell the KeyboardHandler to give the assignment window the input exclusively while it is open.
2. KeyBindings will skip processing pressed keys if mumble reports that we are in a text field.