### PR TITLE
Multiple edge case fixes.

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -49,7 +49,7 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>DEBUG;NOMOUSEHOOK;NOKEYBOARDHOOK</DefineConstants>
+    <DefineConstants>DEBUG;NOMOUSEHOOK;NOKEYBOARDHOOK;THROWONBADTEXTURE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -49,7 +49,7 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>DEBUG;NOMOUSEHOOK;NOKEYBOARDHOOK;THROWONBADTEXTURE</DefineConstants>
+    <DefineConstants>DEBUG;NOMOUSEHOOK;NOKEYBOARDHOOK</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/Blish HUD/Controls/Tooltip.cs
+++ b/Blish HUD/Controls/Tooltip.cs
@@ -19,7 +19,7 @@ namespace Blish_HUD.Controls {
 
         private static Thickness _contentEdgeBuffer;
 
-        private static List<Tooltip> _allTooltips;
+        private static ControlCollection<Tooltip> _allTooltips;
 
         private static Texture2D _textureTooltip;
 
@@ -28,7 +28,7 @@ namespace Blish_HUD.Controls {
 
             _textureTooltip = Content.GetTexture("tooltip");
 
-            _allTooltips = new List<Tooltip>();
+            _allTooltips = new ControlCollection<Tooltip>();
 
             ActiveControlChanged   += ControlOnActiveControlChanged;
             Input.Mouse.MouseMoved += HandleMouseMoved;

--- a/Blish HUD/GameServices/Debug/Contingency.cs
+++ b/Blish HUD/GameServices/Debug/Contingency.cs
@@ -19,13 +19,12 @@ namespace Blish_HUD.Debug {
 
             _contingency.Add(key);
 
-            // Disable hooks and hide the UI, just in case.
-            GameService.Input?.DisableHooks();
-
-            if (BlishHud.Instance.Form.InvokeRequired) {
-                BlishHud.Instance.Form.Invoke((MethodInvoker)(() => BlishHud.Instance.Form.Hide()));
-            } else {
-                BlishHud.Instance.Form.Hide();
+            if (BlishHud.Instance != null) {
+                if (BlishHud.Instance.Form.InvokeRequired) {
+                    BlishHud.Instance.Form.Invoke((MethodInvoker)(() => BlishHud.Instance.Form.Hide()));
+                } else {
+                    BlishHud.Instance.Form.Hide();
+                }
             }
 
             var notifDiag = new TaskDialog() {
@@ -79,6 +78,13 @@ namespace Blish_HUD.Debug {
                               Strings.GameServices.Debug.ContingencyMessages.MissingRef_Title,
                               Strings.GameServices.Debug.ContingencyMessages.MissingRef_Description,
                               "https://link.blishhud.com/missingref");
+        }
+
+        internal static void NotifyCfaBlocking(string path) {
+            NotifyContingency(nameof(NotifyCfaBlocking),
+                              Strings.GameServices.Debug.ContingencyMessages.CfaBlocking_Title,
+                              string.Format(Strings.GameServices.Debug.ContingencyMessages.CfaBlocking_Description, path),
+                              "https://link.blishhud.com/cfablocking");
         }
 
         public static void NotifyFileSaveAccessDenied(string path, string actionDescription, bool promptPortableMode = false) {

--- a/Blish HUD/GameServices/Debug/ContingencyChecks.cs
+++ b/Blish HUD/GameServices/Debug/ContingencyChecks.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using Microsoft.Win32;
+
+namespace Blish_HUD.Debug {
+    internal static class ContingencyChecks {
+
+        public static void RunAll() {
+            CheckArcDps11Injected();
+            CheckMinTls12();
+            CheckControlledFolderAccessBlocking();
+        }
+
+        /// <summary>
+        /// Typically occurs when ArcDps is placed in the same directory as Blish HUD
+        /// and causes Blish HUD to crash almost immediately due to an access violation.
+        /// </summary>
+        private static void CheckArcDps11Injected() {
+            // TODO: Get SetDllDirectory("") working so that we can protect ourselves from this!
+            if (File.Exists("d3d11.dll")) {
+                Contingency.NotifyArcDpsSameDir();
+            }
+        }
+
+        /// <summary>
+        /// Typically occurs on Windows 7 where Tls 1.2 has not been configured as the default.
+        /// </summary>
+        private static void CheckMinTls12() {
+            // https://link.blishhud.com/tls12issue
+            if (!ServicePointManager.SecurityProtocol.HasFlag(SecurityProtocolType.Tls12)) {
+                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+            }
+        }
+
+        /// <summary>
+        /// Indicates if CFA (Windows Ransomeware protection) is enabled.
+        /// This feature prevents us from initializing our log file or writing out our settings.
+        /// </summary>
+        private static void CheckControlledFolderAccessBlocking() {
+            using (var cfaRoot = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\Controlled Folder Access")) {
+                if (cfaRoot == null) {
+                    return;
+                }
+
+                if (cfaRoot.GetValue("EnableControlledFolderAccess", 0) as int? == 1) {
+                    try {
+                        string cfaTestFile = Path.Combine(DirectoryUtil.BasePath, ".cfa");
+
+                        File.WriteAllText(cfaTestFile, "cfa");
+
+                        if (File.Exists(cfaTestFile) && File.ReadAllText(cfaTestFile) == "cfa") {
+                            File.Delete(cfaTestFile);
+                        }
+                    } catch (Exception) {
+                        // The chances that this isn't CFA are pretty slim.
+                        Contingency.NotifyCfaBlocking(DirectoryUtil.BasePath);
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -337,9 +337,9 @@ namespace Blish_HUD.GameIntegration {
                     case WindowUtil.OverlayUpdateResponse.Errored:
                         switch (updateResult.ErrorCode) {
                             case 1400:
-                                this.Gw2Process.Refresh();
-
-                                if (this.Gw2Process.MainWindowHandle == IntPtr.Zero) {
+                                this.Gw2Process?.Refresh();
+                                
+                                if (this.Gw2Process == null || this.Gw2Process.MainWindowHandle == IntPtr.Zero) {
                                     // Guild Wars 2 most likely closed
                                     goto case -1;
                                 }

--- a/Blish HUD/Program.cs
+++ b/Blish HUD/Program.cs
@@ -26,6 +26,14 @@ namespace Blish_HUD {
 
         internal static bool RestartOnExit { get; set; } = false;
 
+        [ThreadStatic]
+        private static readonly bool _isMainThread = true;
+
+        /// <summary>
+        /// Indicates if the current thread is the main thread.
+        /// </summary>
+        public static bool IsMainThread => _isMainThread;
+
         private static void EnableLogging() {
             // Make sure logging and logging services are available as soon as possible
             DebugService.InitDebug();

--- a/Blish HUD/Program.cs
+++ b/Blish HUD/Program.cs
@@ -47,32 +47,12 @@ namespace Blish_HUD {
             }
         }
 
-        private static void HandleArcDps11Contingency() {
-            // TODO: Get SetDllDirectory("") working so that we can protect ourselves from this!
-            // Typically occurs when ArcDps is placed in the same directory as Blish HUD
-            // and causes Blish HUD to crash almost immediately due to an access violation.
-            if (File.Exists("d3d11.dll")) {
-                Debug.Contingency.NotifyArcDpsSameDir();
-            }
-        }
-
-        private static void HandleMinTls12Contingency() {
-            // Typically occurs on Windows 7 where Tls 1.2 has not been configured as the default.
-            // https://link.blishhud.com/tls12issue
-            if (!ServicePointManager.SecurityProtocol.HasFlag(SecurityProtocolType.Tls12)) {
-                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
-            }
-        }
-
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
         private static void Main(string[] args) {
             Directory.SetCurrentDirectory(Path.GetDirectoryName(Application.ExecutablePath));
-
-            HandleArcDps11Contingency();
-            HandleMinTls12Contingency();
 
             var settings = Cli.Parse<ApplicationSettings>(args);
 
@@ -81,6 +61,8 @@ namespace Blish_HUD {
                 RunDebugHelper(settings.MainProcessId.Value);
                 return;
             }
+
+            Debug.ContingencyChecks.RunAll();
 
             // Check to see if we're currently mid-upgrade
             var attemptUpdate = Overlay.SelfUpdater.SelfUpdateUtil.TryHandleUpdate();
@@ -114,7 +96,6 @@ namespace Blish_HUD {
                     using (var game = new BlishHud()) {
                         game.Run();
                     }
-
                 } finally {
                     if (ownsMutex) {
                         // only release if we acquired ownership

--- a/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.Designer.cs
+++ b/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.Designer.cs
@@ -79,6 +79,26 @@ namespace Blish_HUD.Strings.GameServices.Debug {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Blish HUD was actively blocked saving to &apos;{0}&apos; by what appears to Window&apos;s Controlled Folder Access feature.
+        ///
+        ///Please explicitly allow Blish HUD in your &quot;Controlled Folder Access&quot; settings or review the troubleshooting guide linked below..
+        /// </summary>
+        internal static string CfaBlocking_Description {
+            get {
+                return ResourceManager.GetString("CfaBlocking_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Blish HUD Blocked!.
+        /// </summary>
+        internal static string CfaBlocking_Title {
+            get {
+                return ResourceManager.GetString("CfaBlocking_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Update to v{0} of Blish HUD failed.  Relaunch Blish HUD to try again.  The error was:
         ///
         ///{1}.

--- a/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.resx
+++ b/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.resx
@@ -156,4 +156,12 @@ If you have an anti-virus or third party firewall utility, please ensure that Bl
   <data name="CoreUpdateFailed_Description_Timeout" xml:space="preserve">
     <value>There are other instances of Blish HUD running.  Please close the other instances first and then run Blish HUD again to complete the update.</value>
   </data>
+  <data name="CfaBlocking_Title" xml:space="preserve">
+    <value>Blish HUD Blocked!</value>
+  </data>
+  <data name="CfaBlocking_Description" xml:space="preserve">
+    <value>Blish HUD was actively blocked saving to '{0}' by what appears to Window's Controlled Folder Access feature.
+
+Please explicitly allow Blish HUD in your "Controlled Folder Access" settings or review the troubleshooting guide linked below.</value>
+  </data>
 </root>

--- a/Blish HUD/_Extensions/SpriteBatchExtensions.cs
+++ b/Blish HUD/_Extensions/SpriteBatchExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using Blish_HUD.Controls;
-using Blish_HUD;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.BitmapFonts;

--- a/Blish HUD/_Utils/TextureUtil.cs
+++ b/Blish HUD/_Utils/TextureUtil.cs
@@ -37,16 +37,20 @@ namespace Blish_HUD {
                     case -2005270523:
                         // HRESULT: [0x887A0005], Module: [SharpDX.DXGI], ApiCode: [DXGI_ERROR_DEVICE_REMOVED/DeviceRemoved]
                         // The GPU device instance has been suspended. Use GetDeviceRemovedReason to determine the appropriate action.
-                        if (!Program.IsMainThread) {
-                            Logger.Error(ex, "Something attempted to create a texture off of the main thread.");
-                        }
-
-                        texture = ContentService.Textures.Error;
                         break;
                 }
+            } catch (AccessViolationException) {
+                // Not sure how this happens.
             }
 
-            return texture;
+            if (!Program.IsMainThread) {
+                Logger.Debug("Something attempted to create a texture off of the main thread - this is dangerous and should be resolved as it will eventually throw an exception for something.");
+                #if DEBUG && THROWONBADTEXTURE
+                throw new InvalidOperationException("A texture was made outside of the main thread.  Textures should be created on the main thread only.");
+                #endif
+            }
+
+            return texture ?? ContentService.Textures.Error;
         }
 
         private static byte ApplyAlpha(byte color, byte alpha) {

--- a/Blish HUD/_Utils/TextureUtil.cs
+++ b/Blish HUD/_Utils/TextureUtil.cs
@@ -1,9 +1,12 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Blish_HUD {
     public static class TextureUtil {
+
+        private static readonly Logger Logger = Logger.GetLogger(typeof(TextureUtil));
 
         /// <summary>
         /// Creates a Texture2D from a stream, supports formats bmp, gif, jpg, png, tif and dds.
@@ -12,20 +15,36 @@ namespace Blish_HUD {
         /// </summary>
         /// <remarks>https://community.monogame.net/t/texture2d-fromstream-in-3-7/10973/9</remarks>
 		public static Texture2D FromStreamPremultiplied(GraphicsDevice graphics, Stream stream) {
-            var texture = Texture2D.FromStream(graphics, stream);
+            Texture2D texture = null;
 
-            Color[] data = new Color[texture.Width * texture.Height];
-            texture.GetData(data);
+            try {
+                texture = Texture2D.FromStream(graphics, stream);
 
-            for (int i = 0; i < data.Length; ++i) {
-                byte a = data[i].A;
+                Color[] data = new Color[texture.Width * texture.Height];
+                texture.GetData(data);
 
-                data[i].R = ApplyAlpha(data[i].R, a);
-                data[i].G = ApplyAlpha(data[i].G, a);
-                data[i].B = ApplyAlpha(data[i].B, a);
+                for (int i = 0; i < data.Length; ++i) {
+                    byte a = data[i].A;
+
+                    data[i].R = ApplyAlpha(data[i].R, a);
+                    data[i].G = ApplyAlpha(data[i].G, a);
+                    data[i].B = ApplyAlpha(data[i].B, a);
+                }
+
+                texture.SetData(data);
+            } catch (SharpDX.SharpDXException ex) {
+                switch (ex.HResult) {
+                    case -2005270523:
+                        // HRESULT: [0x887A0005], Module: [SharpDX.DXGI], ApiCode: [DXGI_ERROR_DEVICE_REMOVED/DeviceRemoved]
+                        // The GPU device instance has been suspended. Use GetDeviceRemovedReason to determine the appropriate action.
+                        if (!Program.IsMainThread) {
+                            Logger.Error(ex, "Something attempted to create a texture off of the main thread.");
+                        }
+
+                        texture = ContentService.Textures.Error;
+                        break;
+                }
             }
-
-            texture.SetData(data);
 
             return texture;
         }


### PR DESCRIPTION
- Fixes several issues identified by the error submission module.
  - Issues with Tooltips not being thread-safe.
  - Issue with a race condition as Guild Wars 2 closes.
  - Properly notify when CFA is enabled.
  - Return failed texture load instead of crashing Blish HUD when a texture is loaded on the wrong thread.
- Fixes a bug that would cause Blish HUD to crash just before reporting issues with ArcDPS injecting itself into Blish HUD.