### PR TITLE
Embed PDB in exe.

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -47,13 +47,18 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DebugType>full</DebugType>
+    <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants>DEBUG;NOMOUSEHOOK;NOKEYBOARDHOOK</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DefineConstants>WINDOWS</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DebugType>embedded</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Embed the PDB into the main exe to reduce our footprint in the destination folder (and ensure that when we provide alt exes for users that the PDB is included all just with the one exe).