### PR TITLE
Fix graphics device locking

### DIFF
--- a/Blish HUD/GameServices/ContentService.cs
+++ b/Blish HUD/GameServices/ContentService.cs
@@ -45,17 +45,15 @@ namespace Blish_HUD {
             public static Texture2D TransparentPixel { get; private set; }
 
             public static void Load() {
-                var graphicsDevice = Graphics.LendGraphicsDevice(true);
+                using (var ctx = Graphics.LendGraphicsDeviceContext(true)) {
+                    Error = Content.GetTexture(@"common\error");
 
-                Error = Content.GetTexture(@"common\error");
+                    Pixel = new Texture2D(ctx.GraphicsDevice, 1, 1);
+                    Pixel.SetData(new[] { Color.White });
 
-                Pixel = new Texture2D(graphicsDevice, 1, 1);
-                Pixel.SetData(new[] { Color.White });
-
-                TransparentPixel = new Texture2D(graphicsDevice, 1, 1);
-                TransparentPixel.SetData(new[] { Color.Transparent });
-
-                Graphics.ReturnGraphicsDevice();
+                    TransparentPixel = new Texture2D(ctx.GraphicsDevice, 1, 1);
+                    TransparentPixel.SetData(new[] { Color.Transparent });
+                }
             }
         }
 

