### PR TITLE
TextInputBase.TextChanged: Changed event args to correct type

### DIFF
--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -52,7 +52,7 @@ namespace Blish_HUD.Controls {
         /// <summary>
         /// Fires when the <see cref="Text"/> is changed.
         /// </summary>
-        public event EventHandler<EventArgs> TextChanged;
+        public event EventHandler<ValueChangedEventArgs<string>> TextChanged;
 
         /// <summary>
         /// Fires when the <see cref="CursorIndex"/> is changed.

--- a/Blish HUD/GameServices/Gw2WebApi/UI/Views/RegisterApiKeyView.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/UI/Views/RegisterApiKeyView.cs
@@ -289,7 +289,7 @@ namespace Blish_HUD.Gw2WebApi.UI.Views {
             return _tokenTestCanceller.Token;
         }
 
-        private void ApiKeyTextBoxOnTextChanged(object sender, EventArgs e) {
+        private void ApiKeyTextBoxOnTextChanged(object sender, ValueChangedEventArgs<string> e) {
             SetTokenStatus(ApiTokenStatusType.Loading);
             _tokenCheckDebounceWrapper(this.ApiKey);
         }

--- a/Blish HUD/GameServices/Modules/UI/Views/ModuleRepoView.cs
+++ b/Blish HUD/GameServices/Modules/UI/Views/ModuleRepoView.cs
@@ -90,7 +90,7 @@ namespace Blish_HUD.Modules.UI.Views {
             };
         }
 
-        private void SearchboxOnTextChanged(object sender, EventArgs e) {
+        private void SearchboxOnTextChanged(object sender, ValueChangedEventArgs<string> e) {
             this.RepoFlowPanel.FilterChildren<ViewContainer>(viewContainer => PkgParamFilter(viewContainer, PkgNeedsUpdateFilter, PkgSearchFilter));
         }
 


### PR DESCRIPTION
This PR changes the event args of the TextInputBase.TextChanged event to the correct type which gets passed to the event via the OnTextChanged method.

If this event has been subscribed to via an anonymous function, this PR is a breaking change.
If the event has been subscribed to via a normal function, this PR is non breaking.

It has to be considered that this PR is breaking for some modules.