### PR TITLE
Fix #614 Add Selection dragging support to TextInputBase

### DIFF
--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -752,8 +752,8 @@ namespace Blish_HUD.Controls {
         }
 
         protected void HandleMouseSelectionDrag(int newIndex) {
-            this.SelectionStart = Math.Min(_cursorIndex, newIndex);
-            this.SelectionEnd = Math.Max(_cursorIndex, newIndex);
+            UserSetCursorIndex(newIndex);
+            this.SelectionEnd = newIndex;
         }
 
         protected override void OnLeftMouseButtonPressed(MouseEventArgs e) {

--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -198,6 +198,7 @@ namespace Blish_HUD.Controls {
         protected bool _multiline;
         protected bool _caretVisible;
         protected bool _cursorMoved;
+        protected bool _cursorDragging;
 
         private TimeSpan _lastInvalidate;
         private bool     _insertMode;
@@ -744,12 +745,24 @@ namespace Blish_HUD.Controls {
             }
         }
 
+        protected void HandleMouseSelectionDrag(int newIndex) {
+            this.SelectionStart = Math.Min(_cursorIndex, newIndex);
+            this.SelectionEnd = Math.Max(_cursorIndex, newIndex);
+        }
+
         protected override void OnLeftMouseButtonPressed(MouseEventArgs e) {
             base.OnLeftMouseButtonPressed(e);
 
             this.Focused = true;
+            _cursorDragging = true;
 
             HandleMouseUpdatedCursorIndex(GetCursorIndexFromPosition(this.RelativeMousePosition));
+        }
+
+        protected override void OnMouseMoved(MouseEventArgs e) {
+            base.OnMouseMoved(e);
+
+            if (_cursorDragging) HandleMouseSelectionDrag(GetCursorIndexFromPosition(this.RelativeMousePosition));
         }
 
         protected override void OnClick(MouseEventArgs e) {

--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -742,14 +742,20 @@ namespace Blish_HUD.Controls {
             }
         }
 
+        protected override void OnLeftMouseButtonPressed(MouseEventArgs e) {
+            base.OnLeftMouseButtonPressed(e);
+
+            this.Focused = true;
+
+            HandleMouseUpdatedCursorIndex(GetCursorIndexFromPosition(this.RelativeMousePosition));
+        }
+
         protected override void OnClick(MouseEventArgs e) {
             base.OnClick(e);
 
             this.Focused = true;
 
-            int newIndex = GetCursorIndexFromPosition(this.RelativeMousePosition);
-            HandleMouseUpdatedCursorIndex(newIndex);
-            if (e.IsDoubleClick) HandleMouseDoubleClick(newIndex);
+            if (e.IsDoubleClick) HandleMouseDoubleClick(GetCursorIndexFromPosition(this.RelativeMousePosition));
         }
 
         protected void PaintText(SpriteBatch spriteBatch, Rectangle textRegion, HorizontalAlignment horizontalAlignment = HorizontalAlignment.Left) {

--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -314,15 +314,13 @@ namespace Blish_HUD.Controls {
         private void DeleteSelection() {
             if (_selectionStart == _selectionEnd) return;
 
-            if (_selectionStart < _selectionEnd) {
-                Delete(_selectionStart, _selectionEnd - _selectionStart);
-                _selectionEnd = _selectionStart;
-            } else {
-                Delete(_selectionEnd, _selectionStart - _selectionEnd);
-                _selectionStart = _selectionEnd;
-            }
+            int deleteStart = Math.Min(_selectionStart, _selectionEnd);
+            int deleteLength = Math.Max(_selectionStart, _selectionEnd) - deleteStart;
 
-            UserSetCursorIndex(_selectionStart);
+            Delete(deleteStart, deleteLength);
+
+            UserSetCursorIndex(deleteStart);
+            ResetSelection();
         }
 
         private bool Paste(string value) {

--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -727,6 +727,7 @@ namespace Blish_HUD.Controls {
 
         private void OnGlobalMouseLeftMouseButtonReleased(object sender, MouseEventArgs e) {
             this.Focused = _mouseOver && _enabled;
+            _cursorDragging = false;
         }
 
         public abstract int GetCursorIndexFromPosition(int x, int y);

--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -170,6 +170,7 @@ namespace Blish_HUD.Controls {
         }
 
         protected int _cursorIndex;
+        protected int _prevCursorIndex;
 
         /// <summary>
         /// Gets or sets the current index of the cursor within the text.
@@ -177,6 +178,7 @@ namespace Blish_HUD.Controls {
         public int CursorIndex {
             get => _cursorIndex;
             set {
+                _prevCursorIndex = _cursorIndex;
                 if (SetProperty(ref _cursorIndex, value, true)) {
                     OnCursorIndexChanged(new ValueEventArgs<int>(value));
                 }
@@ -735,10 +737,10 @@ namespace Blish_HUD.Controls {
             UpdateSelectionIfShiftDown();
         }
 
-        protected void HandleMouseDoubleClick(int newIndex) {
-            if (_cursorIndex == newIndex) {
-                this.SelectionStart = GetClosestLeftWordBoundary(newIndex);
-                this.SelectionEnd = GetClosestRightWordBoundary(newIndex);
+        protected void HandleMouseDoubleClick() {
+            if (_cursorIndex == _prevCursorIndex) {
+                this.SelectionStart = GetClosestLeftWordBoundary(_cursorIndex);
+                this.SelectionEnd = GetClosestRightWordBoundary(_cursorIndex);
             }
         }
 
@@ -755,7 +757,7 @@ namespace Blish_HUD.Controls {
 
             this.Focused = true;
 
-            if (e.IsDoubleClick) HandleMouseDoubleClick(GetCursorIndexFromPosition(this.RelativeMousePosition));
+            if (e.IsDoubleClick) HandleMouseDoubleClick();
         }
 
         protected void PaintText(SpriteBatch spriteBatch, Rectangle textRegion, HorizontalAlignment horizontalAlignment = HorizontalAlignment.Left) {

--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -170,6 +170,7 @@ namespace Blish_HUD.Controls {
         }
 
         protected int _cursorIndex;
+        protected int _prevCursorIndex;
 
         /// <summary>
         /// Gets or sets the current index of the cursor within the text.
@@ -177,6 +178,7 @@ namespace Blish_HUD.Controls {
         public int CursorIndex {
             get => _cursorIndex;
             set {
+                _prevCursorIndex = _cursorIndex;
                 if (SetProperty(ref _cursorIndex, value, true)) {
                     OnCursorIndexChanged(new ValueEventArgs<int>(value));
                 }
@@ -742,8 +744,8 @@ namespace Blish_HUD.Controls {
             UpdateSelectionIfShiftDown();
         }
 
-        protected void HandleMouseDoubleClick(int newIndex) {
-            if (newIndex == _cursorIndex) {
+        protected void HandleMouseDoubleClick() {
+            if (_cursorIndex == _prevCursorIndex) {
                 this.SelectionStart = GetClosestLeftWordBoundary(_cursorIndex);
                 this.SelectionEnd = GetClosestRightWordBoundary(_cursorIndex);
             }
@@ -774,7 +776,7 @@ namespace Blish_HUD.Controls {
 
             this.Focused = true;
 
-            if (e.IsDoubleClick) HandleMouseDoubleClick(GetCursorIndexFromPosition(this.RelativeMousePosition));
+            if (e.IsDoubleClick) HandleMouseDoubleClick();
         }
 
         protected void PaintText(SpriteBatch spriteBatch, Rectangle textRegion, HorizontalAlignment horizontalAlignment = HorizontalAlignment.Left) {

--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -709,11 +709,13 @@ namespace Blish_HUD.Controls {
 
         private void UpdateFocusState(bool focused) {
             if (focused) {
+                Input.Mouse.LeftMouseButtonPressed  += OnGlobalMouseLeftMouseButtonPressed;
                 Input.Mouse.LeftMouseButtonReleased += OnGlobalMouseLeftMouseButtonReleased;
                 Input.Keyboard.KeyStateChanged      += OnGlobalKeyboardKeyStateChanged;
 
                 GameService.Input.Keyboard.SetTextInputListner(OnTextInput);
             } else {
+                Input.Mouse.LeftMouseButtonPressed  -= OnGlobalMouseLeftMouseButtonPressed;
                 Input.Mouse.LeftMouseButtonReleased -= OnGlobalMouseLeftMouseButtonReleased;
                 Input.Keyboard.KeyStateChanged      -= OnGlobalKeyboardKeyStateChanged;
 
@@ -725,8 +727,11 @@ namespace Blish_HUD.Controls {
             }
         }
 
-        private void OnGlobalMouseLeftMouseButtonReleased(object sender, MouseEventArgs e) {
+        private void OnGlobalMouseLeftMouseButtonPressed(object sender, MouseEventArgs e) {
             this.Focused = _mouseOver && _enabled;
+        }
+
+        private void OnGlobalMouseLeftMouseButtonReleased(object sender, MouseEventArgs e) {
             _cursorDragging = false;
         }
 

--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -170,7 +170,6 @@ namespace Blish_HUD.Controls {
         }
 
         protected int _cursorIndex;
-        protected int _prevCursorIndex;
 
         /// <summary>
         /// Gets or sets the current index of the cursor within the text.
@@ -178,7 +177,6 @@ namespace Blish_HUD.Controls {
         public int CursorIndex {
             get => _cursorIndex;
             set {
-                _prevCursorIndex = _cursorIndex;
                 if (SetProperty(ref _cursorIndex, value, true)) {
                     OnCursorIndexChanged(new ValueEventArgs<int>(value));
                 }
@@ -744,8 +742,8 @@ namespace Blish_HUD.Controls {
             UpdateSelectionIfShiftDown();
         }
 
-        protected void HandleMouseDoubleClick() {
-            if (_cursorIndex == _prevCursorIndex) {
+        protected void HandleMouseDoubleClick(int newIndex) {
+            if (newIndex == _cursorIndex) {
                 this.SelectionStart = GetClosestLeftWordBoundary(_cursorIndex);
                 this.SelectionEnd = GetClosestRightWordBoundary(_cursorIndex);
             }
@@ -776,7 +774,7 @@ namespace Blish_HUD.Controls {
 
             this.Focused = true;
 
-            if (e.IsDoubleClick) HandleMouseDoubleClick();
+            if (e.IsDoubleClick) HandleMouseDoubleClick(GetCursorIndexFromPosition(this.RelativeMousePosition));
         }
 
         protected void PaintText(SpriteBatch spriteBatch, Rectangle textRegion, HorizontalAlignment horizontalAlignment = HorizontalAlignment.Left) {

--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -730,13 +730,15 @@ namespace Blish_HUD.Controls {
 
         public int GetCursorIndexFromPosition(Point position) => GetCursorIndexFromPosition(position.X, position.Y);
 
-        protected void HandleMouseUpdatedCursorIndex(int newIndex, bool isDoubleClick) {
-            if (_cursorIndex == newIndex && isDoubleClick) {
+        protected void HandleMouseUpdatedCursorIndex(int newIndex) {
+            UserSetCursorIndex(newIndex);
+            UpdateSelectionIfShiftDown();
+        }
+
+        protected void HandleMouseDoubleClick(int newIndex) {
+            if (_cursorIndex == newIndex) {
                 this.SelectionStart = GetClosestLeftWordBoundary(newIndex);
-                this.SelectionEnd   = GetClosestRightWordBoundary(newIndex);
-            } else {
-                UserSetCursorIndex(newIndex);
-                UpdateSelectionIfShiftDown();
+                this.SelectionEnd = GetClosestRightWordBoundary(newIndex);
             }
         }
 
@@ -745,7 +747,9 @@ namespace Blish_HUD.Controls {
 
             this.Focused = true;
 
-            HandleMouseUpdatedCursorIndex(GetCursorIndexFromPosition(this.RelativeMousePosition), e.IsDoubleClick);
+            int newIndex = GetCursorIndexFromPosition(this.RelativeMousePosition);
+            HandleMouseUpdatedCursorIndex(newIndex);
+            if (e.IsDoubleClick) HandleMouseDoubleClick(newIndex);
         }
 
         protected void PaintText(SpriteBatch spriteBatch, Rectangle textRegion, HorizontalAlignment horizontalAlignment = HorizontalAlignment.Left) {


### PR DESCRIPTION
Fixes issue #614 

Notably this change moves text cursor index movement to mouse pressed, rather than mouse released (click). This is consistent with other text input fields such as VS, GitHub, and GW2's own chat, but requires that we also move setting the control's focus to global mouse pressed, from global mouse released.