### PR TITLE
Prerelease cleanup

### DIFF
--- a/Blish HUD/GameServices/Modules/ModuleDependency.cs
+++ b/Blish HUD/GameServices/Modules/ModuleDependency.cs
@@ -57,9 +57,13 @@ namespace Blish_HUD.Modules {
         public ModuleDependencyCheckDetails GetDependencyDetails() {
             // Check against Blish HUD version
             if (this.IsBlishHud) {
-                bool satisfied = Program.OverlayVersion.PreRelease == null
-                                     ? this.VersionRange.IsSatisfied(Program.OverlayVersion.BaseVersion())
-                                     : this.VersionRange.IsSatisfied(Program.OverlayVersion);
+                bool satisfied = this.VersionRange.IsSatisfied(Program.OverlayVersion.BaseVersion());
+
+                // This is a bit scuffed - the idea here is that we only want to evaluate this like a prerelease if the version range intends to target one
+                // Otherwise, we don't want to check this way since it will make non-prerelease tags on this version to evaluate as satisfied
+                if (Program.OverlayVersion.PreRelease != null && this.VersionRange.ToString().Contains("-ci")) {
+                    satisfied &= this.VersionRange.IsSatisfied(Program.OverlayVersion);
+                }
 
                 return new ModuleDependencyCheckDetails(this,
                                                         satisfied || Program.OverlayVersion.BaseVersion() == new Version(0, 0, 0) // Ensure local builds ignore prerequisite

--- a/Blish HUD/GameServices/Modules/UI/Presenters/ModuleDependencyPresenter.cs
+++ b/Blish HUD/GameServices/Modules/UI/Presenters/ModuleDependencyPresenter.cs
@@ -47,12 +47,12 @@ namespace Blish_HUD.Modules.UI.Presenters {
                                            : dependencyCheck.Module.Manifest.Version.BaseVersion().ToString();
 
                 string status = dependencyCheck.CheckResult switch {
-                    ModuleDependencyCheckResult.NotFound => $"{Strings.GameServices.ModulesService.Dependency_NotFound} {requiredRange}",
-                    ModuleDependencyCheckResult.Available => $"v{actualVersion}",
-                    ModuleDependencyCheckResult.AvailableNotEnabled => $"{Strings.GameServices.ModulesService.Dependency_NotEnabled} {requiredRange}",
+                    ModuleDependencyCheckResult.NotFound              => $"{Strings.GameServices.ModulesService.Dependency_NotFound} {requiredRange}",
+                    ModuleDependencyCheckResult.Available             => $"{requiredRange} | v{actualVersion}",
+                    ModuleDependencyCheckResult.AvailableNotEnabled   => $"{Strings.GameServices.ModulesService.Dependency_NotEnabled} {requiredRange}",
                     ModuleDependencyCheckResult.AvailableWrongVersion => $"{Strings.GameServices.ModulesService.Dependency_WrongVersion} {requiredRange}",
-                    ModuleDependencyCheckResult.FoundInRepo => $"[Found In Repo (Not Implemented)] v{requiredRange}",
-                    _ => ""
+                    ModuleDependencyCheckResult.FoundInRepo           => $"[Found In Repo (Not Implemented)] {requiredRange}",
+                    _                                                 => ""
                 };
 
                 checkResults.Add((dependencyCheck.GetDisplayName(), status, dependencyCheck.CheckResult));

--- a/Blish HUD/GameServices/Overlay/SelfUpdater/Controls/SelfUpdateWindow.cs
+++ b/Blish HUD/GameServices/Overlay/SelfUpdater/Controls/SelfUpdateWindow.cs
@@ -57,7 +57,9 @@ namespace Blish_HUD.Overlay.SelfUpdater.Controls {
                 AutoSizeHeight      = true,
                 Height              = 82,
                 Top                 = blishHudHero.Bottom,
-                Text                = Strings.GameServices.OverlayService.SelfUpdate_NewUpdateAvailable,
+                Text                = newReleaseManifest.IsPrerelease 
+                                          ? Strings.GameServices.OverlayService.SelfUpdate_NewPrereleaseAvailable
+                                          : Strings.GameServices.OverlayService.SelfUpdate_NewUpdateAvailable,
                 Font                = GameService.Content.DefaultFont32,
                 StrokeText          = true,
                 VerticalAlignment   = VerticalAlignment.Middle,

--- a/Blish HUD/Strings/GameServices/OverlayService.Designer.cs
+++ b/Blish HUD/Strings/GameServices/OverlayService.Designer.cs
@@ -269,6 +269,15 @@ namespace Blish_HUD.Strings.GameServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to New Prerelease Available.
+        /// </summary>
+        internal static string SelfUpdate_NewPrereleaseAvailable {
+            get {
+                return ResourceManager.GetString("SelfUpdate_NewPrereleaseAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to New Release Available.
         /// </summary>
         internal static string SelfUpdate_NewUpdateAvailable {

--- a/Blish HUD/Strings/GameServices/OverlayService.de.resx
+++ b/Blish HUD/Strings/GameServices/OverlayService.de.resx
@@ -259,4 +259,7 @@ Für die beste Erfahrung auf die selbe Taste wie im Spiel setzen.</value>
   <data name="Setting_InteractKey_DisplayName" xml:space="preserve">
     <value>Interagieren</value>
   </data>
+  <data name="SelfUpdate_NewPrereleaseAvailable" xml:space="preserve">
+    <value>Neue Beta-Version verfügbar</value>
+  </data>
 </root>

--- a/Blish HUD/Strings/GameServices/OverlayService.fr.resx
+++ b/Blish HUD/Strings/GameServices/OverlayService.fr.resx
@@ -257,4 +257,7 @@ Guild Wars 2 et Blish HUD.</value>
   <data name="Setting_Volume_DisplayName" xml:space="preserve">
     <value>Volume</value>
   </data>
+  <data name="SelfUpdate_NewPrereleaseAvailable" xml:space="preserve">
+    <value>Nouvelle version bêta disponible</value>
+  </data>
 </root>

--- a/Blish HUD/Strings/GameServices/OverlayService.resx
+++ b/Blish HUD/Strings/GameServices/OverlayService.resx
@@ -321,4 +321,7 @@ participate in the conversation?</value>
   <data name="About_DiscordCallToAction_Button" xml:space="preserve">
     <value>Join our Discord</value>
   </data>
+  <data name="SelfUpdate_NewPrereleaseAvailable" xml:space="preserve">
+    <value>New Prerelease Available</value>
+  </data>
 </root>


### PR DESCRIPTION
- Correct the logic related to prerelease version ranges.
- Make UI more clear when we have a valid dependency.
- Show prerelease banner in the update window.