### PR TITLE
Fixes for API handling

### DIFF
--- a/Blish HUD/GameServices/Gw2WebApiService.cs
+++ b/Blish HUD/GameServices/Gw2WebApiService.cs
@@ -111,7 +111,7 @@ namespace Blish_HUD {
         private async void PlayerCharacterOnNameChanged(object sender, ValueEventArgs<string> e) {
             if (!_characterRepository.ContainsKey(e.Value)) {
                 // We don't currently have an API key associated to this character so we double-check the characters on each key
-                await RefreshRegisteredKeys ();
+                await RefreshRegisteredKeys();
             } else {
                 await UpdateActiveApiKey();
             }
@@ -213,7 +213,20 @@ namespace Blish_HUD {
 
         protected override void Unload() { /* NOOP */ }
 
-        protected override void Update(GameTime gameTime) { /* NOOP */ }
+        private double _checkFrequency = 0;
+
+        protected override void Update(GameTime gameTime) {
+            _checkFrequency += gameTime.ElapsedGameTime.TotalMilliseconds;
+
+            if (_checkFrequency > 180000) {
+                _checkFrequency = 0;
+
+                if (string.IsNullOrEmpty(PrivilegedConnection.Connection.AccessToken)) {
+                    RefreshRegisteredKeys();
+                }
+            }
+            
+        }
 
     }
 }

--- a/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
+++ b/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
@@ -18,7 +18,13 @@ namespace Blish_HUD.Modules.Managers {
         private static readonly List<Gw2ApiManager> _apiManagers = new List<Gw2ApiManager>();
 
         internal static async Task RenewAllSubtokens() {
-            foreach (var apiManager in _apiManagers.ToArray()) {
+            Gw2ApiManager[] apiManagers;
+
+            lock(_apiManagers) {
+                apiManagers = _apiManagers.ToArray();
+            }
+
+            foreach (var apiManager in apiManagers) {
                 await apiManager.RenewSubtoken();
             }
         }
@@ -38,7 +44,9 @@ namespace Blish_HUD.Modules.Managers {
         public List<TokenPermission> Permissions => _permissions.ToList();
 
         private Gw2ApiManager(IEnumerable<TokenPermission> permissions, ManagedConnection moduleConnection) {
-            _apiManagers.Add(this);
+            lock (_apiManagers) {
+                _apiManagers.Add(this);
+            }
 
             _permissions       = permissions.ToHashSet();
             _activePermissions = new HashSet<TokenPermission>();

--- a/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
+++ b/Blish HUD/GameServices/Modules/Managers/Gw2ApiManager.cs
@@ -18,7 +18,7 @@ namespace Blish_HUD.Modules.Managers {
         private static readonly List<Gw2ApiManager> _apiManagers = new List<Gw2ApiManager>();
 
         internal static async Task RenewAllSubtokens() {
-            foreach (var apiManager in _apiManagers) {
+            foreach (var apiManager in _apiManagers.ToArray()) {
                 await apiManager.RenewSubtoken();
             }
         }


### PR DESCRIPTION
- Automatically check for a matching token on an interval if no matching token is found.
- Ensure registered managers can't change while we are renewing tokens (is more likely to happen with the API is going super slow).