### PR TITLE
Fix for logfile cleanup

### DIFF
--- a/Blish HUD/GameServices/DebugService.cs
+++ b/Blish HUD/GameServices/DebugService.cs
@@ -49,10 +49,6 @@ namespace Blish_HUD {
                 FileNameKind      = FilePathKind.Absolute,
                 ArchiveFileKind   = FilePathKind.Absolute,
                 FileName          = Path.Combine(logPath, "blishhud.${cached:${date:format=yyyyMMdd-HHmmss}}.log"),
-                ArchiveFileName   = Path.Combine(logPath, "blishhud.${cached:${date:format=yyyyMMdd-HHmmss}}.{#}.log"),
-                ArchiveDateFormat = "yyyyMMdd-HHmmss",
-                ArchiveAboveSize  = MAX_LOG_SIZE,
-                ArchiveNumbering  = ArchiveNumberingMode.Sequence,
                 MaxArchiveFiles   = MAX_LOG_SESSIONS,
                 EnableFileDelete  = true,
                 CreateDirs        = true,
@@ -80,16 +76,6 @@ namespace Blish_HUD {
             LogManager.Configuration = _logConfiguration;
 
             Logger = Logger.GetLogger<DebugService>();
-
-            // Cleanup old logfiles since nLog logrotate can't handle timestamps in filenames
-            DirectoryInfo di = new DirectoryInfo(logPath);
-            var logsToBeDeleted = (from log in di.GetFiles("blishhud.*.log", SearchOption.TopDirectoryOnly)
-                                   orderby log.LastWriteTime descending, log.Name descending
-                                   select log).Skip(MAX_LOG_SESSIONS).ToArray();
-            foreach (var log in logsToBeDeleted) {
-                Logger.Debug("Logile cleanup: " + log);
-                File.Delete(log.FullName);
-            }
         }
 
         public static void TargetDebug(string time, string level, string logger, string message) {

--- a/Blish HUD/GameServices/DebugService.cs
+++ b/Blish HUD/GameServices/DebugService.cs
@@ -50,6 +50,7 @@ namespace Blish_HUD {
                 ArchiveFileKind   = FilePathKind.Absolute,
                 FileName          = Path.Combine(logPath, "blishhud.${cached:${date:format=yyyyMMdd-HHmmss}}.log"),
                 MaxArchiveFiles   = MAX_LOG_SESSIONS,
+                ArchiveAboveSize  = MAX_LOG_SIZE,
                 EnableFileDelete  = true,
                 CreateDirs        = true,
                 Encoding          = Encoding.UTF8,

--- a/Blish HUD/GameServices/DebugService.cs
+++ b/Blish HUD/GameServices/DebugService.cs
@@ -80,6 +80,16 @@ namespace Blish_HUD {
             LogManager.Configuration = _logConfiguration;
 
             Logger = Logger.GetLogger<DebugService>();
+
+            // Cleanup old logfiles since nLog logrotate can't handle timestamps in filenames
+            DirectoryInfo di = new DirectoryInfo(logPath);
+            var logsToBeDeleted = (from log in di.GetFiles("blishhud.*.log", SearchOption.TopDirectoryOnly)
+                                   orderby log.LastWriteTime descending, log.Name descending
+                                   select log).Skip(MAX_LOG_SESSIONS).ToArray();
+            foreach (var log in logsToBeDeleted) {
+                Logger.Debug("Logile cleanup: " + log);
+                File.Delete(log.FullName);
+            }
         }
 
         public static void TargetDebug(string time, string level, string logger, string message) {


### PR DESCRIPTION
Fix for #550

nLog does not support fancy filenames, so we have to enroll our own cleanup routine.