### PR TITLE
Split drive settings fix

### DIFF
--- a/Blish HUD/GameServices/SettingsService.cs
+++ b/Blish HUD/GameServices/SettingsService.cs
@@ -103,7 +103,7 @@ namespace Blish_HUD {
             string rawSettings = JsonConvert.SerializeObject(this.Settings, Formatting.Indented, JsonReaderSettings);
 
             try {
-                string tempSettingsPath = Path.GetTempFileName();
+                string tempSettingsPath = $"{_settingsPath}.new";
                 using (var settingsWriter = new StreamWriter(tempSettingsPath, false)) {
                     settingsWriter.Write(rawSettings);
                 }


### PR DESCRIPTION
Ensure that temp settings are created on the same drive by putting them in the same folder.