### PR TITLE
Fix menu item re-aligning

### DIFF
--- a/Blish HUD/Controls/Menu.cs
+++ b/Blish HUD/Controls/Menu.cs
@@ -151,5 +151,15 @@ namespace Blish_HUD.Controls {
             }
         }
 
+        public override void RecalculateLayout() {
+            int lastBottom = 0;
+
+            foreach (var child in _children.Where(c => c.Visible)) {
+                child.Location = new Point(0, lastBottom);
+                child.Width = this.Width;
+
+                lastBottom = child.Bottom;
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the issue with menu items not re-aligning after an menu item has been deleted in the middle.
The current state would leave a gap.