### PR TITLE
Catch ArgumentException when trying to read the game process environment variables

### DIFF
--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -204,6 +204,8 @@ namespace Blish_HUD.GameIntegration {
                     Logger.Warn("Failed to auto-detect Guild Wars 2 environment variables.  Restart Guild Wars 2 to try again.");
                 } catch (NullReferenceException e) {
                     Logger.Warn(e, "Failed to grab Guild Wars 2 env variable.  It is likely exiting.");
+                } catch (ArgumentException e) {
+                    Logger.Warn(e, "Failed to parse the Guild Wars 2 env variables.");
                 }
 
                 // GW2 is running if the "_gw2Process" isn't null and the class name of process' 


### PR DESCRIPTION
This is my workaround for https://github.com/blish-hud/Blish-HUD/issues/698 where Blish-HUD fails to parse the environment variables on my machine. Adding this doesn't seem to affect the functionality for me, I am able to start it and load plugins normally.

Maybe it's better to consolidate those three catch blocks into a single generic one?