### PR TITLE
🐛fix SettingsCollection.RenderInUi not being used in constructor

### DIFF
--- a/Blish HUD/GameServices/Settings/SettingCollection.cs
+++ b/Blish HUD/GameServices/Settings/SettingCollection.cs
@@ -142,11 +142,15 @@ namespace Blish_HUD.Settings {
         }
 
         public SettingCollection AddSubCollection(string collectionKey, bool lazyLoaded = false) {
-            return AddSubCollection(collectionKey, false, lazyLoaded);
+            return AddSubCollection(collectionKey, false, lazyLoaded, null);
         }
 
         public SettingCollection AddSubCollection(string collectionKey, bool renderInUi, bool lazyLoaded = false) {
-            return AddSubCollection(collectionKey, false, lazyLoaded, null);
+            return AddSubCollection(collectionKey, renderInUi, lazyLoaded, null);
+        }
+
+        public SettingCollection AddSubCollection(string collectionKey, bool renderInUi, Func<string> displayNameFunc = null) {
+            return AddSubCollection(collectionKey, renderInUi, false, displayNameFunc);
         }
 
         public SettingCollection AddSubCollection(string collectionKey, bool renderInUi, bool lazyLoaded = false, Func<string> displayNameFunc = null) {


### PR DESCRIPTION
renderInUi was not used in the simplest SettingsCollection constructor which forced us to use the longest overload everytime.

I added another overload without lazyLoaded and made all overloads reference the longest overload directly.