### PR TITLE
Fixes to assist with porting to .net 6

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <Platforms>x64</Platforms>
@@ -231,17 +231,9 @@
   <ItemGroup>
     <PackageReference Include="Adhesive" Version="2.0.1-alpha" PrivateAssets="all" />
     <PackageReference Include="AsyncClipboardService" Version="[1.7.1]" />
-    <PackageReference Include="Costura.Fody" Version="4.1.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="DynamicLanguageRuntime" Version="1.2.2" PrivateAssets="all" />
     <PackageReference Include="EntryPoint" Version="1.3.0" PrivateAssets="all" />
     <PackageReference Include="Flurl.Http" Version="2.4.2" PrivateAssets="all" />
-    <PackageReference Include="Fody" Version="6.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Gapotchenko.FX.Diagnostics.Process" Version="2021.1.5" />
     <PackageReference Include="Gw2Sharp" Version="1.7.0" />
     <PackageReference Include="Humanizer.Core.de" Version="2.6.2" PrivateAssets="all" />
@@ -262,18 +254,22 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.14.1" />
     <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
     <PackageReference Include="protobuf-net" Version="3.0.101" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Windows.Forms" />
+    <PackageReference Include="Costura.Fody" Version="5.7.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; compile; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <Target Name="BuildRef" AfterTargets="Build">
     <!-- Build ref.dat -->
     <ZipDirectory SourceDirectory="$(ProjectDir)ref" DestinationFile="$(OutDir)/ref.dat" Overwrite="true" />
   </Target>
-  
+
   <Target Name="CleanRef" AfterTargets="Clean">
     <!-- Clean custom output files -->
     <Delete Files="$(OutDir)/ref.dat" />

