### PR TITLE
Improve Gw2WebApi service relationship with modules

### DIFF
--- a/Blish HUD/GameServices/Gw2WebApi/ManagedConnection.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/ManagedConnection.cs
@@ -42,7 +42,7 @@ namespace Blish_HUD.Gw2WebApi {
         private void UserLocaleOnSettingChanged(object sender, ValueChangedEventArgs<Locale> e) {
             _internalConnection.Locale = e.NewValue;
 
-            Logger.Debug($"{nameof(ManagedConnection)} updated locale to {e.NewValue} (was {e.PrevousValue}).");
+            Logger.Debug($"{nameof(ManagedConnection)} updated locale to {e.NewValue} (was {e.PreviousValue}).");
         }
 
         public bool SetApiKey(string apiKey) {

--- a/Blish HUD/GameServices/Gw2WebApi/ManagedConnection.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/ManagedConnection.cs
@@ -50,6 +50,10 @@ namespace Blish_HUD.Gw2WebApi {
 
             _internalConnection.AccessToken = apiKey;
 
+            Logger.Debug(apiKey == string.Empty
+                             ? $"{_internalConnection.UserAgent} cleared API token."
+                             : $"{_internalConnection.UserAgent} updated API token to {apiKey}.");
+
             return true;
         }
 

--- a/Blish HUD/GameServices/Gw2WebApi/UI/Presenters/ApiTokenPresenter.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/UI/Presenters/ApiTokenPresenter.cs
@@ -56,8 +56,8 @@ namespace Blish_HUD.Gw2WebApi.UI.Presenters {
             return true;
         }
 
-        private void TokenDeleteClicked(object sender, EventArgs e) {
-            GameService.Gw2WebApi.UnregisterKey(this.Model);
+        private async void TokenDeleteClicked(object sender, EventArgs e) {
+            await GameService.Gw2WebApi.UnregisterKey(this.Model);
 
             this.View.RemoveTokenView();
         }

--- a/Blish HUD/GameServices/Gw2WebApi/UI/Views/RegisterApiKeyView.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/UI/Views/RegisterApiKeyView.cs
@@ -133,13 +133,7 @@ namespace Blish_HUD.Gw2WebApi.UI.Views {
 
             clearKeyBttn.Click += delegate { ClearApiKey(); };
 
-            _registerKeyBttn.Click += delegate {
-                GameService.Gw2WebApi.RegisterKey(_loadedDetails.AccountInfo.Name, this.ApiKey);
-
-                ReloadApiKeys();
-
-                ClearApiKey();
-            };
+            _registerKeyBttn.Click += RegisterKeyBttnClicked;
 
             var instructions = new Label() {
                 Text           = Strings.Common.Instructions,
@@ -253,6 +247,14 @@ namespace Blish_HUD.Gw2WebApi.UI.Views {
             ReloadApiKeys();
 
             SetTokenStatus(ApiTokenStatusType.Neutral);
+        }
+
+        private async void RegisterKeyBttnClicked(object sender, Input.MouseEventArgs e) {
+            await GameService.Gw2WebApi.RegisterKey(_loadedDetails.AccountInfo.Name, this.ApiKey);
+
+            ReloadApiKeys();
+
+            ClearApiKey();
         }
 
         private void ReloadApiKeys() {

--- a/Blish HUD/GameServices/Gw2WebApiService.cs
+++ b/Blish HUD/GameServices/Gw2WebApiService.cs
@@ -87,45 +87,49 @@ namespace Blish_HUD {
                                                                 int.MaxValue - 11);
         }
 
-        private void UpdateBaseConnection(string apiKey) {
+        private async Task UpdateBaseConnection(string apiKey) {
             if (_privilegedConnection.SetApiKey(apiKey)) {
-                Modules.Managers.Gw2ApiManager.RenewAllSubtokens();
+                await Modules.Managers.Gw2ApiManager.RenewAllSubtokens();
             }
         }
 
-        private void UpdateActiveApiKey() {
+        private async Task UpdateActiveApiKey() {
             if (_characterRepository.TryGetValue(Gw2Mumble.PlayerCharacter.Name, out string charApiKey)) {
-                UpdateBaseConnection(charApiKey);
+                await UpdateBaseConnection(charApiKey);
                 Logger.Debug($"Associated key {charApiKey} with user {Gw2Mumble.PlayerCharacter.Name}.");
             } else {
-                UpdateBaseConnection(string.Empty);
-                Logger.Info("Could not find registered API key associated with character {characterName}", Gw2Mumble.PlayerCharacter.Name);
+                if (string.IsNullOrWhiteSpace(Gw2Mumble.PlayerCharacter.Name)) {
+                    // We skip the message if no user is defined yet.
+                    Logger.Info("Could not find registered API key associated with character {characterName}", Gw2Mumble.PlayerCharacter.Name);
+                }
+
+                await UpdateBaseConnection(string.Empty);
             }
         }
 
-        private void PlayerCharacterOnNameChanged(object sender, ValueEventArgs<string> e) {
+        private async void PlayerCharacterOnNameChanged(object sender, ValueEventArgs<string> e) {
             if (!_characterRepository.ContainsKey(e.Value)) {
                 // We don't currently have an API key associated to this character so we double-check the characters on each key
-                RefreshRegisteredKeys();
+                await RefreshRegisteredKeys ();
             } else {
-                UpdateActiveApiKey();
+                await UpdateActiveApiKey();
             }
         }
 
-        private void RefreshRegisteredKeys() {
+        private async Task RefreshRegisteredKeys() {
             foreach (SettingEntry<string> key in _apiKeyRepository.Cast<SettingEntry<string>>()) {
-                UpdateCharacterList(key);
+                await UpdateCharacterList(key);
             }
         }
 
         #region API Management
 
-        public void RegisterKey(string name, string apiKey) {
+        public async Task RegisterKey(string name, string apiKey) {
             SettingEntry<string> registeredKey = _apiKeyRepository.DefineSetting(name, "");
 
             registeredKey.Value = apiKey;
 
-            UpdateCharacterList(registeredKey);
+            await UpdateCharacterList(registeredKey);
         }
 
         public void UnregisterKey(string apiKey) {
@@ -141,20 +145,20 @@ namespace Blish_HUD {
             return _apiKeyRepository.Cast<SettingEntry<string>>().Select((setting) => setting.Value).ToArray();
         }
 
-        private void UpdateCharacterList(SettingEntry<string> definedKey) {
-            GetCharacters(GetConnection(definedKey.Value)).ContinueWith((charactersResponse) => {
-                if (charactersResponse.Exception == null && charactersResponse.Result != null) {
-                    foreach (string characterId in charactersResponse.Result) {
-                        _characterRepository.AddOrUpdate(characterId, definedKey.Value, (k, o) => definedKey.Value);
-                    }
+        private async Task UpdateCharacterList(SettingEntry<string> definedKey) {
+            try {
+                List<string> characters = await GetCharacters(GetConnection(definedKey.Value));
 
-                    Logger.Info("Associated API key {keyName} with characters: {charactersList}", definedKey.EntryKey, string.Join(", ", charactersResponse.Result));
-                } else {
-                    Logger.Warn(charactersResponse.Exception, "Failed to get list of associated characters for API key {keyName}.", definedKey.EntryKey);
+                foreach (string characterId in characters) {
+                    _characterRepository.AddOrUpdate(characterId, definedKey.Value, (k, o) => definedKey.Value);
                 }
 
-                UpdateActiveApiKey();
-            });
+                Logger.Info("Associated API key {keyName} with characters: {charactersList}", definedKey.EntryKey, string.Join(", ", characters));
+            } catch (Exception ex) {
+                Logger.Warn(ex, "Failed to get list of associated characters for API key {keyName}.", definedKey.EntryKey);
+            }
+
+            await UpdateActiveApiKey();
         }
 
         private async Task<List<string>> GetCharacters(ManagedConnection connection) {
@@ -166,10 +170,16 @@ namespace Blish_HUD {
         }
 
         public async Task<string> RequestSubtoken(ManagedConnection connection, IEnumerable<TokenPermission> permissions, int days) {
+            var tokenPermissions = permissions as TokenPermission[] ?? permissions.ToArray();
+
+            if (!tokenPermissions.Any() || string.IsNullOrEmpty(connection.Connection.AccessToken)) {
+                return string.Empty;
+            }
+
             try {
                 return (await connection.Client
                                         .V2.CreateSubtoken
-                                        .WithPermissions(permissions)
+                                        .WithPermissions(tokenPermissions)
                                         .Expires(DateTime.UtcNow.AddDays(days))
                                         .GetAsync()).Subtoken;
             } catch (InvalidAccessTokenException ex) {
@@ -178,7 +188,7 @@ namespace Blish_HUD {
                 Logger.Warn(ex, "The provided API token could not be used to request a subtoken.");
             }
 
-            return "";
+            return string.Empty;
         }
 
         #endregion

--- a/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
+++ b/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
@@ -71,6 +71,8 @@ namespace Blish_HUD.Modules.Managers {
                                                  .Select(y => (TokenPermission)Enum.Parse(typeof(TokenPermission), y.Value, true))
                                                  .ToHashSet();
 
+                    // TODO: consider checking against the expiration claim.
+
                     SubtokenUpdated?.Invoke(this, new ValueEventArgs<IEnumerable<TokenPermission>>(_activePermissions));
                 } catch (Exception ex) {
                     Logger.Warn(ex, "Failed to parse API subtoken.");

--- a/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
+++ b/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
@@ -5,16 +5,21 @@ using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
+using System.Threading.Tasks;
+
 namespace Blish_HUD.Modules.Managers {
     public class Gw2ApiManager {
 
-        private const int SUBTOKEN_LIFETIME = 7;
+        private static readonly Logger Logger = Logger.GetLogger<Gw2ApiManager>();
+
+        private const int    SUBTOKEN_LIFETIME  = 7;
+        private const string SUBTOKEN_CLAIMTYPE = "permissions";
 
         private static readonly List<Gw2ApiManager> _apiManagers = new List<Gw2ApiManager>();
 
-        internal static void RenewAllSubtokens() {
+        internal static async Task RenewAllSubtokens() {
             foreach (var apiManager in _apiManagers) {
-                apiManager.RenewSubtoken();
+                await apiManager.RenewSubtoken();
             }
         }
 
@@ -24,7 +29,7 @@ namespace Blish_HUD.Modules.Managers {
 
         private readonly JwtSecurityTokenHandler _subtokenHandler;
 
-        private ManagedConnection _connection;
+        private readonly ManagedConnection _connection;
 
         public event EventHandler<ValueEventArgs<IEnumerable<TokenPermission>>> SubtokenUpdated;
 
@@ -32,47 +37,52 @@ namespace Blish_HUD.Modules.Managers {
 
         public List<TokenPermission> Permissions => _permissions.ToList();
 
-        private Gw2ApiManager(IEnumerable<TokenPermission> permissions) {
+        private Gw2ApiManager(IEnumerable<TokenPermission> permissions, ManagedConnection moduleConnection) {
             _apiManagers.Add(this);
 
             _permissions       = permissions.ToHashSet();
             _activePermissions = new HashSet<TokenPermission>();
             _subtokenHandler   = new JwtSecurityTokenHandler();
 
-            RenewSubtoken();
+            _connection = moduleConnection;
         }
 
         internal static Gw2ApiManager GetModuleInstance(ModuleManager module) {
-            return new Gw2ApiManager(module.State.UserEnabledPermissions ?? new TokenPermission[0]);
+            return new Gw2ApiManager(module.State.UserEnabledPermissions ?? Array.Empty<TokenPermission>(), GameService.Gw2WebApi.GetConnection(string.Empty));
         }
 
-        private void RenewSubtoken() {
-            // Default to anonymous if permissions aren't requested
-            // and while we wait for subtoken response.
-            _connection = GameService.Gw2WebApi.AnonymousConnection;
-
+        internal async Task RenewSubtoken() {
+            // If we have no consented permissions, we early exit.
             if (_permissions == null || !_permissions.Any()) return;
 
-            GameService.Gw2WebApi.RequestPrivilegedSubtoken(_permissions, SUBTOKEN_LIFETIME)
-                       .ContinueWith(subtokenTask => {
-                            if (_connection.SetApiKey(subtokenTask.Result)) {
-                                var jwtToken = _subtokenHandler.ReadJwtToken(subtokenTask.Result);
-                                _activePermissions = jwtToken.Claims.Where(x => x.Type.Equals("permissions") && Enum.TryParse(x.Value, true, out TokenPermission _))
-                                                                    .Select(y => (TokenPermission)Enum.Parse(typeof(TokenPermission), y.Value, true)).ToHashSet();
-                                SubtokenUpdated?.Invoke(this, new ValueEventArgs<IEnumerable<TokenPermission>>(_activePermissions));
-                            }
-                        });
+            string responseToken = string.Empty;
+
+            try {
+                responseToken = await GameService.Gw2WebApi.RequestPrivilegedSubtoken(_permissions, SUBTOKEN_LIFETIME);
+            } catch (Exception ex) {
+                Logger.Warn(ex, "Failed to get privileged subtoken for module.");
+            }
+
+            if (_connection.SetApiKey(responseToken) && _subtokenHandler.CanReadToken(responseToken)) {
+                try {
+                    var jwtToken = _subtokenHandler.ReadJwtToken(responseToken);
+
+                    _activePermissions = jwtToken.Claims.Where(x => x.Type.Equals(SUBTOKEN_CLAIMTYPE) && Enum.TryParse(x.Value, true, out TokenPermission _))
+                                                 .Select(y => (TokenPermission)Enum.Parse(typeof(TokenPermission), y.Value, true))
+                                                 .ToHashSet();
+
+                    SubtokenUpdated?.Invoke(this, new ValueEventArgs<IEnumerable<TokenPermission>>(_activePermissions));
+                } catch (Exception ex) {
+                    Logger.Warn(ex, "Failed to parse API subtoken.");
+                }
+            }
         }
 
-        [Obsolete("HavePermission is deprecated, please use HasPermission instead.")]
-        public bool HavePermission(TokenPermission permission) {
-            return _permissions.Contains(permission);
-        }
+        [Obsolete("HavePermission is deprecated, please use HasPermission instead.", true)]
+        public bool HavePermission(TokenPermission permission) => HasPermission(permission);
 
-        [Obsolete("HavePermissions is deprecated, please use HasPermissions instead.")]
-        public bool HavePermissions(IEnumerable<TokenPermission> permissions) {
-            return _permissions.IsSupersetOf(permissions);
-        }
+        [Obsolete("HavePermissions is deprecated, please use HasPermissions instead.", true)]
+        public bool HavePermissions(IEnumerable<TokenPermission> permissions) => HasPermissions(permissions);
 
         public bool HasPermissions(IEnumerable<TokenPermission> permissions) {
             return _activePermissions.IsSupersetOf(permissions);

--- a/Blish HUD/GameServices/Modules/Module.cs
+++ b/Blish HUD/GameServices/Modules/Module.cs
@@ -78,7 +78,7 @@ namespace Blish_HUD.Modules {
 
         [ImportingConstructor]
         protected Module([Import("ModuleParameters")] ModuleParameters moduleParameters) {
-            ModuleParameters = moduleParameters;
+            this.ModuleParameters = moduleParameters;
         }
 
         #region Module Method Interface
@@ -92,7 +92,12 @@ namespace Blish_HUD.Modules {
         public void DoLoad() {
             this.RunState = ModuleRunState.Loading;
 
-            _loadTask = Task.Run(LoadAsync);
+            _loadTask = Task.Run(InternalLoadAsync);
+        }
+
+        private async Task InternalLoadAsync() {
+            await this.ModuleParameters.LoadAsync();
+            await LoadAsync();
         }
 
         private void CheckForLoaded() {

--- a/Blish HUD/GameServices/Modules/ModuleParameters.cs
+++ b/Blish HUD/GameServices/Modules/ModuleParameters.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Blish_HUD.Modules.Managers;
-using Gw2Sharp.WebApi.V2.Models;
 
 namespace Blish_HUD.Modules {
 
@@ -41,7 +41,6 @@ namespace Blish_HUD.Modules {
             var builtModuleParameters = new ModuleParameters {
                 _manifest = manifest,
 
-                // TODO: Change manager registers so that they only need an instance of the ExternalModule and not specific params
                 _settingsManager    = SettingsManager.GetModuleInstance(module),
                 _contentsManager    = ContentsManager.GetModuleInstance(module),
                 _directoriesManager = DirectoriesManager.GetModuleInstance(module),
@@ -61,6 +60,10 @@ namespace Blish_HUD.Modules {
             }
 
             return builtModuleParameters;
+        }
+
+        internal async Task LoadAsync() {
+            await _gw2ApiManager.RenewSubtoken();
         }
 
         public void Dispose() {


### PR DESCRIPTION
- Makes Gw2WebApi calls async friendly.
- Improves logging output for Gw2WebApi service.
- Fixes a bug that could accidentally escalate the privileges on the shared anonymous connection.
- Stopped creating so many ManagedConnections and instead just keep using the existing one.
- Subtokens are requested before modules are told to load so the API _should_ be ready when the module loads (assuming a token could be acquired).
- When a token is removed, update all module subtokens to reflect this if they were using the removed token.
- Stopped requesting subtokens when we know the privileged connection doesn't have a key to use yet.

@agaertner Do you feel this covers everything left that was needed?  If so, we can likely close #496.