### PR TITLE
Manual incompatibility listing.

### DIFF
--- a/Blish HUD/ref/compatibility.json
+++ b/Blish HUD/ref/compatibility.json
@@ -1,0 +1,3 @@
+{
+  "Taimi.UndaDaSea_BlishHUD": "<2.0.0" // Audio dependency changes break UndaDaSea in early versions.
+}


### PR DESCRIPTION
Add manual compatibility listings so that releases can occur without loading modules that would normally crash Blish HUD on launch.