### PR TITLE
Locked to 90 made as default frame limiter.

### DIFF
--- a/Blish HUD/GameServices/GraphicsService.cs
+++ b/Blish HUD/GameServices/GraphicsService.cs
@@ -221,7 +221,7 @@ namespace Blish_HUD {
 
         private void DefineSettings(SettingCollection settings) {
             _frameLimiterSetting = settings.DefineSetting("FramerateLimiter",
-                                                          FramerateMethod.SyncWithGame,
+                                                          FramerateMethod.LockedTo90Fps,
                                                           () => Strings.GameServices.GraphicsService.Setting_FramerateLimiter_DisplayName,
                                                           () => Strings.GameServices.GraphicsService.Setting_FramerateLimiter_Description);
 


### PR DESCRIPTION
90 is the new default frame limiter.

- Sync with game still has a tad too much overhead for most users.
- 90 should cover most high bound FPS scenarios.
- VSync is enabled by default which should bring it back down to 60 if the user doesn't support it anyways.

This will not override what other users have selected if they have manually selected an option.