### PR TITLE
Set Focused property after internal logic

### DIFF
--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -757,10 +757,11 @@ namespace Blish_HUD.Controls {
         protected override void OnLeftMouseButtonPressed(MouseEventArgs e) {
             base.OnLeftMouseButtonPressed(e);
 
-            this.Focused = true;
             _cursorDragging = true;
 
             HandleMouseUpdatedCursorIndex(GetCursorIndexFromPosition(this.RelativeMousePosition));
+
+            this.Focused = true;
         }
 
         protected override void OnMouseMoved(MouseEventArgs e) {
@@ -772,9 +773,9 @@ namespace Blish_HUD.Controls {
         protected override void OnClick(MouseEventArgs e) {
             base.OnClick(e);
 
-            this.Focused = true;
-
             if (e.IsDoubleClick) HandleMouseDoubleClick();
+
+            this.Focused = true;
         }
 
         protected void PaintText(SpriteBatch spriteBatch, Rectangle textRegion, HorizontalAlignment horizontalAlignment = HorizontalAlignment.Left) {


### PR DESCRIPTION
`Focused` on `TextInputBase` is currently set on click or left mouse pressed. However, this happens before internal logic to place the cursor. This makes it difficult to customize the behaviour of `TextInputBase` on focus such as selecting all text on focus.

This change moves setting of the Focused property to after internal logic has run to place the cursor.

Tested locally. With this change it's now possible to set the selection range directly in the handler for the `InputFocusChanged` event.