### PR TITLE
No restart on PID and fix for NRE

### DIFF
--- a/Blish HUD/GameServices/Input/Mouse/MouseHandler.cs
+++ b/Blish HUD/GameServices/Input/Mouse/MouseHandler.cs
@@ -74,7 +74,9 @@ namespace Blish_HUD.Input {
                 return false;
             }
 
-            if (Form.ActiveForm != null && Form.ActiveForm.ClientRectangle.Contains(new System.Drawing.Point(mouseEventArgs.PointX, mouseEventArgs.PointY))) {
+            var activeForm = Form.ActiveForm;
+
+            if (activeForm != null && activeForm.ClientRectangle.Contains(new System.Drawing.Point(mouseEventArgs.PointX, mouseEventArgs.PointY))) {
                 // If another form is active (like Debug, Pathing editor, etc.) don't intercept
                 return false;
             }

--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -129,10 +129,14 @@ namespace Blish_HUD {
                                                               () => Strings.GameServices.OverlayService.Setting_AppCulture_DisplayName,
                                                               () => Strings.GameServices.OverlayService.Setting_AppCulture_Description);
 
-            this.StayInTray    =       settings.DefineSetting("StayInTray",
-                                                              true,
-                                                              () => Strings.GameServices.OverlayService.Setting_StayInTray_DisplayName,
-                                                              () => Strings.GameServices.OverlayService.Setting_StayInTray_Description + (ApplicationSettings.Instance.StartGw2 > 0 ? " (Disabled because you launched Blish HUD with --startgw2 or -g)" : ""));
+            this.StayInTray = settings.DefineSetting("StayInTray",
+                                                     true,
+                                                     () => Strings.GameServices.OverlayService.Setting_StayInTray_DisplayName,
+                                                     () => Strings.GameServices.OverlayService.Setting_StayInTray_Description
+                                                         + (ApplicationSettings.Instance.StartGw2  > 0
+                                                         || ApplicationSettings.Instance.ProcessId > 0
+                                                                ? Strings.GameServices.OverlayService.Setting_StayInTray_AppendDisabled
+                                                                : string.Empty));
 
             this.ShowInTaskbar =       settings.DefineSetting("ShowInTaskbar",
                                                               false,
@@ -169,7 +173,7 @@ namespace Blish_HUD {
             this.ToggleBlishWindow.Value.Activated            += delegate { this.BlishHudWindow.ToggleWindow(); };
 
             // Lock 'StayInTray' if we launched Guild Wars 2 with a launch argument.
-            if (ApplicationSettings.Instance.StartGw2 > 0) {
+            if (ApplicationSettings.Instance.StartGw2 > 0 || ApplicationSettings.Instance.ProcessId > 0) {
                 this.StayInTray.SetDisabled();
             }
 

--- a/Blish HUD/Program.cs
+++ b/Blish HUD/Program.cs
@@ -100,7 +100,9 @@ namespace Blish_HUD {
                         singleInstanceMutex.ReleaseMutex();
                     }
 
-                    if (RestartOnExit) {
+                    if (RestartOnExit 
+                     && (ApplicationSettings.Instance.StartGw2 > 0 
+                      || ApplicationSettings.Instance.ProcessId > 0)) {
                         Application.Restart();
                     }
                 }

--- a/Blish HUD/Strings/GameServices/OverlayService.Designer.cs
+++ b/Blish HUD/Strings/GameServices/OverlayService.Designer.cs
@@ -469,6 +469,15 @@ namespace Blish_HUD.Strings.GameServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to  (Disabled because you launched Blish HUD with --startgw2, --pid, -g, or -P).
+        /// </summary>
+        internal static string Setting_StayInTray_AppendDisabled {
+            get {
+                return ResourceManager.GetString("Setting_StayInTray_AppendDisabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to If true, Blish HUD will automatically minimize when GW2 closes and will continue running until GW2 is launched again.
         ///You can also use the Blish HUD icon in the tray to launch Guild Wars 2..
         /// </summary>

--- a/Blish HUD/Strings/GameServices/OverlayService.resx
+++ b/Blish HUD/Strings/GameServices/OverlayService.resx
@@ -289,4 +289,7 @@ WARNING: Prerelease modules or Blish HUD versions may be unstable.  By enabling 
   <data name="Setting_DynamicHUDWindows_DisplayName" xml:space="preserve">
     <value>Windows</value>
   </data>
+  <data name="Setting_StayInTray_AppendDisabled" xml:space="preserve">
+    <value> (Disabled because you launched Blish HUD with --startgw2, --pid, -g, or -P)</value>
+  </data>
 </root>


### PR DESCRIPTION
If --pid is defined, we do not allow Blish HUD to auto-restart.  Just doesn't make sense because it will try to attach to the same PID again.  This causes issues with certain multi-box launchers.

Also fixes a rare NRE in the mouse handler.