--- a/Blish HUD/GameServices/GraphicsDeviceContext.cs
+++ b/Blish HUD/GameServices/GraphicsDeviceContext.cs
@@ -1,19 +1,23 @@
-﻿using Microsoft.Xna.Framework.Graphics;
+﻿using System.Runtime.CompilerServices;
+using Microsoft.Xna.Framework.Graphics;
 
 namespace Blish_HUD {
     public readonly ref struct GraphicsDeviceContext {
 
         private readonly GraphicsService _service;
 
+        private readonly bool _highPriority;
+
         /// <summary>
         /// Constructs a new graphics device context, that automatically
         /// calls <see cref="GraphicsService.LendGraphicsDevice(bool)"/> on creation
-        /// and <see cref="GraphicsService.ReturnGraphicsDevice(string)"/> when disposed.
+        /// and <see cref="GraphicsService.ReturnGraphicsDevice"/> when disposed.
         /// </summary>
         /// <param name="service">The graphics service instance to use.</param>
         /// <param name="highPriority">A value indicating whether to acquire a high priority instance.</param>
         internal GraphicsDeviceContext(GraphicsService service, bool highPriority) {
-            _service = service;
+            _service       = service;
+            _highPriority  = highPriority;
             GraphicsDevice = _service.LendGraphicsDevice(highPriority);
         }
 
@@ -23,10 +27,10 @@ namespace Blish_HUD {
         public GraphicsDevice GraphicsDevice { get; }
 
         /// <summary>
-        /// Disposes of this graphics context, calling <see cref="GraphicsService.ReturnGraphicsDevice(string)"/>
+        /// Disposes of this graphics context, calling <see cref="GraphicsService.ReturnGraphicsDevice"/>
         /// </summary>
         public void Dispose() {
-            _service.ReturnGraphicsDevice();
+            _service.ReturnGraphicsDevice(_highPriority);
         }
     }
 }

--- a/Blish HUD/GameServices/GraphicsService.cs
+++ b/Blish HUD/GameServices/GraphicsService.cs
@@ -340,8 +340,6 @@ namespace Blish_HUD {
         private readonly object _lendLockNext   = new object();
         private readonly object _lendLockDevice = new object();
 
-        private volatile bool _currentLenderHighPriority = false;
-
         /// <summary>
         /// Provides exclusive and locked access to the <see cref="GraphicsDevice"/>. This
         /// method blocks until the device is available and will yield to higher priority
@@ -359,9 +357,6 @@ namespace Blish_HUD {
 
             Monitor.Enter(_lendLockNext);
             Monitor.Enter(_lendLockDevice);
-
-            _currentLenderHighPriority = highPriority;
-
             Monitor.Exit(_lendLockNext);
 
             return BlishHud.Instance.ActiveGraphicsDeviceManager.GraphicsDevice;
@@ -373,7 +368,7 @@ namespace Blish_HUD {
         /// lend requests. Core lend requests receive priority over these requests.  Once
         /// done with the <see cref="GraphicsDevice"/> unlock it with <see cref="ReturnGraphicsDevice"/>.
         /// </summary>
-        public GraphicsDevice LendGraphicsDevice() {
+        internal GraphicsDevice LendGraphicsDevice() {
             return LendGraphicsDevice(false);
         }
 
@@ -408,10 +403,10 @@ namespace Blish_HUD {
         /// <summary>
         /// Unlocks access to the <see cref="GraphicsDevice"/>.  You must call this after <see cref="LendGraphicsDevice"/>.
         /// </summary>
-        public void ReturnGraphicsDevice() {
+        internal void ReturnGraphicsDevice(bool highPriority) {
             Monitor.Exit(_lendLockDevice);
 
-            if (!_currentLenderHighPriority) {
+            if (!highPriority) {
                 Monitor.Exit(_lendLockLow);
             }
         }

--- a/Blish HUD/GameServices/GraphicsService.cs
+++ b/Blish HUD/GameServices/GraphicsService.cs
@@ -408,7 +408,7 @@ namespace Blish_HUD {
         /// <summary>
         /// Unlocks access to the <see cref="GraphicsDevice"/>.  You must call this after <see cref="LendGraphicsDevice"/>.
         /// </summary>
-        public void ReturnGraphicsDevice([CallerMemberName] string callerName = null) {
+        public void ReturnGraphicsDevice() {
             Monitor.Exit(_lendLockDevice);
 
             if (!_currentLenderHighPriority) {

--- a/Blish HUD/GameServices/Modules/Managers/ContentsManager.cs
+++ b/Blish HUD/GameServices/Modules/Managers/ContentsManager.cs
@@ -70,8 +70,8 @@ namespace Blish_HUD.Modules.Managers {
             long effectDataLength = _reader.GetFileBytes(effectPath, out byte[] effectData);
 
             if (effectDataLength > 0) {
-                var effect = new Effect(GameService.Graphics.LendGraphicsDevice(), effectData, 0, (int)effectDataLength);
-                GameService.Graphics.ReturnGraphicsDevice();
+                using var ctx    = GameService.Graphics.LendGraphicsDeviceContext();
+                var       effect = new Effect(ctx.GraphicsDevice, effectData, 0, (int)effectDataLength);
 
                 return effect;
             }

--- a/Blish HUD/_Extensions/Texture2DExtension.cs
+++ b/Blish HUD/_Extensions/Texture2DExtension.cs
@@ -7,13 +7,12 @@ namespace Blish_HUD {
 
         /// <remarks>https://stackoverflow.com/a/16141281/595437</remarks>
         public static Texture2D GetRegion(this Texture2D texture2D, Rectangle region) {
-            Texture2D croppedTexture = new Texture2D(GameService.Graphics.LendGraphicsDevice(), region.Width, region.Height);
+            using var ctx            = GameService.Graphics.LendGraphicsDeviceContext();
+            var       croppedTexture = new Texture2D(ctx.GraphicsDevice, region.Width, region.Height);
 
             Color[] clrData = new Color[region.Width * region.Height];
             texture2D.GetData(0, region, clrData, 0, region.Width * region.Height);
             croppedTexture.SetData(clrData);
-
-            GameService.Graphics.ReturnGraphicsDevice();
 
             return croppedTexture;
         }

--- a/Blish HUD/_Utils/TextureUtil.cs
+++ b/Blish HUD/_Utils/TextureUtil.cs
@@ -15,10 +15,11 @@ namespace Blish_HUD {
         /// </summary>
         /// <remarks>https://community.monogame.net/t/texture2d-fromstream-in-3-7/10973/9</remarks>
         public static Texture2D FromStreamPremultiplied(Stream stream) {
-            using var ctx     = GameService.Graphics.LendGraphicsDeviceContext();
-            var       texture = FromStreamPremultiplied(ctx.GraphicsDevice, stream);
+            using (var ctx = GameService.Graphics.LendGraphicsDeviceContext()) {
+                var texture = FromStreamPremultiplied(ctx.GraphicsDevice, stream);
 
-            return texture;
+                return texture;
+            }
         }
 
         /// <summary>

--- a/Blish HUD/_Utils/TextureUtil.cs
+++ b/Blish HUD/_Utils/TextureUtil.cs
@@ -15,9 +15,8 @@ namespace Blish_HUD {
         /// </summary>
         /// <remarks>https://community.monogame.net/t/texture2d-fromstream-in-3-7/10973/9</remarks>
         public static Texture2D FromStreamPremultiplied(Stream stream) {
-            var texture = FromStreamPremultiplied(GameService.Graphics.LendGraphicsDevice(), stream);
-
-            GameService.Graphics.ReturnGraphicsDevice();
+            using var ctx     = GameService.Graphics.LendGraphicsDeviceContext();
+            var       texture = FromStreamPremultiplied(ctx.GraphicsDevice, stream);
 
             return texture;
         }


### PR DESCRIPTION
Thanks to @eksime for the tremendous help in narrowing down this issue.

Re-entering locks from the same thread would break the dirty priority tracking that was being done.  This has been moved to the context and Return now requires the priority be manually specified.