### PR TITLE
API and Update Stability

### DIFF
--- a/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
@@ -72,7 +72,7 @@ namespace Blish_HUD.Gw2WebApi {
                 return await updateFunc().ConfigureAwait(false);
             } catch (TooManyRequestsException) {
                 // Penalize our token count - we've hit the rate limited
-                this.Tokens = Math.Min(this.Tokens - this.RefillAmount, -1);
+                this.Tokens = Math.Min(this.Tokens - this.RefillAmount, remainingAttempts - FAILED_CONSUME_RETRIES - 1);
 
                 if (remainingAttempts > 0) {
                     return await ConsumeCompliant<T>(updateFunc, remainingAttempts - 1);

--- a/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
@@ -6,7 +6,7 @@ namespace Blish_HUD.Gw2WebApi {
     public class TokenBucket {
 
         private const int REFILL_INTERVAL        = 1000;
-        private const int FAILED_CONSUME_RETRIES = 3;
+        private const int FAILED_CONSUME_RETRIES = 8;
 
         /// <summary>
         /// The maximum number of tokens in the bucket.

--- a/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
@@ -80,6 +80,17 @@ namespace Blish_HUD.Gw2WebApi {
 
                 // Too many attempts
                 throw;
+            } catch (UnexpectedStatusException ex) {
+                if (ex.Response != null) {
+                    // <head><title>504 Gateway Time-out</title></head>
+                    if (ex.Response.StatusCode == System.Net.HttpStatusCode.GatewayTimeout || ex.Response.Content.Contains("504")) {
+                        await Task.Delay(1000);
+
+                        if (remainingAttempts > 0) {
+                            return await ConsumeCompliant<T>(updateFunc, remainingAttempts - 1);
+                        }
+                    }
+                }
             } catch (RequestException ex) {
                 var baseEx = ex.GetBaseException();
 

--- a/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
@@ -86,7 +86,7 @@ namespace Blish_HUD.Gw2WebApi {
                 switch (baseEx.HResult) {
                     case -2147467259:
                         if (baseEx.Message.Contains("forbidden by its access")) { // An attempt was made to access a socket in a way forbidden by its access permissions.
-                            // This will only work on Windows systems, but it's an ambiguous HResult and changing the UI language I think isn't worth it.
+                            // This will only work on systems in English, but it's an ambiguous HResult and changing the UI language I think isn't worth it.
                             Debug.Contingency.NotifyHttpAccessDenied("to the Guild Wars 2 API");
                         }
                         break;

--- a/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
+++ b/Blish HUD/GameServices/Gw2WebApi/TokenBucket.cs
@@ -91,6 +91,8 @@ namespace Blish_HUD.Gw2WebApi {
                         }
                     }
                 }
+
+                throw;
             } catch (RequestException ex) {
                 var baseEx = ex.GetBaseException();
 

--- a/Blish HUD/GameServices/Overlay/SelfUpdater/SelfUpdateUtil.cs
+++ b/Blish HUD/GameServices/Overlay/SelfUpdater/SelfUpdateUtil.cs
@@ -109,7 +109,7 @@ namespace Blish_HUD.Overlay.SelfUpdater {
             for (int i = SINGLEPROCESS_DELAY; i > 0; i--) {
                 Process[] instances = Process.GetProcessesByName(Path.GetFileNameWithoutExtension(FILE_EXE));
 
-                if (instances.Length == 1) {
+                if (instances.Length <= 1) {
                     timedout = false;
                     continue;
                 }


### PR DESCRIPTION
**Self Update Fixes:**
- The previous check was for explicitly one instance of Blish HUD, which we've found is not always what we want.

**API Service Fixes:**
- Retry attempts are now upped to 8.
- Penalty strategy has been revised to be a bit more aggressive (longer retry period in hopes that it ends up self-resolving more frequently).
- We now retry if we get the, now very frequent, 504 Gateway error.