--- a/Blish HUD/Controls/Container.cs
+++ b/Blish HUD/Controls/Container.cs
@@ -122,7 +122,7 @@ namespace Blish_HUD.Controls {
 
         public IEnumerable<Control> GetDescendants() {
             // Breadth-first unrolling without the inefficiency of recursion.
-            var remainingChildren = new Queue<Control>(this.Children);
+            var remainingChildren = new Queue<Control>(this.Children.ToArray());
 
             while (remainingChildren.Count > 0) {
                 var child = remainingChildren.Dequeue();

--- a/Blish HUD/FodyWeavers.xsd
+++ b/Blish HUD/FodyWeavers.xsd
@@ -17,6 +17,16 @@
                   <xs:documentation>A list of assembly names to include from the default action of "embed all Copy Local references", delimited with line breaks.</xs:documentation>
                 </xs:annotation>
               </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="ExcludeRuntimeAssemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of runtime assembly names to exclude from the default action of "embed all Copy Local references", delimited with line breaks</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="IncludeRuntimeAssemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of runtime assembly names to include from the default action of "embed all Copy Local references", delimited with line breaks.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="Unmanaged32Assemblies" type="xs:string">
                 <xs:annotation>
                   <xs:documentation>A list of unmanaged 32 bit assembly names to include, delimited with line breaks.</xs:documentation>
@@ -41,6 +51,16 @@
             <xs:attribute name="IncludeDebugSymbols" type="xs:boolean">
               <xs:annotation>
                 <xs:documentation>Controls if .pdbs for reference assemblies are also embedded.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IncludeRuntimeReferences" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>Controls if runtime assemblies are also embedded.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UseRuntimeReferencePaths" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>Controls whether the runtime assemblies are embedded with their full path or only with their assembly name.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="DisableCompression" type="xs:boolean">
@@ -71,6 +91,16 @@
             <xs:attribute name="IncludeAssemblies" type="xs:string">
               <xs:annotation>
                 <xs:documentation>A list of assembly names to include from the default action of "embed all Copy Local references", delimited with |.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ExcludeRuntimeAssemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of runtime assembly names to exclude from the default action of "embed all Copy Local references", delimited with |</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IncludeRuntimeAssemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of runtime assembly names to include from the default action of "embed all Copy Local references", delimited with |.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="Unmanaged32Assemblies" type="xs:string">

--- a/Blish HUD/GameServices/Debug/Contingency.cs
+++ b/Blish HUD/GameServices/Debug/Contingency.cs
@@ -3,7 +3,6 @@ using Ookii.Dialogs.WinForms;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using System.Windows.Forms;
 
 namespace Blish_HUD.Debug {
     public static class Contingency {
@@ -21,7 +20,7 @@ namespace Blish_HUD.Debug {
 
             if (BlishHud.Instance != null) {
                 if (BlishHud.Instance.Form.InvokeRequired) {
-                    BlishHud.Instance.Form.Invoke((MethodInvoker)(() => BlishHud.Instance.Form.Hide()));
+                    BlishHud.Instance.Form.Invoke(new Action(() => BlishHud.Instance.Form.Hide()));
                 } else {
                     BlishHud.Instance.Form.Hide();
                 }

--- a/Blish HUD/GameServices/Gw2WebApi/UI/Views/RegisterApiKeyView.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/UI/Views/RegisterApiKeyView.cs
@@ -24,6 +24,11 @@ namespace Blish_HUD.Gw2WebApi.UI.Views {
             Perfect
         }
 
+        private static readonly ProcessStartInfo ArenaNetApplicationsWebsiteProcessStartInfo = new ProcessStartInfo() {
+            FileName = "https://account.arena.net/applications",
+            UseShellExecute = true
+        };
+
         private static readonly Logger Logger = Logger.GetLogger<RegisterApiKeyView>();
 
         private const int MAX_KEYNAME_LENGTH = 14;
@@ -242,7 +247,7 @@ namespace Blish_HUD.Gw2WebApi.UI.Views {
                 Parent         = buildPanel
             };
 
-            openAnetApplicationsBttn.Click += delegate { Process.Start("https://account.arena.net/applications"); };
+            openAnetApplicationsBttn.Click += delegate { Process.Start(ArenaNetApplicationsWebsiteProcessStartInfo); };
 
             ReloadApiKeys();
 

--- a/Blish HUD/GameServices/Input/DebugHelperHookManager.cs
+++ b/Blish HUD/GameServices/Input/DebugHelperHookManager.cs
@@ -9,6 +9,7 @@ namespace Blish_HUD.Input {
     internal class DebugHelperHookManager : IHookManager {
 
         private static readonly Logger Logger = Logger.GetLogger<DebugHelperHookManager>();
+        private static readonly PingMessage PingMessage = new PingMessage();
 
         private IMouseHookManager    _mouseHookManager;
         private IKeyboardHookManager _keyboardHookManager;
@@ -40,7 +41,13 @@ namespace Blish_HUD.Input {
             _debugHelperMessageService.Start();
 
             _pingTimer         =  new Timer(10) { AutoReset = true };
-            _pingTimer.Elapsed += (s, e) => _debugHelperMessageService.Send(new PingMessage());
+            _pingTimer.Elapsed += (s, e) => {
+                try {
+                    _debugHelperMessageService.Send(PingMessage);
+                } catch (MissingMethodException) {
+                    // Unsure why this happens only once, but seems to be related to Fody
+                }
+            };
             _pingTimer.Start();
 
             _mouseHookManager    = new DebugHelperMouseHookManager(_debugHelperMessageService);

--- a/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
@@ -174,8 +174,6 @@ namespace Blish_HUD.Input {
             this.ActiveModifiers = KeysUtil.ModifiersFromKeys(downArray);
         }
 
-        private void EndTextInputAsyncInvoke(IAsyncResult asyncResult) { _textInputDelegate?.EndInvoke(asyncResult); }
-
         private bool ShouldBlockKeyEvent(Keys key) {
             // TODO: WIN key combinations should probably completely handled by the OS
 

--- a/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
@@ -242,7 +242,7 @@ namespace Blish_HUD.Input {
             // Handle text input
             if (_textInputDelegate != null) {
                 string chars = TypedInputUtil.VkCodeToString((uint)key, eventType == KeyboardEventType.KeyDown);
-                _textInputDelegate?.BeginInvoke(chars, EndTextInputAsyncInvoke, null);
+                _textInputDelegate?.Invoke(chars);
                 return ShouldBlockKeyEvent(key);
             }
 

--- a/Blish HUD/Program.cs
+++ b/Blish HUD/Program.cs
@@ -1,13 +1,8 @@
 ﻿using Blish_HUD.DebugHelper.Services;
 using EntryPoint;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Net;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Windows.Forms;
 
@@ -106,14 +101,7 @@ namespace Blish_HUD {
                     }
 
                     if (RestartOnExit) {
-                        // REF: https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/Application.cs,1447
-                        var arguments = Environment.GetCommandLineArgs().Skip(1).Select(arg => $"\"{arg}\"");
-
-                        var currentStartInfo = Process.GetCurrentProcess().StartInfo;
-                        currentStartInfo.FileName  = Application.ExecutablePath;
-                        currentStartInfo.Arguments = string.Join(" ", arguments);
-
-                        Process.Start(currentStartInfo);
+                        Application.Restart();
                     }
                 }
             }


### PR DESCRIPTION
This change is mostly clean-up to get the current build running nicely under .net6, actual behaviour should be identical.

Specifically:

* Swaps out assembly references for package references where possible + general csproj cleanup
* bump fody version
* Fixes implicit call of ControlCollection.CopyTo under .net 6 from Queue ctor in Container.GetDescendants
* Swap MethodInvoker cast to Action as it's cross-compatiable (although not required at all in .net 6)
* Fix Process.Start for api key webpage open, requires UseShellExecute in .net 6
* Workaround protobuf MissingMethodException when using Fody under .net 6 for PingMessage
* Remove BeginInvoke for keyboard handler _textInputDelegate as it is no longer allowed in .net 6