### PR TITLE
Fix numeric settings clamping values before compliance is applied.

### DIFF
--- a/Blish HUD/GameServices/Settings/UI/Views/FloatSettingView.cs
+++ b/Blish HUD/GameServices/Settings/UI/Views/FloatSettingView.cs
@@ -1,4 +1,5 @@
-﻿using Blish_HUD.Controls;
+﻿using System;
+using Blish_HUD.Controls;
 
 namespace Blish_HUD.Settings.UI.Views {
     public class FloatSettingView : NumericSettingView<float> {
@@ -33,6 +34,10 @@ namespace Blish_HUD.Settings.UI.Views {
         }
 
         protected override void RefreshValue(float value) {
+            // Prevent us clamping the setting value before compliance is applied
+            _valueTrackBar.MinValue = Math.Min(_valueTrackBar.MinValue, value);
+            _valueTrackBar.MaxValue = Math.Max(_valueTrackBar.MaxValue, value);
+
             _valueTrackBar.Value = value;
         }
 

--- a/Blish HUD/GameServices/Settings/UI/Views/IntSettingView.cs
+++ b/Blish HUD/GameServices/Settings/UI/Views/IntSettingView.cs
@@ -1,4 +1,6 @@
-﻿namespace Blish_HUD.Settings.UI.Views {
+﻿using System;
+
+namespace Blish_HUD.Settings.UI.Views {
     public class IntSettingView : NumericSettingView<int> {
 
         public IntSettingView(SettingEntry<int> setting, int definedWidth = -1) : base(setting, definedWidth) { /* NOOP */ }
@@ -25,6 +27,10 @@
         }
 
         protected override void RefreshValue(int value) {
+            // Prevent us clamping the setting value before compliance is applied
+            _valueTrackBar.MinValue = Math.Min(_valueTrackBar.MinValue, value);
+            _valueTrackBar.MaxValue = Math.Max(_valueTrackBar.MaxValue, value);
+
             _valueTrackBar.Value = value;
         }
 


### PR DESCRIPTION
This fixes a recent regression which can cause settings which are applied outside of the default trackbar min/max to clamp before compliance is applied to expand the min/max.

We just automatically expand the range if the setting value is explicitly set.