### PR TITLE
add KeyBinding.BindingChanged event

### DIFF
--- a/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
@@ -10,6 +10,10 @@ namespace Blish_HUD.Input {
     /// Allows for actions to be ran as the result of a provided key combination.
     /// </summary>
     public class KeyBinding {
+        /// <summary>
+        /// Fires when the keys of the <see cref="KeyBinding"/> are changed.
+        /// </summary>
+        public event EventHandler<EventArgs> KeysChanged; 
 
         /// <summary>
         /// Fires when the <see cref="KeyBinding"/> is triggered.
@@ -20,18 +24,38 @@ namespace Blish_HUD.Input {
             Activated?.Invoke(this, e);
         }
 
+        private Keys _primaryKey;
         /// <summary>
         /// The primary key in the binding.
         /// </summary>
         [JsonProperty]
-        public Keys PrimaryKey { get; set; }
+        public Keys PrimaryKey { 
+            get => _primaryKey;
+            set {
+                if (_primaryKey == value) {
+                    return;
+                }
+                _primaryKey = value;
+                KeysChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
 
+        private ModifierKeys _modifierKeys;
         /// <summary>
         /// Any combination of <see cref="ModifierKeys"/> required to be pressed
         /// in addition to the <see cref="PrimaryKey"/> for the <see cref="KeyBinding"/> to fire.
         /// </summary>
         [JsonProperty]
-        public ModifierKeys ModifierKeys { get; set; }
+        public ModifierKeys ModifierKeys {
+            get => _modifierKeys;
+            set {
+                if (_modifierKeys == value) {
+                    return;
+                }
+                _modifierKeys = value;
+                KeysChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
 
         private bool _enabled;
 
@@ -79,8 +103,8 @@ namespace Blish_HUD.Input {
         public KeyBinding(Keys primaryKey) : this(ModifierKeys.None, primaryKey) { /* NOOP */ }
 
         public KeyBinding(ModifierKeys modifierKeys, Keys primaryKey) {
-            this.ModifierKeys = modifierKeys;
-            this.PrimaryKey   = primaryKey;
+            _modifierKeys = modifierKeys;
+            _primaryKey   = primaryKey;
         }
 
         private void KeyboardOnKeyStateChanged(object sender, KeyboardEventArgs e) {

--- a/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
@@ -13,7 +13,7 @@ namespace Blish_HUD.Input {
         /// <summary>
         /// Fires when the keys of the <see cref="KeyBinding"/> are changed.
         /// </summary>
-        public event EventHandler<EventArgs> KeysChanged; 
+        public event EventHandler<EventArgs> BindingChanged; 
 
         /// <summary>
         /// Fires when the <see cref="KeyBinding"/> is triggered.
@@ -36,7 +36,7 @@ namespace Blish_HUD.Input {
                     return;
                 }
                 _primaryKey = value;
-                KeysChanged?.Invoke(this, EventArgs.Empty);
+                BindingChanged?.Invoke(this, EventArgs.Empty);
             }
         }
 
@@ -53,7 +53,7 @@ namespace Blish_HUD.Input {
                     return;
                 }
                 _modifierKeys = value;
-                KeysChanged?.Invoke(this, EventArgs.Empty);
+                BindingChanged?.Invoke(this, EventArgs.Empty);
             }
         }
 


### PR DESCRIPTION
I am dealing with saving and loading KeyBindings from settings a lot.

**Problems**
- Only the KeyAssigner control itself has an appropriate event for when the assignment changed which forbids one to reuse the SettingsView inside a custom ViewContainer for self managment and instead build the KeyAssigner.
- The SettingEntry<KeyBinding>.SettingChanged event only fires when the object itself changes.

**Solution:**
- Event that makes it possible to continuously work with the KeyBinding stored in the SettingEntry while reusing the SettingsView inside a custom ViewContainer.