### PR TITLE
Allow Keybindings to block primarykey input

### DIFF
--- a/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
@@ -44,8 +44,6 @@ namespace Blish_HUD.Input {
             get => _enabled;
             set {
                 if (_enabled != value) {
-                    if (this.PrimaryKey == Keys.None && value) return;
-
                     if (value) {
                         GameService.Input.Keyboard.KeyStateChanged += KeyboardOnKeyStateChanged;
                     } else {
@@ -71,6 +69,8 @@ namespace Blish_HUD.Input {
         }
 
         private void KeyboardOnKeyStateChanged(object sender, KeyboardEventArgs e) {
+            if (this.PrimaryKey == Keys.None) return;
+
             CheckTrigger(GameService.Input.Keyboard.ActiveModifiers, GameService.Input.Keyboard.KeysDown);
         }
 

--- a/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
@@ -63,7 +63,7 @@ namespace Blish_HUD.Input {
         /// If <c>true</c>, the <see cref="PrimaryKey"/> is not send to the game when it is
         /// the final key pressed in the keybinding sequence.
         /// </summary>
-        public bool BlocksInput { get; set; } = false;
+        public bool BlockSequenceFromGw2 { get; set; } = false;
 
         private bool _isTriggering;
 
@@ -104,7 +104,7 @@ namespace Blish_HUD.Input {
             if ((this.ModifierKeys & activeModifiers) == this.ModifierKeys) {
                 if (pressedKeys.Contains(this.PrimaryKey)) {
                     Fire();
-                } else if (this.BlocksInput) {
+                } else if (this.BlockSequenceFromGw2) {
                     GameService.Input.Keyboard.StageKeyBinding(this);
                 }
             } else if ((this.ModifierKeys & activeModifiers) != this.ModifierKeys) {

--- a/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
@@ -60,7 +60,7 @@ namespace Blish_HUD.Input {
         }
 
         /// <summary>
-        /// If <c>true</c>, the <see cref="PrimaryKey"/> is not send to the game when it is
+        /// If <c>true</c>, the <see cref="PrimaryKey"/> is not sent to the game when it is
         /// the final key pressed in the keybinding sequence.
         /// </summary>
         public bool BlockSequenceFromGw2 { get; set; } = false;

--- a/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
@@ -102,16 +102,19 @@ namespace Blish_HUD.Input {
             if (GameService.Gw2Mumble.UI.IsTextInputFocused) return;
 
             if ((this.ModifierKeys & activeModifiers) == this.ModifierKeys) {
-                if (pressedKeys.Contains(this.PrimaryKey)) {
-                    Fire();
-                } else if (this.BlockSequenceFromGw2) {
+                if (this.BlockSequenceFromGw2) {
                     GameService.Input.Keyboard.StageKeyBinding(this);
                 }
-            } else if ((this.ModifierKeys & activeModifiers) != this.ModifierKeys) {
+
+                if (pressedKeys.Contains(this.PrimaryKey)) {
+                    Fire();
+                    return;
+                }
+            } else {
                 GameService.Input.Keyboard.UnstageKeyBinding(this);
-            } else if (_isTriggering) {
-                StopFiring();
             }
+
+            StopFiring();
         }
 
         /// <summary>

--- a/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
@@ -80,6 +80,8 @@ namespace Blish_HUD.Input {
         
         private Action<string> _textInputDelegate;
 
+        private readonly HashSet<KeyBinding> _stagedKeyBindings = new HashSet<KeyBinding>();
+
         internal KeyboardHandler() { }
 
         public void Update() {
@@ -143,8 +145,6 @@ namespace Blish_HUD.Input {
 
             return true;
         }
-
-        private readonly HashSet<KeyBinding> _stagedKeyBindings = new HashSet<KeyBinding>();
 
         internal void StageKeyBinding(KeyBinding keyBinding) {
             lock (_stagedKeyBindings) {

--- a/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
@@ -93,8 +93,9 @@ namespace Blish_HUD.Input {
                     if (_keysDown.Contains(keyboardEvent.Key)) continue;
 
                     _keysDown.Add(keyboardEvent.Key);
-                } else
+                } else {
                     _keysDown.Remove(keyboardEvent.Key);
+                }
 
                 UpdateStates();
 
@@ -201,6 +202,7 @@ namespace Blish_HUD.Input {
             if (_stagedKeyBindingLock.TryEnterReadLock(0)) {
                 foreach (var keyBinding in _stagedKeyBindings) {
                     if (keyBinding.PrimaryKey == key) {
+                        _stagedKeyBindingLock.ExitReadLock();
                         return true;
                     }
                 }

--- a/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
@@ -210,8 +210,6 @@ namespace Blish_HUD.Input {
                 _stagedKeyBindingLock.ExitReadLock();
             }
 
-            // TODO: Implement blocking based on the key that is pressed (for example: Key binding blocking the last pressed key)
-
             return false;
         }
 

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -87,8 +87,9 @@ namespace Blish_HUD {
             this.ShowInTaskbar = settings.DefineSetting("ShowInTaskbar", false,                              () => Strings.GameServices.OverlayService.Setting_ShowInTaskbar_DisplayName, () => Strings.GameServices.OverlayService.Setting_ShowInTaskbar_Description);
             this.OpenBlishWindow = settings.DefineSetting(nameof(this.OpenBlishWindow), new KeyBinding(ModifierKeys.Shift | ModifierKeys.Ctrl, Keys.B), () => Strings.GameServices.OverlayService.Setting_ToggleBlishWindowKeybind_DisplayName, () => Strings.GameServices.OverlayService.Setting_ToggleBlishWindowKeybind_Description);
 
-            this.OpenBlishWindow.Value.Enabled = true;
-            this.OpenBlishWindow.Value.Activated += delegate { this.BlishHudWindow.ToggleWindow(); };
+            this.OpenBlishWindow.Value.BlockSequenceFromGw2 =  true;
+            this.OpenBlishWindow.Value.Enabled              =  true;
+            this.OpenBlishWindow.Value.Activated            += delegate { this.BlishHudWindow.ToggleWindow(); };
 
             // TODO: See https://github.com/blish-hud/Blish-HUD/issues/282
             this.UserLocale.SetExcluded(Locale.Chinese);


### PR DESCRIPTION
Adds new property `BlockSequenceFromGw2` on KeyBindings which, when the primary key of that binding is the last key in the sequence, the key will be blocked from being sent to the game.  This can prevent Blish HUD keybindings from mistakenly activating Gw2 bindings.

This is still optional as some keybindings are intended to silently fire when the actual in-game one is fired (for example: interact).

The toggle for the Blish HUD window (CTRL + SHIFT + B by default) has been set to block.

Finally, a change was made to the enabled property.  Previously you could set a keybinding to be enabled, but it would silently disable itself because it had no keys set.  We now will enable regardless of the keybindings state and when a key is pressed, we'll check then to see if we have the prerequisites before firing.  This reduces confusion for those utilizing keybindings in their code that enabled them before the primary key was set.