### PR TITLE
Delete module folders on clearing settings

### DIFF
--- a/Blish HUD/GameServices/Modules/UI/Presenters/ManageModulePresenter.cs
+++ b/Blish HUD/GameServices/Modules/UI/Presenters/ManageModulePresenter.cs
@@ -110,7 +110,15 @@ namespace Blish_HUD.Modules.UI.Presenters {
                                                  ? Strings.GameServices.ModulesService.ModuleOption_ClearSettings_DescriptionEnabled
                                                  : Strings.GameServices.ModulesService.ModuleOption_ClearSettings_DescriptionDisabled;
 
-            clearSettings.Click += delegate { this.Model.State.Settings = null; };
+            clearSettings.Click += delegate { 
+                this.Model.State.Settings = null;
+                foreach (var directoryName in this.Model.Manifest.Directories) {
+                    var dirPath = Path.Combine(DirectoryUtil.BasePath, directoryName);
+                    if (Directory.Exists(dirPath)) {
+                        Directory.Delete(dirPath, true);
+                    }
+                }
+            };
 
             return clearSettings;
         }


### PR DESCRIPTION
This PR aims to clear all files of modules that currently remain when deleting the module settings.

Some modules use external json files to save some states.
These states currently do not get deleted when clicking "Delete module settings" sometimes causing problems.

This PR will break module settings from certain developers choosing to use bundled folders:
![image](https://user-images.githubusercontent.com/41393569/227783848-f7f76757-908f-4c9f-a62a-ff8e34734c5a.png)
