### PR TITLE
Fix small issue with saving settings and disable StayInTray if we launch with -g or --startgw2

### DIFF
--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -359,7 +359,9 @@ namespace Blish_HUD.GameIntegration {
 
             Logger.Info("Guild Wars 2 application has exited!");
 
-            if (!GameService.Overlay.StayInTray.Value) {
+            // We close the game if we are not configured to stay in the tray OR if we launched GW2 with
+            // command line (we don't want to relaunch the game with a restart).  Otherwise, we restart.
+            if (!GameService.Overlay.StayInTray.Value || ApplicationSettings.Instance.StartGw2 > 0) {
                 GameService.Overlay.Exit();
             } else {
                 GameService.Overlay.Restart();

--- a/Blish HUD/GameServices/GameIntegration/WinFormsIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/WinFormsIntegration.cs
@@ -9,6 +9,8 @@ using Blish_HUD.Properties;
 namespace Blish_HUD.GameIntegration {
     public class WinFormsIntegration : ServiceModule<GameIntegrationService> {
 
+        private static readonly Logger Logger = Logger.GetLogger<WinFormsIntegration>();
+
         private Form _formWrapper;
 
         private NotifyIcon _trayIcon;
@@ -110,7 +112,11 @@ namespace Blish_HUD.GameIntegration {
                     }
                 };
 
+                Logger.Info("Blish HUD starting Guild Wars 2 with args '{gw2Args}'", string.Join(" ", args));
+
                 gw2Proc.Start();
+            } else {
+                Logger.Warn("Blish HUD failed to launch Guild Wars 2.  The path we have is null or does not exist.  Try again after the game has been successfully detected by Blish HUD.");
             }
         }
 

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -83,13 +83,18 @@ namespace Blish_HUD {
 
         private void DefineSettings(SettingCollection settings) {
             this.UserLocale    = settings.DefineSetting("AppCulture",    GetGw2LocaleFromCurrentUICulture(), () => Strings.GameServices.OverlayService.Setting_AppCulture_DisplayName,    () => Strings.GameServices.OverlayService.Setting_AppCulture_Description);
-            this.StayInTray    = settings.DefineSetting("StayInTray",    true,                               () => Strings.GameServices.OverlayService.Setting_StayInTray_DisplayName,    () => Strings.GameServices.OverlayService.Setting_StayInTray_Description);
+            this.StayInTray    = settings.DefineSetting("StayInTray",    true,                               () => Strings.GameServices.OverlayService.Setting_StayInTray_DisplayName,    () => Strings.GameServices.OverlayService.Setting_StayInTray_Description + (ApplicationSettings.Instance.StartGw2 > 0 ? " (Disabled because you launched Blish HUD with --startgw2 or -g)" : ""));
             this.ShowInTaskbar = settings.DefineSetting("ShowInTaskbar", false,                              () => Strings.GameServices.OverlayService.Setting_ShowInTaskbar_DisplayName, () => Strings.GameServices.OverlayService.Setting_ShowInTaskbar_Description);
             this.OpenBlishWindow = settings.DefineSetting(nameof(this.OpenBlishWindow), new KeyBinding(ModifierKeys.Shift | ModifierKeys.Ctrl, Keys.B), () => Strings.GameServices.OverlayService.Setting_ToggleBlishWindowKeybind_DisplayName, () => Strings.GameServices.OverlayService.Setting_ToggleBlishWindowKeybind_Description);
 
             this.OpenBlishWindow.Value.BlockSequenceFromGw2 =  true;
             this.OpenBlishWindow.Value.Enabled              =  true;
             this.OpenBlishWindow.Value.Activated            += delegate { this.BlishHudWindow.ToggleWindow(); };
+
+            // Lock 'StayInTray' if we launched Guild Wars 2 with a launch argument.
+            if (ApplicationSettings.Instance.StartGw2 > 0) {
+                this.StayInTray.SetDisabled();
+            }
 
             // TODO: See https://github.com/blish-hud/Blish-HUD/issues/282
             this.UserLocale.SetExcluded(Locale.Chinese);


### PR DESCRIPTION
Fixed an issue with settings not saving properly.  Disable the StayInTray option setting when -g or --startgw2 is used.