### PR TITLE
Revised exception to ensure all API failures are caught and handled.

### DIFF
--- a/Blish HUD/GameServices/Gw2WebApi/UI/Views/RegisterApiKeyView.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/UI/Views/RegisterApiKeyView.cs
@@ -310,10 +310,10 @@ namespace Blish_HUD.Gw2WebApi.UI.Views {
                     SetTokenStatus(ApiTokenStatusType.Failed, Strings.GameServices.Gw2ApiService.TokenStatus_InvalidToken);
                 } catch (AuthorizationRequiredException) {
                     SetTokenStatus(ApiTokenStatusType.Failed, Strings.GameServices.Gw2ApiService.TokenStatus_AccountFailed);
-                } catch (UnexpectedStatusException) {
-                    SetTokenStatus(ApiTokenStatusType.Failed, Strings.Common.Unknown);
                 } catch (RequestCanceledException) {
                     // NOOP keep existing status to avoid walking over the call that cancelled us
+                } catch (Exception) {
+                    SetTokenStatus(ApiTokenStatusType.Failed, Strings.Common.Unknown);
                 }
             } else {
                 SetTokenStatus(ApiTokenStatusType.Neutral);


### PR DESCRIPTION
Gw2Sharp has some of the exceptions inherit from exceptions with generics making it difficult to properly catch them.  Instead of attempting to catch the parent exception here, we'll instead just catch on `Exception` as a catch-all.

Resolves #619 