### PR TITLE
Added spoiled module support to the module service.

### DIFF
--- a/Blish HUD/Strings/GameServices/ModulesService.Designer.cs
+++ b/Blish HUD/Strings/GameServices/ModulesService.Designer.cs
@@ -322,7 +322,7 @@ namespace Blish_HUD.Strings.GameServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Module Version Is Too Old.
+        ///   Looks up a localized string similar to Module Version Is Incompatible.
         /// </summary>
         internal static string ModuleState_Custom_ExplicitlyIncompatible {
             get {

--- a/Blish HUD/Strings/GameServices/ModulesService.de.resx
+++ b/Blish HUD/Strings/GameServices/ModulesService.de.resx
@@ -220,7 +220,7 @@
     <value>Einstellungen werden angezeigt sobald das Modul aktiviert ist</value>
   </data>
   <data name="ModuleState_Custom_ExplicitlyIncompatible" xml:space="preserve">
-    <value>Modul Version ist zu alt</value>
+    <value>Modulversion ist inkompatibel</value>
   </data>
   <data name="NoModules_Info" xml:space="preserve">
     <value>Du hast aktuell keine Module.

--- a/Blish HUD/Strings/GameServices/ModulesService.fr.resx
+++ b/Blish HUD/Strings/GameServices/ModulesService.fr.resx
@@ -227,7 +227,7 @@ Téléchargez des modules et placez-les dans le dossier modules.</value>
     <value>Supprimer le module</value>
   </data>
   <data name="ModuleState_Custom_ExplicitlyIncompatible" xml:space="preserve">
-    <value>La version du module est trop ancienne</value>
+    <value>La version du module est incompatible</value>
   </data>
   <data name="PkgInstall_Progress_Installing" xml:space="preserve">
     <value>Installation...</value>

--- a/Blish HUD/Strings/GameServices/ModulesService.resx
+++ b/Blish HUD/Strings/GameServices/ModulesService.resx
@@ -240,7 +240,7 @@ Download some modules and place them in the modules folder.</value>
     <value>Delete Module</value>
   </data>
   <data name="ModuleState_Custom_ExplicitlyIncompatible" xml:space="preserve">
-    <value>Module Version Is Too Old</value>
+    <value>Module Version Is Incompatible</value>
   </data>
   <data name="PkgManagement_IsPreview" xml:space="preserve">
     <value>Preview Release</value>


### PR DESCRIPTION
Adds an additional check on load to ensure that modules part of the 'spoiled' list are not enabled.  A warning is also shown on the module's page indicating that it is not compatible.

![image](https://user-images.githubusercontent.com/1950594/188515013-675fc785-03f4-4709-88b8-1657172109a1.png)

Module spoiling is handled through SSRD and generates the following static file:

https://pkgs.blishhud.com/spoiled.json