### PR TITLE
Fix #563

### DIFF
--- a/Blish HUD/GameServices/GraphicsService.cs
+++ b/Blish HUD/GameServices/GraphicsService.cs
@@ -198,17 +198,19 @@ namespace Blish_HUD {
         public Point Resolution {
             get => new Point(BlishHud.Instance.ActiveGraphicsDeviceManager.PreferredBackBufferWidth, BlishHud.Instance.ActiveGraphicsDeviceManager.PreferredBackBufferHeight);
             set {
-                try {
-                    BlishHud.Instance.ActiveGraphicsDeviceManager.PreferredBackBufferWidth  = value.X;
-                    BlishHud.Instance.ActiveGraphicsDeviceManager.PreferredBackBufferHeight = value.Y;
+                if (!this.Resolution.Equals(value)) {
+                    try {
+                        BlishHud.Instance.ActiveGraphicsDeviceManager.PreferredBackBufferWidth  = value.X;
+                        BlishHud.Instance.ActiveGraphicsDeviceManager.PreferredBackBufferHeight = value.Y;
 
-                    BlishHud.Instance.ActiveGraphicsDeviceManager.ApplyChanges();
+                        BlishHud.Instance.ActiveGraphicsDeviceManager.ApplyChanges();
 
-                    // Exception would be from the code above, but don't update our
-                    // scaling if there is an exception
-                    ScreenSizeUpdated(value);
-                } catch (SharpDX.SharpDXException sdxe) {
-                    // If device lost, we should hopefully handle in device lost event below
+                        // Exception would be from the code above, but don't update our
+                        // scaling if there is an exception
+                        ScreenSizeUpdated(value);
+                    } catch (SharpDX.SharpDXException sdxe) {
+                        // If device lost, we should hopefully handle in device lost event below
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hopefully fixes #563 - or is at least a band-aid for it. The allocation was occurring inside the `GraphicsDeviceManager.ApplyChanges()` call in: https://github.com/blish-hud/Blish-HUD/blob/87d19ea57cf63f98c9bd0f03db698c3727dcf4f5/Blish%20HUD/GameServices/GraphicsService.cs#L198-L214

`ApplyChanges` was called each time the resolution property was set, which was each time the window gained focus - this change should prevent it from being called when the Resolution is unchanged on re-focus.