### PR TITLE
Ensure scissor rectangle is properly scaled when a control is set to not clip bounds.

### DIFF
--- a/Blish HUD/Controls/Control.cs
+++ b/Blish HUD/Controls/Control.cs
@@ -381,7 +381,6 @@ namespace Blish_HUD.Controls {
 
         #endregion
 
-        // TODO: Allow controls to skip clipping via a "ClipsBounds" setting
         public bool ClipsBounds { get; set; } = true;
 
         private ControlEffect _effectBehind;
@@ -777,7 +776,7 @@ namespace Blish_HUD.Controls {
                 spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, drawBounds, _backgroundColor);
 
             if (!this.ClipsBounds) {
-                Graphics.GraphicsDevice.ScissorRectangle = Graphics.SpriteScreen.LocalBounds;
+                Graphics.GraphicsDevice.ScissorRectangle = Graphics.SpriteScreen.LocalBounds.ScaleBy(Graphics.UIScaleMultiplier);
             }
 
             // Draw control


### PR DESCRIPTION
Fixes #562 

An old bug that went unnoticed caused controls that were set not to clip bounds to assign the screen scaled bounds to the scissor instead of the non-screen scaled bounds.