### PR TITLE
Embed PDB in the exe.

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -60,7 +60,7 @@
     <OutputPath>bin\x64\Debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG;WINDOWS;NODIRMODULES;NOMOUSEHOOK</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>full</DebugType>
+    <DebugType>embedded</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
Embed the PDB into the main exe to reduce our footprint in the destination folder (and ensure that when we provide alt exes for users that the PDB is included all just with the one exe).