### PR TITLE
Fix subtoken requests happening before privileged connection has key

### DIFF
--- a/Blish HUD/GameServices/Gw2WebApi/ManagedConnection.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/ManagedConnection.cs
@@ -53,5 +53,8 @@ namespace Blish_HUD.Gw2WebApi {
             return true;
         }
 
+        public bool HasApiKey() {
+            return !string.IsNullOrEmpty(_internalConnection.AccessToken);
+        }
     }
 }

--- a/Blish HUD/GameServices/Gw2WebApi/ManagedConnection.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/ManagedConnection.cs
@@ -1,8 +1,10 @@
-﻿using System;
-using Gw2Sharp;
+﻿using Gw2Sharp;
 using Gw2Sharp.WebApi;
 using Gw2Sharp.WebApi.Caching;
-
+using Gw2Sharp.WebApi.V2.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 namespace Blish_HUD.Gw2WebApi {
     public sealed class ManagedConnection {
 
@@ -56,5 +58,10 @@ namespace Blish_HUD.Gw2WebApi {
         public bool HasApiKey() {
             return !string.IsNullOrEmpty(_internalConnection.AccessToken);
         }
+
+        internal async Task<string> RequestPrivilegedSubtoken(IEnumerable<TokenPermission> permissions, int days) {
+            return HasApiKey() ? await GameService.Gw2WebApi.RequestSubtoken(this, permissions, days) : string.Empty;
+        }
+
     }
 }

--- a/Blish HUD/GameServices/Gw2WebApi/ManagedConnection.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/ManagedConnection.cs
@@ -59,9 +59,5 @@ namespace Blish_HUD.Gw2WebApi {
             return !string.IsNullOrEmpty(_internalConnection.AccessToken);
         }
 
-        internal async Task<string> RequestPrivilegedSubtoken(IEnumerable<TokenPermission> permissions, int days) {
-            return HasApiKey() ? await GameService.Gw2WebApi.RequestSubtoken(this, permissions, days) : string.Empty;
-        }
-
     }
 }

--- a/Blish HUD/GameServices/Gw2WebApiService.cs
+++ b/Blish HUD/GameServices/Gw2WebApiService.cs
@@ -161,6 +161,9 @@ namespace Blish_HUD {
             return (await connection.Client.V2.Characters.IdsAsync()).ToList();
         }
 
