### PR TITLE
Allow custom textbox background color

### DIFF
--- a/Blish HUD/Controls/MultilineTextBox.cs
+++ b/Blish HUD/Controls/MultilineTextBox.cs
@@ -8,6 +8,16 @@ namespace Blish_HUD.Controls {
         private const int TEXT_TOPPADDING  = 7;
         private const int TEXT_LEFTPADDING = 10;
 
+        private Color _textBackgroundColor = Color.Black;
+        public Color TextBackgroundColor {
+            get => _textBackgroundColor;
+            set {
+                if (_textBackgroundColor.Equals(value)) return;
+                _textBackgroundColor = value;
+                OnPropertyChanged(nameof(TextBackgroundColor));
+            }
+        }
+
         public MultilineTextBox() {
             _multiline = true;
             _maxLength = 524288;
@@ -194,23 +204,23 @@ namespace Blish_HUD.Controls {
 
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
             // Background tint
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, 1, bounds.Width - 2, bounds.Height - 2), Color.Black * 0.5f);
+            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, 1, bounds.Width - 2, bounds.Height - 2), TextBackgroundColor * 0.5f);
 
             // Top
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, 0, bounds.Width - 2, 2), Color.Black * 0.3f);
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, 0, bounds.Width - 2, 1), Color.Black * 0.2f);
+            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, 0, bounds.Width - 2, 2), TextBackgroundColor * 0.3f);
+            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, 0, bounds.Width - 2, 1), TextBackgroundColor * 0.2f);
 
             // Left
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(0, 1, 2, bounds.Height - 2), Color.Black * 0.3f);
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(0, 1, 1, bounds.Height - 2), Color.Black * 0.2f);
+            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(0, 1, 2, bounds.Height - 2), TextBackgroundColor * 0.3f);
+            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(0, 1, 1, bounds.Height - 2), TextBackgroundColor * 0.2f);
 
             // Bottom
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, bounds.Height - 2, bounds.Width - 2, 2), Color.Black * 0.3f);
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, bounds.Height - 2, bounds.Width - 2, 1), Color.Black * 0.2f);
+            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, bounds.Height - 2, bounds.Width - 2, 2), TextBackgroundColor * 0.3f);
+            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, bounds.Height - 2, bounds.Width - 2, 1), TextBackgroundColor * 0.2f);
 
             // Right
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(bounds.Width - 2, 1, 2, bounds.Height - 2), Color.Black * 0.3f);
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(bounds.Width - 2, 1, 1, bounds.Height - 2), Color.Black * 0.2f);
+            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(bounds.Width - 2, 1, 2, bounds.Height - 2), TextBackgroundColor * 0.3f);
+            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(bounds.Width - 2, 1, 1, bounds.Height - 2), TextBackgroundColor * 0.2f);
 
             PaintText(spriteBatch, _textRegion);
             

--- a/Blish HUD/Controls/MultilineTextBox.cs
+++ b/Blish HUD/Controls/MultilineTextBox.cs
@@ -11,11 +11,7 @@ namespace Blish_HUD.Controls {
         private bool _hideBackground;
         public bool HideBackground {
             get => _hideBackground;
-            set {
-                if (_hideBackground == value) return;
-                _hideBackground = value;
-                OnPropertyChanged(nameof(HideBackground));
-            }
+            set => SetProperty(ref _hideBackground, value);
         }
 
         public MultilineTextBox() {
@@ -203,7 +199,7 @@ namespace Blish_HUD.Controls {
         protected override void UpdateScrolling() { /* NOOP */ }
 
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
-            if (!HideBackground) {
+            if (!this.HideBackground) {
                 // Background tint
                 spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, 1, bounds.Width - 2, bounds.Height - 2), Color.Black * 0.5f);
 

--- a/Blish HUD/Controls/MultilineTextBox.cs
+++ b/Blish HUD/Controls/MultilineTextBox.cs
@@ -8,13 +8,13 @@ namespace Blish_HUD.Controls {
         private const int TEXT_TOPPADDING  = 7;
         private const int TEXT_LEFTPADDING = 10;
 
-        private Color _textBackgroundColor = Color.Black;
-        public Color TextBackgroundColor {
-            get => _textBackgroundColor;
+        private bool _hideBackground;
+        public bool HideBackground {
+            get => _hideBackground;
             set {
-                if (_textBackgroundColor.Equals(value)) return;
-                _textBackgroundColor = value;
-                OnPropertyChanged(nameof(TextBackgroundColor));
+                if (_hideBackground == value) return;
+                _hideBackground = value;
+                OnPropertyChanged(nameof(HideBackground));
             }
         }
 
@@ -203,24 +203,26 @@ namespace Blish_HUD.Controls {
         protected override void UpdateScrolling() { /* NOOP */ }
 
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
-            // Background tint
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, 1, bounds.Width - 2, bounds.Height - 2), TextBackgroundColor * 0.5f);
+            if (!HideBackground) {
+                // Background tint
+                spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, 1, bounds.Width - 2, bounds.Height - 2), Color.Black * 0.5f);
 
-            // Top
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, 0, bounds.Width - 2, 2), TextBackgroundColor * 0.3f);
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, 0, bounds.Width - 2, 1), TextBackgroundColor * 0.2f);
+                // Top
+                spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, 0, bounds.Width - 2, 2), Color.Black * 0.3f);
+                spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, 0, bounds.Width - 2, 1), Color.Black * 0.2f);
 
