### PR TITLE
Revise suspendlayout on flowpanel

### DIFF
--- a/Blish HUD/Controls/Control.cs
+++ b/Blish HUD/Controls/Control.cs
@@ -914,14 +914,16 @@ namespace Blish_HUD.Controls {
         #region Helper Classes
         private readonly struct SuspendLayoutScope : IDisposable {
             private readonly Control _owner;
+            private readonly bool    _forceRecalculate;
 
-            public SuspendLayoutScope(Control owner) {
-                _owner = owner;
+            public SuspendLayoutScope(Control owner, bool forceRecalculate = false) {
+                _owner            = owner;
+                _forceRecalculate = forceRecalculate;
                 _owner.SuspendLayout();
             }
 
             public void Dispose() {
-                _owner.ResumeLayout();
+                _owner.ResumeLayout(_forceRecalculate);
             }
         }
         #endregion

--- a/Blish HUD/Controls/FlowPanel.cs
+++ b/Blish HUD/Controls/FlowPanel.cs
@@ -106,23 +106,33 @@ namespace Blish_HUD.Controls {
         }
 
         protected override void OnChildAdded(ChildChangedEventArgs e) {
+            OnChildrenChanged(e.ResultingChildren);
             base.OnChildAdded(e);
 
             e.ChangedChild.Resized += ChangedChildOnResized;
         }
 
         protected override void OnChildRemoved(ChildChangedEventArgs e) {
+            OnChildrenChanged(e.ResultingChildren);
             base.OnChildRemoved(e);
 
             e.ChangedChild.Resized -= ChangedChildOnResized;
         }
 
         private void ChangedChildOnResized(object sender, ResizedEventArgs e) {
-            this.Invalidate();
+            OnChildrenChanged(_children.ToArray());
+        }
+
+        private void OnChildrenChanged(IEnumerable<Control> resultingChildren) {
+            if (this.IsLayoutSuspended) {
+                Invalidate();
+            } else {
+                ReflowChildLayout(resultingChildren);
+            }
         }
 
         public override void RecalculateLayout() {
-            ReflowChildLayout(_children);
+            ReflowChildLayout(_children.ToArray());
 
             base.RecalculateLayout();
         }
@@ -329,6 +339,8 @@ namespace Blish_HUD.Controls {
                     ReflowChildLayoutSingleBottomToTop(filteredChildren);
                     break;
             }
+
+            Logger.GetLogger(this.GetType()).Info("DID A REFLOW");
         }
 
         protected override void DisposeControl() {

--- a/Blish HUD/Controls/FlowPanel.cs
+++ b/Blish HUD/Controls/FlowPanel.cs
@@ -339,8 +339,6 @@ namespace Blish_HUD.Controls {
                     ReflowChildLayoutSingleBottomToTop(filteredChildren);
                     break;
             }
-
-            Logger.GetLogger(this.GetType()).Info("DID A REFLOW");
         }
 
         protected override void DisposeControl() {


### PR DESCRIPTION
Some controls appear to not call base methods as expected or otherwise can't handle the revised suspendlayout flow.  These minor changes help to keep backwards compatibility with that flow.

Also adds support for force recalculation on the suspendlayoutcontext.