### PR TITLE
Option to launch Guild Wars 2 with Blish HUD.

### DIFF
--- a/Blish HUD/ApplicationSettings.cs
+++ b/Blish HUD/ApplicationSettings.cs
@@ -104,7 +104,7 @@ namespace Blish_HUD {
             OptionParameter(OPTION_STARTGW2, 'g'),
             Help("Allows you to launch Guild Wars 2 with Blish HUD (0 = don't start, 1 = start gw2, 2 = start gw2 autologin).")
         ]
-        public int StartGw2 { get; private set; } = -1;
+        public int StartGw2 { get; private set; }
 
         public const string OPTION_USERSETTINGSPATH = "settings";
         /// <summary>

--- a/Blish HUD/ApplicationSettings.cs
+++ b/Blish HUD/ApplicationSettings.cs
@@ -46,6 +46,7 @@ namespace Blish_HUD {
          * r, ref       - The path to the ref.dat file.
          * s, settings  - The path where Blish HUD will save settings and other files.
          * w, window    - The name of the window to overlay.
+         * g, startgw2  - The start mode for Gw2 (0 = don't start, 1 = start gw2, 2 = start gw2 autologin).
          */
 
         #region Game Integration
@@ -93,6 +94,17 @@ namespace Blish_HUD {
         #endregion
 
         #region Utility
+
+        public const string OPTION_STARTGW2 = "startgw2";
+        /// <summary>
+        /// If we should launch Gw2 as part of Blish HUD launching.
+        /// 0 = no, 1 = yes, and 2 = yes with autologin.
+        /// </summary>
+        [
+            OptionParameter(OPTION_STARTGW2, 'g'),
+            Help("Allows you to launch Guild Wars 2 with Blish HUD (0 = don't start, 1 = start gw2, 2 = start gw2 autologin).")
+        ]
+        public int StartGw2 { get; private set; } = -1;
 
         public const string OPTION_USERSETTINGSPATH = "settings";
         /// <summary>

--- a/Blish HUD/GameServices/GameIntegration/WinFormsIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/WinFormsIntegration.cs
@@ -27,6 +27,7 @@ namespace Blish_HUD.GameIntegration {
         public override void Load() {
             WrapMainForm();
             BuildTrayIcon();
+            AutoLaunchGame();
         }
 
         private void WrapMainForm() {
@@ -80,6 +81,12 @@ namespace Blish_HUD.GameIntegration {
         private void TrayIconMenuOnOpening(object sender, CancelEventArgs e) {
             _launchGw2Tsi.Enabled = _launchGw2AutoTsi.Enabled = !_service.Gw2Instance.Gw2IsRunning
                                                              && File.Exists(_service.Gw2Instance.Gw2ExecutablePath);
+        }
+
+        private void AutoLaunchGame() {
+            if (ApplicationSettings.Instance.StartGw2 > 0) {
+                LaunchGw2(ApplicationSettings.Instance.StartGw2 > 1);
+            }
         }
 
         private void LaunchGw2(bool autologin = false) {


### PR DESCRIPTION
Adds new `--startgw2` and `-g` option which accepts either a 1 or 2 to autolaunch Guild Wars 2 when Blish HUD starts.  1 indicates normal launch and 2 indicates autologin.

Closes #215