+        internal async Task<string> RequestPrivilegedSubtoken(IEnumerable<TokenPermission> permissions, int days) {
+            return await GameService.Gw2WebApi.RequestSubtoken(_privilegedConnection, permissions, days);
+        }
 
         public async Task<string> RequestSubtoken(ManagedConnection connection, IEnumerable<TokenPermission> permissions, int days) {
             try {

--- a/Blish HUD/GameServices/Gw2WebApiService.cs
+++ b/Blish HUD/GameServices/Gw2WebApiService.cs
@@ -162,7 +162,7 @@ namespace Blish_HUD {
         }
 
         internal async Task<string> RequestPrivilegedSubtoken(IEnumerable<TokenPermission> permissions, int days) {
-            return await RequestSubtoken(_privilegedConnection, permissions, days);
+            return _privilegedConnection.HasApiKey() ? await RequestSubtoken(_privilegedConnection, permissions, days) : string.Empty;
         }
 
         public async Task<string> RequestSubtoken(ManagedConnection connection, IEnumerable<TokenPermission> permissions, int days) {

--- a/Blish HUD/GameServices/Gw2WebApiService.cs
+++ b/Blish HUD/GameServices/Gw2WebApiService.cs
@@ -161,9 +161,6 @@ namespace Blish_HUD {
             return (await connection.Client.V2.Characters.IdsAsync()).ToList();
         }
 
-        internal async Task<string> RequestPrivilegedSubtoken(IEnumerable<TokenPermission> permissions, int days) {
-            return _privilegedConnection.HasApiKey() ? await RequestSubtoken(_privilegedConnection, permissions, days) : string.Empty;
-        }
 
         public async Task<string> RequestSubtoken(ManagedConnection connection, IEnumerable<TokenPermission> permissions, int days) {
             try {

--- a/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
+++ b/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
@@ -51,7 +51,7 @@ namespace Blish_HUD.Modules.Managers {
             // and while we wait for subtoken response.
             _connection = GameService.Gw2WebApi.AnonymousConnection;
 
-            if (_permissions == null || !_permissions.Any()) return;
+            if (!GameService.Gw2WebApi.PrivilegedConnection.HasApiKey() || _permissions == null || !_permissions.Any()) return;
 
             GameService.Gw2WebApi.RequestPrivilegedSubtoken(_permissions, SUBTOKEN_LIFETIME)
                        .ContinueWith(subtokenTask => {

--- a/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
+++ b/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
@@ -53,7 +53,7 @@ namespace Blish_HUD.Modules.Managers {
 
             if (_permissions == null || !_permissions.Any()) return;
 
-            GameService.Gw2WebApi.RequestPrivilegedSubtoken(_permissions, SUBTOKEN_LIFETIME)
+            GameService.Gw2WebApi.PrivilegedConnection.RequestPrivilegedSubtoken(_permissions, SUBTOKEN_LIFETIME)
                        .ContinueWith(subtokenTask => {
                             if (subtokenTask.IsFaulted || string.IsNullOrEmpty(subtokenTask.Result)) return;
 

--- a/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
+++ b/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
@@ -51,10 +51,12 @@ namespace Blish_HUD.Modules.Managers {
             // and while we wait for subtoken response.
             _connection = GameService.Gw2WebApi.AnonymousConnection;
 
-            if (!GameService.Gw2WebApi.PrivilegedConnection.HasApiKey() || _permissions == null || !_permissions.Any()) return;
+            if (_permissions == null || !_permissions.Any()) return;
 
             GameService.Gw2WebApi.RequestPrivilegedSubtoken(_permissions, SUBTOKEN_LIFETIME)
                        .ContinueWith(subtokenTask => {
+                            if (subtokenTask.IsFaulted || string.IsNullOrEmpty(subtokenTask.Result)) return;
+
                             if (_connection.SetApiKey(subtokenTask.Result)) {
                                 var jwtToken = _subtokenHandler.ReadJwtToken(subtokenTask.Result);
                                 _activePermissions = jwtToken.Claims.Where(x => x.Type.Equals("permissions") && Enum.TryParse(x.Value, true, out TokenPermission _))

--- a/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
+++ b/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
@@ -51,9 +51,9 @@ namespace Blish_HUD.Modules.Managers {
             // and while we wait for subtoken response.
             _connection = GameService.Gw2WebApi.AnonymousConnection;
 
-            if (_permissions == null || !_permissions.Any()) return;
+            if (!GameService.Gw2WebApi.PrivilegedConnection.HasApiKey() || _permissions == null || !_permissions.Any()) return;
 
-            GameService.Gw2WebApi.PrivilegedConnection.RequestPrivilegedSubtoken(_permissions, SUBTOKEN_LIFETIME)
+            GameService.Gw2WebApi.RequestPrivilegedSubtoken(_permissions, SUBTOKEN_LIFETIME)
                        .ContinueWith(subtokenTask => {
                             if (subtokenTask.IsFaulted || string.IsNullOrEmpty(subtokenTask.Result)) return;
 


### PR DESCRIPTION
The call of ``RenewSubtoken`` in the constructor of the Gw2ApiManager will cause a subtoken request on each module load before the main key is assigned to the PrivilegedConnection.
That call was probably put there for when you enable a module in an already ongoing session with a privileged connection that already owns a main key.

This resolves the issue for faulting subtoken requests happening at the launch of the program where Gw2ApiManagers are created before the privileged connection is assigned an api key.

(The validity of the api key is already checked elsewhere so a simple non-null-non-empty key check suffices.)