### PR TITLE
Hopefully fixes all of the input issues encountered occassionally

### DIFF
--- a/Blish HUD/DebugHelper/Models/MouseEventMessage.cs
+++ b/Blish HUD/DebugHelper/Models/MouseEventMessage.cs
@@ -17,7 +17,7 @@ namespace Blish_HUD.DebugHelper.Models {
 
         [ProtoMember(106)] public int Time { get; set; }
 
-        [ProtoMember(107)] public int ExtraInfo { get; set; }
+        [ProtoMember(107)] public long ExtraInfo { get; set; }
 
     }
 

--- a/Blish HUD/DebugHelper/Native/MOUSELLHOOKSTRUCT.cs
+++ b/Blish HUD/DebugHelper/Native/MOUSELLHOOKSTRUCT.cs
@@ -9,7 +9,7 @@ namespace Blish_HUD.DebugHelper.Native {
         public int   mouseData;
         public int   flags;
         public int   time;
-        public int   extraInfo;
+        public long  extraInfo;
 
     }
 

--- a/Blish HUD/GameServices/Input/Mouse/MouseEventArgs.cs
+++ b/Blish HUD/GameServices/Input/Mouse/MouseEventArgs.cs
@@ -36,7 +36,7 @@ namespace Blish_HUD.Input {
 
         internal int Time { get; }
 
-        internal int Extra { get; }
+        internal long Extra { get; }
 
         internal int WheelDelta {
             get {
@@ -52,10 +52,10 @@ namespace Blish_HUD.Input {
 
         internal MouseEventArgs(MouseEventType eventType, MouseLLHookStruct details) : this(
                                                                                             eventType, details.Point.X, details.Point.Y, details.MouseData, details.Flags,
-                                                                                            details.Time, (int)details.Extra
+                                                                                            details.Time, (long)details.Extra
                                                                                            ) { }
 
-        internal MouseEventArgs(MouseEventType eventType, int pointX, int pointY, int mouseData, int flags, int time, int extraInfo) : this(eventType) {
+        internal MouseEventArgs(MouseEventType eventType, int pointX, int pointY, int mouseData, int flags, int time, long extraInfo) : this(eventType) {
             this.PointX    = pointX;
             this.PointY    = pointY;
             this.MouseData = mouseData;


### PR DESCRIPTION
Looks like the struct we were using for the mouse input was wrong and there's some flag that causes the Extras field to overflow the poor int which was crashing the mouse hook.  We weren't catching this because the mouse hook was successfully being created - it just wasn't crashing until after one of these inputs with the extra data occurred and as it was on a different thread, we weren't seeing it throw.

I'm not actually sure what the extra data is on the input, but we've corrected the data type as a long which appears to have resolved the issue.