### PR TITLE
Minor fixes

### DIFF
--- a/Blish HUD/GameServices/GameIntegration/AudioIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/AudioIntegration.cs
@@ -168,7 +168,14 @@ namespace Blish_HUD.GameIntegration {
 
             _gw2AudioDevices.Clear();
             foreach (var device in _deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active)) {
-                var sessionEnumerator = device.AudioSessionManager.Sessions;
+                SessionCollection sessionEnumerator = null;
+
+                try {
+                    sessionEnumerator = device.AudioSessionManager.Sessions;
+                } catch (COMException ex) when ((uint)ex.HResult == 0x88890008) {
+                    // Skip this audio device.  Something about it is unsupported.
+                    continue;
+                }
 
                 bool shouldDispose = true;
                 for (int i = 0; i < sessionEnumerator.Count; i++) {

--- a/Blish HUD/GameServices/GameIntegration/GfxSettingsIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/GfxSettingsIntegration.cs
@@ -135,8 +135,15 @@ namespace Blish_HUD.GameIntegration {
         }
 
         private void EnableWatchDir() {
+            string gw2AppDataPath = Path.Combine(_service.Gw2Instance.AppDataPath, GFXSETTINGS_PATH);
+
+            if (!Directory.Exists(gw2AppDataPath)) {
+                Logger.Warn("Guild Wars 2 AppData path '{appDataPath}' does not appear to exist so GfxSettings will not be loaded.", gw2AppDataPath);
+                return;
+            }
+
             _fileSystemWatcher = new FileSystemWatcher {
-                Path                  = Path.Combine(_service.Gw2Instance.AppDataPath, GFXSETTINGS_PATH),
+                Path                  = gw2AppDataPath,
                 NotifyFilter          = NotifyFilters.LastWrite,
                 Filter                = GFXSETTINGS_NAME,
                 EnableRaisingEvents   = true,
@@ -191,7 +198,6 @@ namespace Blish_HUD.GameIntegration {
         }
 
         private async Task LoadGfxSettings(int remainingAttempts) {
-
             try {
                 if (TryGetGfxSettingsFileStream(out var gfxSettingsFileStream)) {
                     using (var gfxSettingsXmlReader = XmlReader.Create(gfxSettingsFileStream, new XmlReaderSettings { Async = true })) {
@@ -237,9 +243,11 @@ namespace Blish_HUD.GameIntegration {
 
         public override void Unload() {
             _service.Gw2Instance.Gw2Started -= Gw2Proc_Gw2Started;
-            _fileSystemWatcher.Changed      -= GfxSettingsFileChanged;
 
-            _fileSystemWatcher.Dispose();
+            if (_fileSystemWatcher != null) {
+                _fileSystemWatcher.Changed -= GfxSettingsFileChanged;
+                _fileSystemWatcher.Dispose();
+            }
         }
     }
 }

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -137,6 +137,8 @@ namespace Blish_HUD {
 
         private void ApplyInitialSettings() {
             UserLocaleOnSettingChanged(this.UserLocale, new ValueChangedEventArgs<Locale>(GetGw2LocaleFromCurrentUICulture(), this.UserLocale.Value));
+
+            GameIntegration.WinForms.SetShowInTaskbar(GameIntegration.Gw2Instance.Gw2IsRunning && this.ShowInTaskbar.Value);
         }
 
         private void ShowInTaskbarOnSettingChanged(object sender, ValueChangedEventArgs<bool> e) {


### PR DESCRIPTION
- Should fix issues with task bar icon showing when it's turned off.
- Fixes an issue where the user doesn't have GW2 installed which will crash Blish HUD (for users doing dev work).
- Hopefully fixes an issue with some audio devices which are unsupported.