### PR TITLE
Fix API keys mistakenly being shared between modules.

### DIFF
--- a/Blish HUD/GameServices/Gw2WebApiService.cs
+++ b/Blish HUD/GameServices/Gw2WebApiService.cs
@@ -202,6 +202,11 @@ namespace Blish_HUD {
         #endregion
 
         public ManagedConnection GetConnection(string accessToken) {
+            // Avoid caching connections without an API key
+            if (string.IsNullOrWhiteSpace(accessToken)) {
+                return new ManagedConnection(string.Empty, _sharedTokenBucketMiddleware, _sharedWebCache, _sharedRenderCache);
+            }
+
             return _cachedConnections.GetOrAdd(accessToken, (token) => new ManagedConnection(token, _sharedTokenBucketMiddleware, _sharedWebCache, _sharedRenderCache));
         }
 


### PR DESCRIPTION
Stop caching the base managed connection and causing issues with modules accidentally sharing managed connections.