### PR TITLE
Update window pos on launch

### DIFF
--- a/Blish HUD/BlishHud.cs
+++ b/Blish HUD/BlishHud.cs
@@ -59,9 +59,9 @@ namespace Blish_HUD {
             FormHandle = this.Window.Handle;
             Form       = Control.FromHandle(FormHandle).FindForm();
 
-            // Avoid the flash the window shows when the application launches
+            // Avoid the flash the window shows when the application launches (-32000x-32000 is where windows places minimized windows)
             Form.BackColor = System.Drawing.Color.Black;
-            Form.Location  = new System.Drawing.Point(-Form.Width * 2, -Form.Height * 2);
+            Form.Location  = new System.Drawing.Point(-32000, -32000);
 
             this.Window.IsBorderless = true;
             this.Window.AllowAltF4   = false;


### PR DESCRIPTION
Fixes a bug for folks with many monitors in a specific configuration that allows users to see the loading window before intended.