### PR TITLE
Color picker - Remove Forced Tint

### DIFF
--- a/Blish HUD/Controls/ColorPicker.cs
+++ b/Blish HUD/Controls/ColorPicker.cs
@@ -61,6 +61,7 @@ namespace Blish_HUD.Controls {
         }
 
         public ColorPicker() : base() {
+            this.ShowTint = true;
             this.Colors                   =  new ObservableCollection<Gw2Sharp.WebApi.V2.Models.Color>();
             this.Colors.CollectionChanged += ColorsOnCollectionChanged;
 
@@ -132,10 +133,10 @@ namespace Blish_HUD.Controls {
             this.ContentRegion = new Rectangle(COLOR_PADDING, COLOR_PADDING, (this.Width - 10) - (COLOR_PADDING * 2), this.Height - (COLOR_PADDING * 2));
         }
 
-        public override void PaintBeforeChildren(SpriteBatch spriteBatch, Rectangle bounds) {
-            // Draw background
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, bounds, Color.Black * 0.5f);
-        }
+        //public override void PaintBeforeChildren(SpriteBatch spriteBatch, Rectangle bounds) {
+        //    // Draw background
+        //    spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, bounds, Color.Black * 0.5f);
+        //}
 
     }
 

--- a/Blish HUD/Controls/ColorPicker.cs
+++ b/Blish HUD/Controls/ColorPicker.cs
@@ -133,11 +133,6 @@ namespace Blish_HUD.Controls {
             this.ContentRegion = new Rectangle(COLOR_PADDING, COLOR_PADDING, (this.Width - 10) - (COLOR_PADDING * 2), this.Height - (COLOR_PADDING * 2));
         }
 
-        //public override void PaintBeforeChildren(SpriteBatch spriteBatch, Rectangle bounds) {
-        //    // Draw background
-        //    spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, bounds, Color.Black * 0.5f);
-        //}
-
     }
 
 }


### PR DESCRIPTION
Replaced forced tint on background of ColorPicker to allow the dev to select Tint, BackgroundColor, or BackgroundTexture, or none (if placing the ColorPicker on a panel, for instance).  

Set the default value ShowTint = true, to closely reproduce the previous setting.  (Panel default of 0.4 instead of previous value 0.5).  This might want to be removed all together to not confuse the dev though.  