### PR TITLE
Detect incompatible fullscreen / dx9 combo.

### DIFF
--- a/Blish HUD/GameServices/Debug/Contingency.cs
+++ b/Blish HUD/GameServices/Debug/Contingency.cs
@@ -111,6 +111,13 @@ namespace Blish_HUD.Debug {
                               (new TaskDialogButton(Strings.GameServices.Debug.ContingencyMessages.NvidiaSettings_OpenControlPanelAction), OpenNvidaControlPanel));
         }
 
+        internal static void NotifyConflictingFullscreenSettings() {
+            NotifyContingency(nameof(NotifyConflictingFullscreenSettings),
+                              Strings.GameServices.Debug.ContingencyMessages.ConflictingFullscreenSettings_Title,
+                              Strings.GameServices.Debug.ContingencyMessages.ConflictingFullscreenSettings_Description,
+                              "https://link.blishhud.com/fullscreenmode");
+        }
+
         public static void NotifyFileSaveAccessDenied(string path, string actionDescription, bool promptPortableMode = false) {
             // TODO: If promptPortabelMode is true, add a new button to the diag that allows the user to enable portable mode as a work around.
             NotifyContingency(nameof(NotifyFileSaveAccessDenied),

--- a/Blish HUD/GameServices/Debug/ContingencyChecks.cs
+++ b/Blish HUD/GameServices/Debug/ContingencyChecks.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using Microsoft.Win32;
 using nspector.Common;
@@ -14,6 +12,8 @@ using nspector.Native.NvApi.DriverSettings;
 
 namespace Blish_HUD.Debug {
     internal static class ContingencyChecks {
+
+        #region Launch Checks
 
         public static void RunAll() {
             CheckArcDps11Injected();
@@ -70,6 +70,10 @@ namespace Blish_HUD.Debug {
             }
         }
 
+        /// <summary>
+        /// Checks to ensure that non-default Nvidia control panel settings haven't been set for Blish HUD.
+        /// For specific settings, this can cause Blish HUD to render with an opaque background.
+        /// </summary>
         private static void CheckNvidiaControlPanelSettings() {
             try {
                 var customSettingNames    = CustomSettingNames.FactoryLoadFromString(nspector.Properties.Resources.CustomSettingNames);
@@ -110,5 +114,22 @@ namespace Blish_HUD.Debug {
                  // in which case the check is useless anyway.
             }
         }
+
+        #endregion
+
+        #region Initiated Checks
+
+        /// <summary>
+        /// Checks to see if Guild Wars 2 is running in fullscreen mode along with DX9.
+        /// Blish HUD can't run while the game is configured this way.
+        /// </summary>
+        internal static void CheckForFullscreenDx9Conflict() {
+            if (GameService.GameIntegration.Gw2Instance.GraphicsApi == GameIntegration.Gw2GraphicsApi.DX9 
+             && GameService.GameIntegration.GfxSettings.ScreenMode  == GameIntegration.GfxSettings.ScreenModeSetting.Fullscreen) {
+                Contingency.NotifyConflictingFullscreenSettings();
+            }
+        }
+
+        #endregion
     }
 }

--- a/Blish HUD/GameServices/GameIntegration/GfxSettingsIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/GfxSettingsIntegration.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Xml;
+using Blish_HUD.Debug;
 using Blish_HUD.GameIntegration.GfxSettings;
 using Blish_HUD.GameServices;
 
@@ -222,6 +223,11 @@ namespace Blish_HUD.GameIntegration {
                     gfxSettingsFileStream.Dispose();
 
                     Logger.Debug("Finished parsing GSA file.");
+
+                    // Easiest place to check where we should now know if the user is in fullscreen or not
+                    if (this.IsAvailable) {
+                        ContingencyChecks.CheckForFullscreenDx9Conflict();
+                    }
                 }
             } catch (IOException ex) {
                 if (remainingAttempts > 0) {

--- a/Blish HUD/GameServices/GameIntegration/Gw2GraphicsApi.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2GraphicsApi.cs
@@ -1,0 +1,19 @@
+﻿namespace Blish_HUD.GameIntegration {
+
+    public enum Gw2GraphicsApi {
+        /// <summary>
+        /// Indicates that the graphics API used could not be detected or that the main game window hasn't been opened yet.
+        /// </summary>
+        Unknown,
+        /// <summary>
+        /// Indicates that Guild Wars 2 is running with DirectX 9 enabled.
+        /// </summary>
+        DX9,
+
+        /// <summary>
+        /// Indicates that Guild Wars 2 is running with DirectX 11 enabled.
+        /// </summary>
+        DX11
+    }
+
+}

--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -11,6 +11,7 @@ using Microsoft.Win32;
 using Microsoft.Xna.Framework;
 
 namespace Blish_HUD.GameIntegration {
+
     public class Gw2InstanceIntegration : ServiceModule<GameIntegrationService> {
 
         private static readonly Logger Logger = Logger.GetLogger<Gw2InstanceIntegration>();
@@ -19,6 +20,8 @@ namespace Blish_HUD.GameIntegration {
         private const string GW2_REGISTRY_PATH_SV = "Path";
 
         private const string GW2_PATCHWINDOW_CLASS = "ArenaNet";
+        private const string GW2_DX9WINDOW_CLASS   = "ArenaNet_Dx_Window_Class";
+        private const string GW2_DX11WINDOW_CLASS  = "ArenaNet_Gr_Window_Class";
 
         private const string APPDATA_ENVKEY = "appdata";
 
@@ -114,7 +117,7 @@ namespace Blish_HUD.GameIntegration {
         }
 
         /// <summary>
-        /// Indicates that the Guild Wars 2 instance is likely a Steam copy of the game.
+        /// Indicates if the Guild Wars 2 instance is likely a Steam copy of the game.
         /// </summary>
         public bool IsSteamVersion => _gw2ExecutablePath.Value.Contains("steamapps\\common");
 
@@ -136,6 +139,11 @@ namespace Blish_HUD.GameIntegration {
             get => _commandLine;
             private set => PropertyUtil.SetProperty(ref _commandLine, value);
         }
+
+        /// <summary>
+        /// Indicates what graphics API Guild Wars 2 is actively using.
+        /// </summary>
+        public Gw2GraphicsApi GraphicsApi { get; private set; } = Gw2GraphicsApi.Unknown;
 
         // Settings
         private SettingEntry<string> _gw2ExecutablePath;
@@ -176,7 +184,24 @@ namespace Blish_HUD.GameIntegration {
             }
         }
 
+        private void UpdateDetectedGraphicsApi(string windowClassName) {
+            var lastDetectedGraphicsApi = this.GraphicsApi;
+
+            // We can detect DX9 vs. DX11 via the window class name
+            this.GraphicsApi = windowClassName switch {
+                GW2_DX9WINDOW_CLASS  => Gw2GraphicsApi.DX9,
+                GW2_DX11WINDOW_CLASS => Gw2GraphicsApi.DX11,
+                _                    => Gw2GraphicsApi.Unknown
+            };
+
+            if (this.GraphicsApi != Gw2GraphicsApi.Unknown && lastDetectedGraphicsApi != this.GraphicsApi) {
+                Logger.Info("Guild Wars 2 is running in {graphicsApi}.", this.GraphicsApi);
+            }
+        }
+
         private void HandleProcessUpdate(Process newProcess) {
+            string windowClass = null;
+
             if (newProcess == null || _gw2Process.HasExited || _gw2Process.MainWindowHandle == IntPtr.Zero) {
                 BlishHud.Instance.Form.Invoke((MethodInvoker)(() => { BlishHud.Instance.Form.Visible = false; }));
 
@@ -215,7 +240,7 @@ namespace Blish_HUD.GameIntegration {
 
                 // GW2 is running if the "_gw2Process" isn't null and the class name of process' 
                 // window is the game window name (so we know we are passed the login screen)
-                string windowClass = WindowUtil.GetClassNameOfWindow(_gw2Process.MainWindowHandle);
+                windowClass = WindowUtil.GetClassNameOfWindow(_gw2Process.MainWindowHandle);
 
                 this.Gw2IsRunning = windowClass == ApplicationSettings.Instance.WindowName
                                  || windowClass != GW2_PATCHWINDOW_CLASS;
@@ -224,6 +249,8 @@ namespace Blish_HUD.GameIntegration {
                     WindowUtil.SetShowInTaskbar(BlishHud.Instance.FormHandle, true);
                 }
             }
+
+            UpdateDetectedGraphicsApi(windowClass);
         }
 
         private void OnGameFocusChanged(object sender, ValueEventArgs<bool> e) {

--- a/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.Designer.cs
+++ b/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.Designer.cs
@@ -99,6 +99,29 @@ namespace Blish_HUD.Strings.GameServices.Debug {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Blish HUD has detected that you are running the game with DirectX 9 enabled while in fullscreen.  Blish HUD is unable to function in this configuration.  To resolve, either:
+        ///
+        ///1) Uncheck &quot;Enable DX9 Rendering (Deprecated)&quot; in your in-game graphics options.
+        ///2) Set &quot;Resolution&quot; to &quot;Windowed Fullscreen&quot; or &quot;Window&quot;.
+        ///
+        ///You can reference the guide linked below for further assistance..
+        /// </summary>
+        internal static string ConflictingFullscreenSettings_Description {
+            get {
+                return ResourceManager.GetString("ConflictingFullscreenSettings_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Conflicting Graphics Settings!.
+        /// </summary>
+        internal static string ConflictingFullscreenSettings_Title {
+            get {
+                return ResourceManager.GetString("ConflictingFullscreenSettings_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Update to v{0} of Blish HUD failed.  Relaunch Blish HUD to try again.  The error was:
         ///
         ///{1}.

--- a/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.resx
+++ b/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.resx
@@ -193,4 +193,15 @@ Please explicitly allow Blish HUD in your "Controlled Folder Access" settings or
   <data name="NvidiaSettings_Title" xml:space="preserve">
     <value>Incompatible NVIDIA Settings</value>
   </data>
+  <data name="ConflictingFullscreenSettings_Title" xml:space="preserve">
+    <value>Conflicting Graphics Settings!</value>
+  </data>
+  <data name="ConflictingFullscreenSettings_Description" xml:space="preserve">
+    <value>Blish HUD has detected that you are running the game with DirectX 9 enabled while in fullscreen.  Blish HUD is unable to function in this configuration.  To resolve, either:
+
+1) Uncheck "Enable DX9 Rendering (Deprecated)" in your in-game graphics options.
+2) Set "Resolution" to "Windowed Fullscreen" or "Window".
+
+You can reference the guide linked below for further assistance.</value>
+  </data>
 </root>


### PR DESCRIPTION
Checks for this issue:

https://github.com/blish-hud/Blish-HUD/discussions/734

And alerts the user if it is detected:

![image](https://user-images.githubusercontent.com/1950594/193495473-1cd82216-b7c1-4f5e-9def-bf2696c91ba6.png)
