### PR TITLE
Split close on Escape out of CanClose

### DIFF
--- a/Blish HUD/Controls/KeybindingAssignmentWindow.cs
+++ b/Blish HUD/Controls/KeybindingAssignmentWindow.cs
@@ -218,6 +218,7 @@ namespace Blish_HUD.Controls {
         public bool   TopMost              => true;
         public double LastInteraction      => double.MaxValue;
         public bool   CanClose             => false;
+        public bool   CanCloseWithEscape   => false;
         public void   BringWindowToFront() { /* NOOP */ }
 
     }

--- a/Blish HUD/Controls/WindowBase.cs
+++ b/Blish HUD/Controls/WindowBase.cs
@@ -319,6 +319,8 @@ namespace Blish_HUD.Controls {
 
         public bool CanClose => true;
 
+        public bool CanCloseWithEscape => true;
+
         #region Window Navigation
 
         private readonly LinkedList<Panel> _currentNav = new LinkedList<Panel>();

--- a/Blish HUD/Controls/WindowBase2.cs
+++ b/Blish HUD/Controls/WindowBase2.cs
@@ -121,6 +121,12 @@ namespace Blish_HUD.Controls {
             set => SetProperty(ref _canClose, value);
         }
 
+        private bool _canCloseWithEscape = true;
+        public bool CanCloseWithEscape {
+            get => _canCloseWithEscape;
+            set => SetProperty(ref _canCloseWithEscape, value, true);
+        }
+
         private bool _canResize = false;
         /// <summary>
         /// Allows the window to be resized by dragging the bottom right corner.

--- a/Blish HUD/Controls/WindowBase2.cs
+++ b/Blish HUD/Controls/WindowBase2.cs
@@ -124,7 +124,7 @@ namespace Blish_HUD.Controls {
         private bool _canCloseWithEscape = true;
         public bool CanCloseWithEscape {
             get => _canCloseWithEscape;
-            set => SetProperty(ref _canCloseWithEscape, value, true);
+            set => SetProperty(ref _canCloseWithEscape, value);
         }
 
         private bool _canResize = false;

--- a/Blish HUD/Controls/_Types/IWindow.cs
+++ b/Blish HUD/Controls/_Types/IWindow.cs
@@ -25,9 +25,14 @@
         void BringWindowToFront();
 
         /// <summary>
-        /// If <c>true</c> the window can support closing itself (X icon or pressing ESC).  Otherwise, an external action will be required to close it.
+        /// If <c>true</c> the window can support closing itself with the X icon.  Otherwise, an external action will be required to close it.
         /// </summary>
         bool CanClose { get; }
+
+        /// <summary>
+        /// If <c>true</c> the window can support closing itself with pressing Escape.  Otherwise, an external action will be required to close it.
+        /// </summary>
+        bool CanCloseWithEscape { get; }
 
         /// <summary>
         /// Hides the window.

--- a/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
@@ -229,7 +229,7 @@ namespace Blish_HUD.Input {
                         // If we found an active window, close it
                         var activeWindow = WindowBase2.ActiveWindow;
 
-                        if (activeWindow != null && activeWindow.CanCloseWithEscape) {
+                        if (activeWindow != null && activeWindow.CanClose && activeWindow.CanCloseWithEscape) {
                             activeWindow.Hide();
                             return true;
                         }

--- a/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
@@ -229,7 +229,7 @@ namespace Blish_HUD.Input {
                         // If we found an active window, close it
                         var activeWindow = WindowBase2.ActiveWindow;
 
-                        if (activeWindow != null && activeWindow.CanClose) {
+                        if (activeWindow != null && activeWindow.CanCloseWithEscape) {
                             activeWindow.Hide();
                             return true;
                         }


### PR DESCRIPTION
This PR splits the option to close a window with esc out of the CanClose-Property, so a window can still be closed by the user with the X-Icon but not anymore with escape.
There are use cases in which closing with esc can close a window on coincidence way more often than on purpose and where there is no need to be able to close it with escape.
That is really apparent in the case of the AchievementTrackerModule where myself and multiple other already experienced that the current behavior is a hindrance.