### PR TITLE
Show base version + prerelease in AboutView.  Not the hash.

### DIFF
--- a/Blish HUD/GameServices/Overlay/UI/Views/AboutView.cs
+++ b/Blish HUD/GameServices/Overlay/UI/Views/AboutView.cs
@@ -56,7 +56,7 @@ namespace Blish_HUD.Overlay.UI.Views {
             var version = new Label() {
                 AutoSizeHeight = true,
                 AutoSizeWidth  = true,
-                Text           = $"Blish HUD v{Program.OverlayVersion}",
+                Text           = $"Blish HUD v{Program.OverlayVersion.BaseAndPrerelease()}",
                 Font           = GameService.Content.DefaultFont14,
                 StrokeText     = true,
                 ClipsBounds    = false,

--- a/Blish HUD/_Extensions/VersionExtensions.cs
+++ b/Blish HUD/_Extensions/VersionExtensions.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Blish_HUD {
+    internal static class VersionExtensions {
+
+        public static string BaseAndPrerelease(this SemVer.Version version) {
+            return version.ToString().Split(new char[]{ '+' }, StringSplitOptions.RemoveEmptyEntries)[0];
+        }
+
+    }
+}


### PR DESCRIPTION
Changes the about page to show the version without the build details (hash, etc.)