### PR TITLE
fix module repo filter checkbox being inverted

### DIFF
--- a/Blish HUD/GameServices/Modules/Pkgs/StaticPkgRepoProvider.cs
+++ b/Blish HUD/GameServices/Modules/Pkgs/StaticPkgRepoProvider.cs
@@ -102,9 +102,9 @@ namespace Blish_HUD.Modules.Pkgs {
 
         protected void ToggleFilter(Func<PkgManifest, bool> filterFunc, bool state) {
             if (state) {
-                _activeFilters.Add(filterFunc);
-            } else {
                 _activeFilters.Remove(filterFunc);
+            } else {
+                _activeFilters.Add(filterFunc);
             }
         }
 


### PR DESCRIPTION
This fixes an issue where toggling filters in the module repo would do nothing on the first toggle, and subsequent toggles would do the opposite of what is expected.