-            // Left
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(0, 1, 2, bounds.Height - 2), TextBackgroundColor * 0.3f);
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(0, 1, 1, bounds.Height - 2), TextBackgroundColor * 0.2f);
+                // Left
+                spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(0, 1, 2, bounds.Height - 2), Color.Black * 0.3f);
+                spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(0, 1, 1, bounds.Height - 2), Color.Black * 0.2f);
 
-            // Bottom
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, bounds.Height - 2, bounds.Width - 2, 2), TextBackgroundColor * 0.3f);
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, bounds.Height - 2, bounds.Width - 2, 1), TextBackgroundColor * 0.2f);
+                // Bottom
+                spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, bounds.Height - 2, bounds.Width - 2, 2), Color.Black * 0.3f);
+                spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(1, bounds.Height - 2, bounds.Width - 2, 1), Color.Black * 0.2f);
 
-            // Right
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(bounds.Width - 2, 1, 2, bounds.Height - 2), TextBackgroundColor * 0.3f);
-            spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(bounds.Width - 2, 1, 1, bounds.Height - 2), TextBackgroundColor * 0.2f);
+                // Right
+                spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(bounds.Width - 2, 1, 2, bounds.Height - 2), Color.Black * 0.3f);
+                spriteBatch.DrawOnCtrl(this, ContentService.Textures.Pixel, new Rectangle(bounds.Width - 2, 1, 1, bounds.Height - 2), Color.Black * 0.2f);
+            }
 
             PaintText(spriteBatch, _textRegion);
             

--- a/Blish HUD/Controls/Textbox.cs
+++ b/Blish HUD/Controls/Textbox.cs
@@ -26,6 +26,16 @@ namespace Blish_HUD.Controls {
         /// </summary>
         public event EventHandler<EventArgs> EnterPressed;
 
+        private bool _hideBackground;
+        public bool HideBackground {
+            get => _hideBackground;
+            set {
+                if (_hideBackground == value) return;
+                _hideBackground = value;
+                OnPropertyChanged(nameof(HideBackground));
+            }
+        }
+
         protected virtual void OnEnterPressed(EventArgs e) {
             this.Focused = false;
 
@@ -129,14 +139,20 @@ namespace Blish_HUD.Controls {
         }
 
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
-            spriteBatch.DrawOnCtrl(this,
-                                   _textureTextbox,
-                                   new Rectangle(Point.Zero, _size - new Point(5, 0)),
-                                   new Rectangle(0, 0, Math.Min(_textureTextbox.Width - 5, _size.X - 5), _textureTextbox.Height));
+            if (!HideBackground) {
+                spriteBatch.DrawOnCtrl(
+                                       this,
+                                       _textureTextbox,
+                                       new Rectangle(Point.Zero, _size - new Point(5, 0)),
+                                       new Rectangle(0,          0, Math.Min(_textureTextbox.Width - 5, _size.X - 5), _textureTextbox.Height)
+                                      );
 
-            spriteBatch.DrawOnCtrl(this, _textureTextbox,
-                                   new Rectangle(_size.X - 5, 0, 5, _size.Y),
-                                   new Rectangle(_textureTextbox.Width - 5, 0, 5, _textureTextbox.Height));
+                spriteBatch.DrawOnCtrl(
+                                       this, _textureTextbox,
+                                       new Rectangle(_size.X               - 5, 0, 5, _size.Y),
+                                       new Rectangle(_textureTextbox.Width - 5, 0, 5, _textureTextbox.Height)
+                                      );
+            }
 
             PaintText(spriteBatch, _textRegion);
 

--- a/Blish HUD/Controls/Textbox.cs
+++ b/Blish HUD/Controls/Textbox.cs
@@ -29,11 +29,7 @@ namespace Blish_HUD.Controls {
         private bool _hideBackground;
         public bool HideBackground {
             get => _hideBackground;
-            set {
-                if (_hideBackground == value) return;
-                _hideBackground = value;
-                OnPropertyChanged(nameof(HideBackground));
-            }
+            set => SetProperty(ref _hideBackground, value);
         }
 
         protected virtual void OnEnterPressed(EventArgs e) {
@@ -139,7 +135,7 @@ namespace Blish_HUD.Controls {
         }
 
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
-            if (!HideBackground) {
+            if (!this.HideBackground) {
                 spriteBatch.DrawOnCtrl(
                                        this,
                                        _textureTextbox,


### PR DESCRIPTION
Small tweak to hide the background of a multiline textbox in order to use a custom one or to have it react dynamically on focus change.
The simple textbox uses a texture and I wasn't sure if I should redo it to be drawn by a single pixel like in the multiline textbox. I could remove the texture and allow color customization here as well.