### PR TITLE
Remove SyncWithGame option and fix restart.

### DIFF
--- a/Blish HUD/GameServices/GraphicsService.cs
+++ b/Blish HUD/GameServices/GraphicsService.cs
@@ -254,6 +254,16 @@ namespace Blish_HUD {
                                                          () => Strings.GameServices.GraphicsService.Setting_Vsync_DisplayName,
                                                          () => Strings.GameServices.GraphicsService.Setting_Vsync_Description);
 
+            if (_frameLimiterSetting.Value == FramerateMethod.SyncWithGame || _frameLimiterSetting.Value == FramerateMethod.Custom) {
+                // SyncWithGame is no longer supported.  It causes more problems than it solves.
+                // We revert to the default settings for both the framerate limiter and vsync.
+
+                // Likewise, Custom framerates are only possible via launch option currently.
+                // Old versions could enable it, so this fixes that.
+                _frameLimiterSetting.Value = FramerateMethod.LockedTo90Fps;
+                _enableVsyncSetting.Value  = true;
+            }
+
             _smoothCharacterPositionSetting = settings.DefineSetting("EnableCharacterPositionBuffer",
                                                                      true,
                                                                      () => Strings.GameServices.GraphicsService.Setting_SmoothCharacterPosition_DisplayName,
@@ -277,7 +287,7 @@ namespace Blish_HUD {
             EnableVsyncChanged(_enableVsyncSetting, new ValueChangedEventArgs<bool>(_enableVsyncSetting.Value, _enableVsyncSetting.Value));
             FrameLimiterSettingMethodChanged(_enableVsyncSetting, new ValueChangedEventArgs<FramerateMethod>(_frameLimiterSetting.Value, _frameLimiterSetting.Value));
 
-            _frameLimiterSetting.SetExcluded(FramerateMethod.Custom);
+            _frameLimiterSetting.SetExcluded(FramerateMethod.Custom, FramerateMethod.SyncWithGame);
 
             if (ApplicationSettings.Instance.TargetFramerate > 0) {
                 // Disable frame limiter setting and update description - user has manually specified via launch arg

--- a/Blish HUD/Program.cs
+++ b/Blish HUD/Program.cs
@@ -1,8 +1,10 @@
 ﻿using Blish_HUD.DebugHelper.Services;
 using EntryPoint;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -23,8 +25,6 @@ namespace Blish_HUD {
         public static SemVer.Version OverlayVersion { get; } = new SemVer.Version(typeof(BlishHud).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion, true);
 
         internal static bool RestartOnExit { get; set; } = false;
-
-        private static string[] _startupArgs;
 
         private static void EnableLogging() {
             // Make sure logging and logging services are available as soon as possible
@@ -66,7 +66,6 @@ namespace Blish_HUD {
             HandleArcDps11Contingency();
             HandleMinTls12Contingency();
 
-            _startupArgs = args;
             var settings = Cli.Parse<ApplicationSettings>(args);
 
             if (settings.MainProcessId.HasValue) {
@@ -118,9 +117,12 @@ namespace Blish_HUD {
                     }
 
                     if (RestartOnExit) {
+                        // REF: https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/Application.cs,1447
+                        var arguments = Environment.GetCommandLineArgs().Skip(1).Select(arg => $"\"{arg}\"");
+
                         var currentStartInfo = Process.GetCurrentProcess().StartInfo;
                         currentStartInfo.FileName  = Application.ExecutablePath;
-                        currentStartInfo.Arguments = string.Join(" ", _startupArgs);
+                        currentStartInfo.Arguments = string.Join(" ", arguments);
 
                         Process.Start(currentStartInfo);
                     }


### PR DESCRIPTION
- Removed SyncWithGame frame sync option as it only causes more issues than it solves.  Users with it set will be swapped to 90FpsLock and vsync on.
- Fixed issue when restarting Blish HUD not keeping the launch args properly quoted.