### PR TITLE
FlowPanel & layout suspension updates

### DIFF
--- a/Blish HUD/Controls/FlowPanel.cs
+++ b/Blish HUD/Controls/FlowPanel.cs
@@ -107,24 +107,18 @@ namespace Blish_HUD.Controls {
 
         protected override void OnChildAdded(ChildChangedEventArgs e) {
             base.OnChildAdded(e);
-            OnChildrenChanged(e);
 
             e.ChangedChild.Resized += ChangedChildOnResized;
         }
 
         protected override void OnChildRemoved(ChildChangedEventArgs e) {
             base.OnChildRemoved(e);
-            OnChildrenChanged(e);
 
             e.ChangedChild.Resized -= ChangedChildOnResized;
         }
 
         private void ChangedChildOnResized(object sender, ResizedEventArgs e) {
-            ReflowChildLayout(_children);
-        }
-
-        private void OnChildrenChanged(ChildChangedEventArgs e) {
-            ReflowChildLayout(e.ResultingChildren);
+            this.Invalidate();
         }
 
         public override void RecalculateLayout() {
@@ -140,7 +134,7 @@ namespace Blish_HUD.Controls {
         /// </summary>
         public void FilterChildren<TControl>(Func<TControl, bool> filter) where TControl : Control {
             _children.Cast<TControl>().ToList().ForEach(tc => tc.Visible = filter(tc));
-            ReflowChildLayout(_children);
+            this.Invalidate();
         }
 
         /// <summary>
@@ -155,7 +149,7 @@ namespace Blish_HUD.Controls {
 
             _children = new ControlCollection<Control>(tempChildren);
 
-            ReflowChildLayout(_children);
+            this.Invalidate();
         }
 
         private void ReflowChildLayoutLeftToRight(IEnumerable<Control> allChildren) {


### PR DESCRIPTION
 * Add IDisposable suspend layout scope to SuspendLayout() - this should be backwards compatible with old code, but allows the use of the code below.  It'll hopefully help ensure people remember to call ResumeLayout, even if there's an error, and should be safe to use in any context. This also swaps the backing field from a bool to an int to track the scope depth, and introduces the internal property `IsLayoutSuspended` which checks if the control, or any ancestor, is currently suspended.
  ```
using (control.SuspendLayout())
{
    //...
}
  ```

 * Convert FlowPanel to use .Invalidate() where appropriate - this is related to the discord discussion, the flowPanel should now respect the layout being suspended before trying to arrange its children.