### PR TITLE
Prevent duplicate setting definitions

### DIFF
--- a/Blish HUD/GameServices/Settings/SettingCollection.cs
+++ b/Blish HUD/GameServices/Settings/SettingCollection.cs
@@ -118,6 +118,7 @@ namespace Blish_HUD.Settings {
 
             _entryLock.EnterWriteLock();
             _undefinedEntries.Remove(definedEntry);
+            _definedEntries.Remove(definedEntry);
             _definedEntries.Add(definedEntry);
             _entryLock.ExitWriteLock();
 


### PR DESCRIPTION
Seen when modules are disabled and enabled multiple times.  Looks like I forgot to ensure we remove them from the defined list if they were previously defined.