### PR TITLE
Fix/560 better module skip

### DIFF
--- a/Blish HUD/GameServices/ModuleService.cs
+++ b/Blish HUD/GameServices/ModuleService.cs
@@ -117,7 +117,6 @@ namespace Blish_HUD {
                                                   _moduleStates.Value[moduleManifest.Namespace],
                                                   moduleReader);
 
-            // Avoid loading modules in the compatibility listing.
             if (ModuleIsExplicitlyIncompatible(moduleManager)) {
                 Logger.Warn("The module {module} is not compatible with this version of Blish HUD so it will not allow you to enable it.  Please remove the module or update to a compatible version if one is available.",
                             moduleManifest.GetDetailedName(),

--- a/Blish HUD/GameServices/ModuleService.cs
+++ b/Blish HUD/GameServices/ModuleService.cs
@@ -68,6 +68,11 @@ namespace Blish_HUD {
             _exportedOnVersions = settings.DefineSetting(EXPORTED_VERSION_SETTING,  new List<string>());
         }
 
+        internal bool ModuleIsExplicitlyIncompatible(ModuleManager moduleManager) {
+            return _incompatibleModules.Any(compatibilityListing => string.Equals(moduleManager.Manifest.Namespace, compatibilityListing.Namespace, StringComparison.OrdinalIgnoreCase)
+                                                                 && compatibilityListing.VersionRange.IsSatisfied(moduleManager.Manifest.Version.BaseVersion()));
+        }
+
         public ModuleManager RegisterModule(IDataReader moduleReader) {
             if (!moduleReader.FileExists(MODULE_MANIFESTNAME)) {
                 Logger.Warn("Attempted to load an invalid module {modulePath}: {manifestName} is missing.", moduleReader.GetPathRepresentation(), MODULE_MANIFESTNAME);
@@ -90,16 +95,8 @@ namespace Blish_HUD {
 
             // Avoid loading the same module multiple times (we just load the first one that we found).
             if (_modules.Any(module => string.Equals(moduleManifest.Namespace, module.Manifest.Namespace, StringComparison.OrdinalIgnoreCase))) {
-                Logger.Warn("A module with the namespace {moduleNamespace} has has already been loaded.  The module at path {modulePath} will not be loaded.  Please remove the duplicate module.",
+                Logger.Warn("A module with the namespace {moduleNamespace} has has already been loaded.  The module at path {modulePath} will not be loaded.  Please remove any duplicate module(s).",
                             moduleManifest.Namespace,
-                            moduleReader.GetPathRepresentation());
-                return null;
-            }
-
-            // Avoid loading modules in the compatibility listing.
-            if (_incompatibleModules.Any(compatibilityListing => string.Equals(moduleManifest.Namespace, compatibilityListing.Namespace, StringComparison.OrdinalIgnoreCase) && compatibilityListing.VersionRange.IsSatisfied(moduleManifest.Version))) {
-                Logger.Warn("The module {module} is not compatible with this version of Blish HUD so it will not be loaded.  Please remove the module or update to a compatible version if one is available.",
-                            moduleManifest.GetDetailedName(),
                             moduleReader.GetPathRepresentation());
                 return null;
             }
@@ -108,9 +105,16 @@ namespace Blish_HUD {
                 _moduleStates.Value.Add(moduleManifest.Namespace, new ModuleState());
             }
 
-            var moduleManager  = new ModuleManager(moduleManifest,
-                                                   _moduleStates.Value[moduleManifest.Namespace],
-                                                   moduleReader);
+            var moduleManager = new ModuleManager(moduleManifest,
+                                                  _moduleStates.Value[moduleManifest.Namespace],
+                                                  moduleReader);
+
+            // Avoid loading modules in the compatibility listing.
+            if (ModuleIsExplicitlyIncompatible(moduleManager)) {
+                Logger.Warn("The module {module} is not compatible with this version of Blish HUD so it will not allow you to enable it.  Please remove the module or update to a compatible version if one is available.",
+                            moduleManifest.GetDetailedName(),
+                            moduleReader.GetPathRepresentation());
+            }
 
             _modules.Add(moduleManager);
 

--- a/Blish HUD/GameServices/Modules/ModuleManager.cs
+++ b/Blish HUD/GameServices/Modules/ModuleManager.cs
@@ -64,7 +64,10 @@ namespace Blish_HUD.Modules {
         }
 
         public bool TryEnable() {
-            if (this.Enabled || this.IsModuleAssemblyStateDirty) return false;
+            if (this.Enabled                                             // We're already enabled.
+             || this.IsModuleAssemblyStateDirty                          // User updated the module after the old assembly had already been enabled.
+             || GameService.Module.ModuleIsExplicitlyIncompatible(this)) // Module is on the explicit "incompatibile" list.
+                return false;
 
             var moduleParams = ModuleParameters.BuildFromManifest(this.Manifest, this);
 

--- a/Blish HUD/GameServices/Modules/UI/Presenters/ManageModulePresenter.cs
+++ b/Blish HUD/GameServices/Modules/UI/Presenters/ManageModulePresenter.cs
@@ -134,9 +134,13 @@ namespace Blish_HUD.Modules.UI.Presenters {
         }
 
         private void DisplayStateDetails() {
-            this.View.ModuleState = Model.ModuleInstance?.RunState ?? ModuleRunState.Unloaded;
+            if (!GameService.Module.ModuleIsExplicitlyIncompatible(this.Model)) {
+                this.View.ModuleState = Model.ModuleInstance?.RunState ?? ModuleRunState.Unloaded;
 
-            GameService.Settings.Save();
+                GameService.Settings.Save();
+            } else {
+                this.View.SetCustomState(Strings.GameServices.ModulesService.ModuleState_Custom_ExplicitlyIncompatible, Control.StandardColors.Yellow);
+            }
 
             DisplaySettingsView(this.View.ModuleState == ModuleRunState.Loaded);
         }
@@ -214,7 +218,11 @@ namespace Blish_HUD.Modules.UI.Presenters {
             // Can't enable if already enabled
             if (this.Model.Enabled) return false;
 
-            // can't enable if model assembly is dirty
+            // Can't enable if the module is on the explicit
+            // "incompatible" list.
+            if (GameService.Module.ModuleIsExplicitlyIncompatible(this.Model)) return false;
+
+            // Can't enable if module's assembly is dirty
             // (i.e. previous version of it has been loaded)
             if (this.Model.IsModuleAssemblyStateDirty) return false;
 

--- a/Blish HUD/GameServices/Modules/UI/Views/ManageModuleView.cs
+++ b/Blish HUD/GameServices/Modules/UI/Views/ManageModuleView.cs
@@ -148,6 +148,11 @@ namespace Blish_HUD.Modules.UI.Views {
             }
         }
 
+        public void SetCustomState(string status, Color color) {
+            UpdateModuleRunState(status, color);
+            UpdateHeaderLayout();
+        }
+
         protected override void Build(Container buildPanel) {
             // Header
 

--- a/Blish HUD/Strings/GameServices/ModulesService.Designer.cs
+++ b/Blish HUD/Strings/GameServices/ModulesService.Designer.cs
@@ -322,6 +322,15 @@ namespace Blish_HUD.Strings.GameServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Module Version Is Too Old.
+        /// </summary>
+        internal static string ModuleState_Custom_ExplicitlyIncompatible {
+            get {
+                return ResourceManager.GetString("ModuleState_Custom_ExplicitlyIncompatible", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Disabled.
         /// </summary>
         internal static string ModuleState_Disabled {

--- a/Blish HUD/Strings/GameServices/ModulesService.resx
+++ b/Blish HUD/Strings/GameServices/ModulesService.resx
@@ -239,4 +239,7 @@ Download some modules and place them in the modules folder.</value>
   <data name="ModuleOption_DeleteModule" xml:space="preserve">
     <value>Delete Module</value>
   </data>
+  <data name="ModuleState_Custom_ExplicitlyIncompatible" xml:space="preserve">
+    <value>Module Version Is Too Old</value>
+  </data>
 </root>

--- a/Blish HUD/ref/compatibility.json
+++ b/Blish HUD/ref/compatibility.json
@@ -1,3 +1,4 @@
 {
+  "bh.general.markersandpaths": "*",   // Replaced by Pathing module.
   "Taimi.UndaDaSea_BlishHUD": "<2.0.0" // Audio dependency changes break UndaDaSea in early versions.
 }


### PR DESCRIPTION
Addresses #560 

- We now load modules marked explicitly incompatible still and now just display a warning on the module page.
- Added Markers & Paths to the list of explicitly unsupported since it never defined a Blish HUD dependency.
- The latest version of a module is now loaded if there are duplicates instead of whichever one was loaded first.