### PR TITLE
Revise module loggers and fix keybind property.

### DIFF
--- a/Blish HUD/GameServices/Debug/Logger.cs
+++ b/Blish HUD/GameServices/Debug/Logger.cs
@@ -1,16 +1,23 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using NLog;
 
 namespace Blish_HUD {
     public class Logger {
 
+        #region Static
+
+        private static readonly ConcurrentDictionary<Type, Logger> _loggers = new ConcurrentDictionary<Type, Logger>();
+
         public static Logger GetLogger(Type type) {
-            return new Logger(type);
+            return _loggers.GetOrAdd(type, (t) => new Logger(t));
         }
 
         public static Logger GetLogger<T>() {
-            return new Logger(typeof(T));
+            return _loggers.GetOrAdd(typeof(T), (t) => new Logger(t));
         }
+
+        #endregion
 
         private readonly NLog.Logger _internalLogger;
 

--- a/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
@@ -63,9 +63,16 @@ namespace Blish_HUD.Input {
         /// If <c>true</c>, the <see cref="PrimaryKey"/> is not sent to the game when it is
         /// the final key pressed in the keybinding sequence.
         /// </summary>
+        [JsonIgnore]
         public bool BlockSequenceFromGw2 { get; set; } = false;
-
-        private bool _isTriggering;
+        
+        /// <summary>
+        /// Indicates if the <see cref="KeyBinding"/> is actively triggered.
+        /// If triggered with <see cref="ManuallyTrigger"/>(), this
+        /// will report <c>true</c> for only a single frame.
+        /// </summary>
+        [JsonIgnore]
+        public bool IsTriggering { get; private set; }
 
         public KeyBinding() { /* NOOP */ }
 
@@ -87,15 +94,15 @@ namespace Blish_HUD.Input {
         }
 
         private void Fire() {
-            if (_isTriggering) return;
+            if (this.IsTriggering) return;
 
-            _isTriggering = true;
+            this.IsTriggering = true;
 
             ManuallyTrigger();
         }
 
         private void StopFiring() {
-            _isTriggering = false;
+            this.IsTriggering = false;
         }
 
         private void CheckTrigger(ModifierKeys activeModifiers, IEnumerable<Keys> pressedKeys) {

--- a/Blish HUD/GameServices/ModuleService.cs
+++ b/Blish HUD/GameServices/ModuleService.cs
@@ -339,7 +339,7 @@ namespace Blish_HUD {
                     try {
                         module.ModuleInstance.DoUpdate(gameTime);
                     } catch (Exception ex) {
-                        Logger.Error(ex, "Module {module} threw an exception while updating.", module.Manifest.GetDetailedName());
+                        Logger.GetLogger(module.GetType()).Error(ex, "Module {module} threw an exception while updating.", module.Manifest.GetDetailedName());
 
                         if (ApplicationSettings.Instance.DebugEnabled) {
                             // To assist in debugging modules
@@ -360,7 +360,7 @@ namespace Blish_HUD {
                         Logger.Info("Unloading module {module}.", module.Manifest.GetDetailedName());
                         module.ModuleInstance.Dispose();
                     } catch (Exception ex) {
-                        Logger.Error(ex, "Module '{module} threw an exception while unloading.", module.Manifest.GetDetailedName());
+                        Logger.GetLogger(module.GetType()).Error(ex, "Module '{module} threw an exception while unloading.", module.Manifest.GetDetailedName());
 
                         if (ApplicationSettings.Instance.DebugEnabled) {
                             // To assist in debugging modules

--- a/Blish HUD/GameServices/Modules/Module.cs
+++ b/Blish HUD/GameServices/Modules/Module.cs
@@ -107,7 +107,7 @@ namespace Blish_HUD.Modules {
                     OnModuleException(loadError);
 
                     if (!loadError.Observed && _loadTask.Exception != null) {
-                        Logger.Error(_loadTask.Exception, "Module {module} had an unhandled exception while loading.", ModuleParameters.Manifest.GetDetailedName());
+                        Logger.GetLogger(GetType()).Error(_loadTask.Exception, "Module {module} had an unhandled exception while loading.", ModuleParameters.Manifest.GetDetailedName());
 
                         if (ApplicationSettings.Instance.DebugEnabled) {
                             throw _loadTask.Exception;


### PR DESCRIPTION
- IsTriggering is now publicly exposed on keybindings.
- Module loggers now use the actual module class as their logger type to ensure that we properly associate those logging events with the correct module.
- Loggers are now cached by type.