### PR TITLE
Fix #499

### DIFF
--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -341,7 +341,9 @@ namespace Blish_HUD.GameIntegration {
                         break;
                 }
 
-                BlishHud.Instance.Form.Visible = !updateResult.Minimized;
+                if (BlishHud.Instance.Form.Visible != !updateResult.Minimized) {
+                    BlishHud.Instance.Form.Visible = !updateResult.Minimized;
+                }
             } else {
                 TryAttachToGw2();
             }


### PR DESCRIPTION
Check form visibility before setting it as the setter is incredibly expensive to use.  Not the cleanest of fixes, but does resolve the performance penalty.  I'd like to eventually get the winform management stuff handled under a window servicemanager under the Overlay service.

Closes #499 