### PR TITLE
Fix Blish HUD crashing when modules are corrupt.

### DIFF
--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -204,10 +204,7 @@ namespace Blish_HUD.GameIntegration {
             string windowClass = null;
 
             if (newProcess == null || _gw2Process.HasExited || _gw2Process.MainWindowHandle == IntPtr.Zero) {
-                if (BlishHud.Instance.Form.IsHandleCreated) {
-                    // Maybe we queue this action on some kind of dedicated subservice that manages invoking things on the mainform?
-                    BlishHud.Instance.Form.Invoke((MethodInvoker)(() => { BlishHud.Instance.Form.Visible = false; }));
-                }
+                BlishHud.Instance.Form.Invoke((MethodInvoker)(() => { BlishHud.Instance.Form.Visible = false; }));
 
                 _gw2Process = null;
                 this.Gw2IsRunning = false;

--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -204,7 +204,10 @@ namespace Blish_HUD.GameIntegration {
             string windowClass = null;
 
             if (newProcess == null || _gw2Process.HasExited || _gw2Process.MainWindowHandle == IntPtr.Zero) {
-                BlishHud.Instance.Form.Invoke((MethodInvoker)(() => { BlishHud.Instance.Form.Visible = false; }));
+                if (BlishHud.Instance.Form.IsHandleCreated) {
+                    // Maybe we queue this action on some kind of dedicated subservice that manages invoking things on the mainform?
+                    BlishHud.Instance.Form.Invoke((MethodInvoker)(() => { BlishHud.Instance.Form.Visible = false; }));
+                }
 
                 _gw2Process = null;
                 this.Gw2IsRunning = false;

--- a/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.Designer.cs
+++ b/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.Designer.cs
@@ -61,7 +61,7 @@ namespace Blish_HUD.Strings.GameServices.Debug {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There is a custom &apos;d3dll.dll&apos; (e.g. ArcDPS) in the same directory as Blish HUD which will attempt to inject into Blish HUD and cause it to crash.  Please move Blish HUD to a different folder..
+        ///   Looks up a localized string similar to There is a custom &apos;d3d11.dll&apos; (e.g. ArcDPS) in the same directory as Blish HUD which will attempt to inject into Blish HUD and cause it to crash.  Please extract Blish HUD into a different folder..
         /// </summary>
         internal static string ArcDpsSameDir_Description {
             get {

--- a/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.resx
+++ b/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.resx
@@ -129,7 +129,7 @@ Relaunch Blish HUD as an administrator or relaunch Guild Wars 2 without admin.</
     <value>Check our &lt;a href="{0}"&gt;troubleshooting guide&lt;/a&gt; for this issue or join our &lt;a href="{1}"&gt;Discord 💢help channel&lt;/a&gt;.</value>
   </data>
   <data name="ArcDpsSameDir_Description" xml:space="preserve">
-    <value>There is a custom 'd3dll.dll' (e.g. ArcDPS) in the same directory as Blish HUD which will attempt to inject into Blish HUD and cause it to crash.  Please move Blish HUD to a different folder.</value>
+    <value>There is a custom 'd3d11.dll' (e.g. ArcDPS) in the same directory as Blish HUD which will attempt to inject into Blish HUD and cause it to crash.  Please extract Blish HUD into a different folder.</value>
   </data>
   <data name="ArcDpsSameDir_Title" xml:space="preserve">
     <value>Blish HUD Can't Run!</value>


### PR DESCRIPTION
Fixes:

```
System.IO.InvalidDataException: End of Central Directory record could not be found.
   at System.IO.Compression.ZipArchive.ReadEndOfCentralDirectory()
   at System.IO.Compression.ZipArchive.Init(Stream stream, ZipArchiveMode mode, Boolean leaveOpen)
   at System.IO.Compression.ZipFile.Open(String archiveFileName, ZipArchiveMode mode, Encoding entryNameEncoding)
   at Blish_HUD.Content.ZipArchiveReader..ctor(String archivePath, String subPath) in D:\a\Blish-HUD\Blish-HUD\Blish HUD\GameServices\Content\ZipArchiveReader.cs:line 27
   at Blish_HUD.ModuleService.RegisterPackedModule(String modulePath) in D:\a\Blish-HUD\Blish-HUD\Blish HUD\GameServices\ModuleService.cs:line 206
   at Blish_HUD.ModuleService.Load() in D:\a\Blish-HUD\Blish-HUD\Blish HUD\GameServices\ModuleService.cs:line 270
   at Blish_HUD.GameService.DoLoad() in D:\a\Blish-HUD\Blish-HUD\Blish HUD\GameServices\GameService.cs:line 57
   at Blish_HUD.BlishHud.BeginRun() in D:\a\Blish-HUD\Blish-HUD\Blish HUD\BlishHud.cs:line 93
   at Microsoft.Xna.Framework.Game.Run(GameRunBehavior runBehavior)
   at Blish_HUD.Program.Main(String[] args) in D:\a\Blish-HUD\Blish-HUD\Blish HUD\Program.cs:line 97
```