### PR TITLE
Fix manually specified mumblelink

### DIFF
--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -256,6 +255,8 @@ namespace Blish_HUD.GameIntegration {
         }
 
         private Process GetMumbleSpecifiedGw2Process() {
+            GameService.Gw2Mumble.RefreshClient();
+
             if (GameService.Gw2Mumble.IsAvailable) {
                 return GetGw2ProcessByPID((int)GameService.Gw2Mumble.Info.ProcessId, "Mumble reported PID");
             }

--- a/Blish HUD/GameServices/Gw2MumbleService.cs
+++ b/Blish HUD/GameServices/Gw2MumbleService.cs
@@ -5,13 +5,14 @@ using Gw2Sharp;
 using Microsoft.Xna.Framework;
 using Gw2Sharp.Mumble;
 using System.Text.RegularExpressions;
+
 namespace Blish_HUD {
 
     public class Gw2MumbleService : GameService {
 
         private const string DEFAULT_MUMBLEMAPNAME = "MumbleLink";
 
-        private static readonly Regex MUMBLE_LINK_REGEX = new Regex("^.+-mumble\\s+?\"(.+?)\".*$", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex MUMBLE_LINK_REGEX = new Regex("^.+-mumble\\s+?\"?([^\" ]*)\"?.*$", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private readonly TimeSpan _syncDelay = TimeSpan.FromMilliseconds(3);
 
@@ -19,6 +20,8 @@ namespace Blish_HUD {
 
         /// <inheritdoc cref="Gw2MumbleClient"/>
         public IGw2MumbleClient RawClient { get; private set; }
+
+        public string CurrentMumbleMapName { get; private set; } = DEFAULT_MUMBLEMAPNAME;
 
         #region Categorized Mumble Data
 
@@ -61,7 +64,7 @@ namespace Blish_HUD {
 
         internal Gw2MumbleService() {
             _gw2Client = new Gw2Client();
-            this.RawClient = GetRawClient();
+            RefreshClient();
 
             this.Info            = new Info(this);
             this.PlayerCharacter = new PlayerCharacter(this);
@@ -77,6 +80,10 @@ namespace Blish_HUD {
         }
 
         private void GameIntegrationOnGw2Started(object sender, EventArgs e) {
+            RefreshClient();
+        }
+
+        internal void RefreshClient() {
             this.RawClient = GetRawClient();
         }
 
@@ -114,8 +121,12 @@ namespace Blish_HUD {
         }
 
         private IGw2MumbleClient GetRawClient() {
-            string linkName = GetLinkName();
-            return _gw2Client.Mumble[linkName];
+            this.CurrentMumbleMapName = GetLinkName();
+            
+            var client = _gw2Client.Mumble[this.CurrentMumbleMapName];
+            client.Update(); // We update once to at least indicate that it's alive.
+
+            return client;
         }
 
         private string GetLinkName() {

--- a/Blish HUD/GameServices/Overlay/UI/Views/AboutView.cs
+++ b/Blish HUD/GameServices/Overlay/UI/Views/AboutView.cs
@@ -82,8 +82,8 @@ namespace Blish_HUD.Overlay.UI.Views {
             mumbleConnection.Show(new ConnectionStatusView().WithPresenter(new ConnectionStatusPresenter(() => Strings.GameServices.OverlayService.ConnectionStatus_Mumble_Name,
                                                                                                          () => GameService.Gw2Mumble.IsAvailable,
                                                                                                          () => GameService.Gw2Mumble.IsAvailable
-                                                                                                                   ? string.Format(Strings.GameServices.OverlayService.ConnectionStatus_Mumble_Connected, ApplicationSettings.Instance.MumbleMapName ?? "mumblelink")
-                                                                                                                   : string.Format(Strings.GameServices.OverlayService.ConnectionStatus_Mumble_Disconnected, ApplicationSettings.Instance.MumbleMapName ?? "mumblelink"))));
+                                                                                                                   ? string.Format(Strings.GameServices.OverlayService.ConnectionStatus_Mumble_Connected, GameService.Gw2Mumble.CurrentMumbleMapName)
+                                                                                                                   : string.Format(Strings.GameServices.OverlayService.ConnectionStatus_Mumble_Disconnected, GameService.Gw2Mumble.CurrentMumbleMapName))));
 
             arcdpsBridgeConnection.Show(new ConnectionStatusView().WithPresenter(new ConnectionStatusPresenter(() => Strings.GameServices.OverlayService.ConnectionStatus_ArcDPSBridge_Name,
                                                                                                                () => !GameService.ArcDps.HudIsActive,


### PR DESCRIPTION
- Updated command line search pattern to make double quotes optional since it doesn't appear to be included always.
- Ensure that we refresh the raw client anytime we detect a new process to help ensure we can auto detect, still avoid falling back when manually specified, and fallback when not manually specified.

Fixes #522 