### PR TITLE
Add GraphicsDeviceContext helper struct + methods

### DIFF
--- a/Blish HUD/GameServices/GraphicsDeviceContext.cs
+++ b/Blish HUD/GameServices/GraphicsDeviceContext.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+
+namespace Blish_HUD {
+    public readonly ref struct GraphicsDeviceContext {
+
+        private readonly GraphicsService _service;
+
+        /// <summary>
+        /// Constructs a new graphics device context, that automatically
+        /// calls <see cref="GraphicsService.LendGraphicsDevice(bool)"/> on creation
+        /// and <see cref="GraphicsService.ReturnGraphicsDevice(string)"/> when disposed.
+        /// </summary>
+        /// <param name="service">The graphics service instance to use.</param>
+        /// <param name="highPriority">A value indicating whether to acquire a high priority instance.</param>
+        internal GraphicsDeviceContext(GraphicsService service, bool highPriority) {
+            _service = service;
+            GraphicsDevice = _service.LendGraphicsDevice(highPriority);
+        }
+
+        /// <summary>
+        /// Get the GraphicsDevice associated with this context.
+        /// </summary>
+        public GraphicsDevice GraphicsDevice { get; }
+
+        /// <summary>
+        /// Disposes of this graphics context, calling <see cref="GraphicsService.ReturnGraphicsDevice(string)"/>
+        /// </summary>
+        public void Dispose() {
+            _service.ReturnGraphicsDevice();
+        }
+    }
+}


### PR DESCRIPTION
Hope these types of PR are ok - this is pretty low priority, as it's just a developer usability thing, but it may be useful :)

This adds a `GraphicsDeviceContext` helper struct + associated methods for use with the tri-lock code added in #644 that makes idiomatic code like: 

```csharp
using var ctx = Graphics.LendGraphicsDeviceContext()
{
// some code using ctx
}
```

possible, which will hopefully help to ensure that graphics devices are returned, including in the case of errors, without having to remember to use a try/finally block or call the release method.

It's implemented as a `readonly ref struct` so it shouldn't incur extra heap allocations and performance impact should be minimal. The existing `LendGraphicsDevice` methods remain, so that both approaches can be used.
