### PR TITLE
Fixed AutoSizeWidth in FormattedLabel

### DIFF
--- a/Blish HUD/Controls/FormattedLabel.cs
+++ b/Blish HUD/Controls/FormattedLabel.cs
@@ -66,7 +66,7 @@ namespace Blish_HUD.Controls {
 
         private void InitializeRectangles() {
             // No need to initialize anything if there is no space
-            if (Width == 0) {
+            if (Width == 0 && !_autoSizeWidth) {
                 return;
             }
 


### PR DESCRIPTION
This fixes the problem that AutoSizeWidth creates a 0 size control.
AutoSizeWidth and AutoSizeHeight will work now as expected.