### PR TITLE
Rework mutex code to handle restarts 

### DIFF
--- a/Blish HUD/ApplicationSettings.cs
+++ b/Blish HUD/ApplicationSettings.cs
@@ -46,8 +46,6 @@ namespace Blish_HUD {
          * r, ref       - The path to the ref.dat file.
          * s, settings  - The path where Blish HUD will save settings and other files.
          * w, window    - The name of the window to overlay.
-         *
-         * restartskipmutex - Forces Blish HUD to allow multiple instances.  Used internally to prevent race condition issues when Blish HUD is restarted.
          */
 
         #region Game Integration
@@ -164,16 +162,6 @@ namespace Blish_HUD {
         #endregion
 
         #region Internal
-        
-        public const string OPTION_RESTARTSKIPMUTEX = "restartskipmutex";
-        /// <summary>
-        /// Forces Blish HUD to allow multiple instances.  Used internally to prevent race condition issues when Blish HUD is restarted.
-        /// </summary>
-        [
-            Option(OPTION_RESTARTSKIPMUTEX),
-            Help("Forces Blish HUD to allow multiple instances.  Used internally to prevent race condition issues when Blish HUD is restarted.")
-        ]
-        public bool RestartSkipMutex { get; private set; }
 
         public const string OPTION_MAINPROCESSID = "mainprocessid";
         /// <summary>

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -150,20 +150,7 @@ namespace Blish_HUD {
         public void Restart() {
             if (!this.BeginExit(0)) return;
 
-            // REF: https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/Application.cs,1447
-
-            var arguments = Environment.GetCommandLineArgs()
-                                                      .Skip(1)
-                                                      .Where(arg => !string.Equals(arg, $"--{ApplicationSettings.OPTION_RESTARTSKIPMUTEX}", StringComparison.OrdinalIgnoreCase))
-                                                      .Append($"--{ApplicationSettings.OPTION_RESTARTSKIPMUTEX}")
-                                                      .Select(arg => $"\"{arg}\"");
-
-            var currentStartInfo = Process.GetCurrentProcess().StartInfo;
-            currentStartInfo.FileName  = Application.ExecutablePath;
-            currentStartInfo.Arguments = string.Join(" ", arguments);
-
-            Process.Start(currentStartInfo);
-
+            Program.RestartOnExit = true;
             ActiveBlishHud.Exit();
         }
 


### PR DESCRIPTION
Should fix https://github.com/blish-hud/Blish-HUD/issues/488

Reworked the startup mutex code so that restartskipmutex is no longer required by adding a RestartOnExit static bool property to the Program class. When set, the program will restart on exit, after the mutex has been released.

Added handling for AbandonedMutexException & wrapped startup in a try ... finally block to ensure mutex is released on unhandled exceptions.