### PR TITLE
More minor fixes.

### DIFF
--- a/Blish HUD/Controls/FormattedLabel.cs
+++ b/Blish HUD/Controls/FormattedLabel.cs
@@ -264,6 +264,8 @@ namespace Blish_HUD.Controls {
 
         protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
             if (finishedInitialization) {
+                float absoluteOpacity = this.AbsoluteOpacity();
+
                 foreach (var rectangle in _rectangles) {
                     var destinationRectangle = rectangle.Rectangle.Rectangle.ToBounds(AbsoluteBounds);
                     var textColor = rectangle.Text.TextColor;
@@ -273,18 +275,18 @@ namespace Blish_HUD.Controls {
                     }
 
                     if (rectangle.ToDraw is string stringText) {
-                        spriteBatch.DrawString(rectangle.Text.Font, stringText, destinationRectangle.Location.ToVector2(), textColor);
+                        spriteBatch.DrawString(rectangle.Text.Font, stringText, destinationRectangle.Location.ToVector2(), textColor * absoluteOpacity);
                     } else if (rectangle.ToDraw is AsyncTexture2D texture) {
-                        spriteBatch.Draw(texture, destinationRectangle, Color.White);
+                        spriteBatch.Draw(texture, destinationRectangle, Color.White * absoluteOpacity);
                     }
 
                     if (rectangle.Text.IsUnderlined) {
-                        spriteBatch.DrawLine(new Vector2(destinationRectangle.X, destinationRectangle.Y + destinationRectangle.Height), new Vector2(destinationRectangle.X + destinationRectangle.Width, destinationRectangle.Y + destinationRectangle.Height), textColor, thickness: 2);
+                        spriteBatch.DrawLine(new Vector2(destinationRectangle.X, destinationRectangle.Y + destinationRectangle.Height), new Vector2(destinationRectangle.X + destinationRectangle.Width, destinationRectangle.Y + destinationRectangle.Height), textColor * absoluteOpacity, thickness: 2);
                     }
 
                     if (rectangle.Text.IsStrikeThrough) {
                         // TODO: Still seemed not centered
-                        spriteBatch.DrawLine(new Vector2(destinationRectangle.X, destinationRectangle.Y + (destinationRectangle.Height / 2)), new Vector2(destinationRectangle.X + destinationRectangle.Width, destinationRectangle.Y + (destinationRectangle.Height / 2)), textColor, thickness: 2);
+                        spriteBatch.DrawLine(new Vector2(destinationRectangle.X, destinationRectangle.Y + (destinationRectangle.Height / 2)), new Vector2(destinationRectangle.X + destinationRectangle.Width, destinationRectangle.Y + (destinationRectangle.Height / 2)), textColor * absoluteOpacity, thickness: 2);
                     }
                 }
             }

--- a/Blish HUD/GameServices/GameIntegration/WinFormsIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/WinFormsIntegration.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -117,7 +118,11 @@ namespace Blish_HUD.GameIntegration {
             }
 
             if (_service.Gw2Instance.IsSteamVersion) {
-                Process.Start("steam://run/1284210//" + string.Join(" ", args));
+                try {
+                    Process.Start("steam://run/1284210//" + string.Join(" ", args));
+                } catch (Exception ex) {
+                    Logger.Warn(ex, "Failed to launch Guild Wars 2 via Steam.");
+                }
                 return;
             }
 
@@ -131,7 +136,11 @@ namespace Blish_HUD.GameIntegration {
 
                 Logger.Info("Blish HUD starting Guild Wars 2 with args '{gw2Args}'", string.Join(" ", args));
 
-                gw2Proc.Start();
+                try {
+                    gw2Proc.Start();
+                } catch (Exception ex) {
+                    Logger.Warn(ex, "Failed to launch Guild Wars 2.");
+                }
             } else {
                 Logger.Warn("Blish HUD failed to launch Guild Wars 2.  The path we have is null or does not exist.  Try again after the game has been successfully detected by Blish HUD.");
             }

--- a/Blish HUD/_Extensions/SpriteBatchExtensions.cs
+++ b/Blish HUD/_Extensions/SpriteBatchExtensions.cs
@@ -193,14 +193,16 @@ namespace Blish_HUD {
             float absoluteOpacity = ctrl.AbsoluteOpacity();
 
             if (stroke) {
-                spriteBatch.DrawString(font, text, textPos.OffsetBy(0,               -strokeDistance), Color.Black * absoluteOpacity);
-                spriteBatch.DrawString(font, text, textPos.OffsetBy(strokeDistance,  -strokeDistance), Color.Black * absoluteOpacity);
-                spriteBatch.DrawString(font, text, textPos.OffsetBy(strokeDistance,  0),               Color.Black * absoluteOpacity);
-                spriteBatch.DrawString(font, text, textPos.OffsetBy(strokeDistance,  strokeDistance),  Color.Black * absoluteOpacity);
-                spriteBatch.DrawString(font, text, textPos.OffsetBy(0,               strokeDistance),  Color.Black * absoluteOpacity);
-                spriteBatch.DrawString(font, text, textPos.OffsetBy(-strokeDistance, strokeDistance),  Color.Black * absoluteOpacity);
-                spriteBatch.DrawString(font, text, textPos.OffsetBy(-strokeDistance, 0),               Color.Black * absoluteOpacity);
-                spriteBatch.DrawString(font, text, textPos.OffsetBy(-strokeDistance, -strokeDistance), Color.Black * absoluteOpacity);
+                var strokePreMultiplied = Color.Black * absoluteOpacity;
+
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(0,               -strokeDistance), strokePreMultiplied);
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(strokeDistance,  -strokeDistance), strokePreMultiplied);
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(strokeDistance,  0),               strokePreMultiplied);
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(strokeDistance,  strokeDistance),  strokePreMultiplied);
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(0,               strokeDistance),  strokePreMultiplied);
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(-strokeDistance, strokeDistance),  strokePreMultiplied);
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(-strokeDistance, 0),               strokePreMultiplied);
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(-strokeDistance, -strokeDistance), strokePreMultiplied);
             }
 
             spriteBatch.DrawString(font, text, textPos, color * absoluteOpacity);


### PR DESCRIPTION
The `OnCtrl` suffixed extension methods for spritebatch are what multiply the controls opacity with the final draw.  The `FormattedLabel` control wasn't using these methods to draw, so it was ignoring the control opacity.  Especially noticeable while fading in or out.  This has been corrected.

Also fixed an issue where Blish HUD will crash if Guild Wars 2 fails to start.  Found a user experiencing this because they managed to rename their exe by mistake and left an empty file in its place.