### PR TITLE
Contingency Popup Improvements

### DIFF
--- a/Blish HUD/GameServices/Debug/ContingencyPopup.Designer.cs
+++ b/Blish HUD/GameServices/Debug/ContingencyPopup.Designer.cs
@@ -179,7 +179,6 @@
             this.MinimizeBox = false;
             this.Name = "ContingencyPopup";
             this.ShowIcon = false;
-            this.ShowInTaskbar = false;
             this.Text = "ContingencyPopup";
             this.TopMost = true;
             this.PnlExtraInfo.ResumeLayout(false);

--- a/Blish HUD/GameServices/Debug/ContingencyPopup.cs
+++ b/Blish HUD/GameServices/Debug/ContingencyPopup.cs
@@ -54,8 +54,17 @@ namespace Blish_HUD.Debug {
             Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
         }
 
+        private bool _clickAttempted = false;
+
         private void BttnOkay_Click(object sender, EventArgs e) {
-            Close();
+            if (_clickAttempted) {
+                // Make sure folks can close the window
+                Process.GetCurrentProcess().Kill();
+            } else {
+                Close();
+            }
+
+            _clickAttempted = true;
         }
 
         private void LblDescription_Resize(object sender, EventArgs e) {

--- a/Blish HUD/GameServices/Debug/ContingencyPopup.cs
+++ b/Blish HUD/GameServices/Debug/ContingencyPopup.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 using System.Windows.Forms;
 
 namespace Blish_HUD.Debug {

--- a/Blish HUD/GameServices/Debug/ContingencyPopup.cs
+++ b/Blish HUD/GameServices/Debug/ContingencyPopup.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Windows.Forms;
 
 namespace Blish_HUD.Debug {


### PR DESCRIPTION
Improvements made to the contingency popup to make it more visible (it now shows in the taskbar).  Some users experienced conflicting issues where the popup would show but couldn't be closed for some reason.  We now force close Blish HUD if this happens.