### PR TITLE
Implement EnabledWithoutGW2 per the manifest spec

### DIFF
--- a/Blish HUD/BlishHud.cs
+++ b/Blish HUD/BlishHud.cs
@@ -111,6 +111,7 @@ namespace Blish_HUD {
                 // If gw2 isn't open so only run the essentials
                 GameService.Debug.DoUpdate(gameTime);
                 GameService.GameIntegration.DoUpdate(gameTime);
+                GameService.Module.DoUpdate(gameTime);
 
                 for (int i = 0; i < 200; i++) { // Wait ~10 seconds between checks
                     if (GameService.GameIntegration.Gw2Instance.Gw2IsRunning || GameService.Overlay.Exiting) break;

--- a/Blish HUD/GameServices/GameService.cs
+++ b/Blish HUD/GameServices/GameService.cs
@@ -77,9 +77,9 @@ namespace Blish_HUD {
         public static readonly OverlayService         Overlay;
         public static readonly InputService           Input;
         public static readonly GameIntegrationService GameIntegration;
-        public static readonly ModuleService          Module;
         public static readonly ArcDpsService          ArcDps;
         public static readonly ContextsService        Contexts;
+        public static readonly ModuleService          Module;
 
         #endregion
 
@@ -96,9 +96,9 @@ namespace Blish_HUD {
                 Graphics        = new GraphicsService(),
                 Overlay         = new OverlayService(),
                 GameIntegration = new GameIntegrationService(),
-                Module          = new ModuleService(),
                 ArcDps          = new ArcDpsService(),
-                Contexts        = new ContextsService()
+                Contexts        = new ContextsService(),
+                Module          = new ModuleService()
             };
 
         }


### PR DESCRIPTION
- Change service load order so that modules are always last so that they have the most recent data they can possibly have.
- Enabled support for EnabledWithoutGW2.
- Ensured modules don't load before Blish HUD is tied to a game instance unless EnabledWithoutGW2 is true.

Idle pre-Gw2 memory usage has been cut down significantly as a result as there are no idle modules sitting there doing nothing.