### PR TITLE
Module menu item improvements

### DIFF
--- a/Blish HUD/GameServices/Modules/ModuleManager.cs
+++ b/Blish HUD/GameServices/Modules/ModuleManager.cs
@@ -245,6 +245,9 @@ namespace Blish_HUD.Modules {
 
             GameService.Module.UnregisterModule(this);
 
+            this.ModuleEnabled = null;
+            this.ModuleEnabled = null;
+
             _moduleAssembly = null;
 
             this.DataReader?.Dispose();


### PR DESCRIPTION
Added icon indicators for each module.  
Added a context menu strip to let you toggle a module on and off quickly from the listing.

![image](https://user-images.githubusercontent.com/1950594/211628007-49699cc5-7208-450b-a51d-bf2cbd3225b4.png)

Closes #827 