### PR TITLE
thread safety changes for tweener class

### DIFF
--- a/Blish HUD/Library/Glide/MemberLerper.cs
+++ b/Blish HUD/Library/Glide/MemberLerper.cs
@@ -1,24 +1,21 @@
-﻿using System;
+﻿namespace Glide {
+    using System;
 
-namespace Glide
-{
-	public abstract class MemberLerper
-	{
-		[Flags]
-		public enum Behavior
-		{
-			None = 0,
-			Reflect = 1,
-			Rotation = 2,
-			RotationRadians = 4,
-			RotationDegrees = 8,
-			Round = 16
-		}
-		
-		protected const float DEG = 180f / (float) Math.PI;
-		protected const float RAD = (float) Math.PI / 180f;
-		
-		public abstract void Initialize(Object fromValue, Object toValue, Behavior behavior);
-		public abstract object Interpolate(float t, object currentValue, Behavior behavior);
-	}
+    public abstract class MemberLerper {
+        [Flags]
+        public enum Behavior {
+            None = 0,
+            Reflect = 1,
+            Rotation = 2,
+            RotationRadians = 4,
+            RotationDegrees = 8,
+            Round = 16
+        }
+
+        protected const float DEG = 180f / (float)Math.PI;
+        protected const float RAD = (float)Math.PI / 180f;
+
+        public abstract void Initialize(Object fromValue, Object toValue, Behavior behavior);
+        public abstract object Interpolate(float t, object currentValue, Behavior behavior);
+    }
 }

--- a/Blish HUD/Library/Glide/Tween.cs
+++ b/Blish HUD/Library/Glide/Tween.cs
@@ -1,88 +1,80 @@
-using System;
-using System.Collections.Generic;
+namespace Glide {
+    using System;
+    using System.Collections.Generic;
 
-namespace Glide
-{
-	public partial class Tween
-	{
-		[Flags]
-		public enum RotationUnit
-		{
-			Degrees,
-			Radians
-		}
+    public partial class Tween {
+        [Flags]
+        public enum RotationUnit {
+            Degrees,
+            Radians
+        }
 
-#region Callbacks
-		private Func<float, float> ease;
+        #region Callbacks
+        private Func<float, float> ease;
         private Action begin, update, complete, repeat;
-#endregion
+        #endregion
 
-#region Timing
-		public bool Paused { get; private set; }
+        #region Timing
+        public bool Paused { get; private set; }
         private float Delay, repeatDelay;
         private float Duration;
 
         private float Time, time;
-#endregion
-		
-		private bool initialized, running;
+        #endregion
+
+        private bool initialized, running;
         private int repeatCount;
         private MemberLerper.Behavior behavior;
-        
+
         private List<MemberAccessor> vars;
         private List<MemberLerper> lerpers;
         private List<object> start, end;
         private Dictionary<string, int> varHash;
-        private TweenerImpl Parent;
         private IRemoveTweens Remover;
-        
-		/// <summary>
-		/// The time remaining before the tween ends or repeats.
-		/// </summary>
+        /// <summary>
+        /// The time remaining before the tween ends or repeats.
+        /// </summary>
         public float TimeRemaining { get { return Duration - Time; } }
-        
+
         /// <summary>
         /// A value between 0 and 1, where 0 means the tween has not been started and 1 means that it has completed.
         /// </summary>
         public float Completion { get { return Duration > 0 ? Math.Min(Math.Max(Time / Duration, 0), 1) : 1; } }
-        
+
         /// <summary>
         /// Whether the tween is currently looping.
         /// </summary>
         public bool Looping { get { return repeatCount != 0; } }
-        
+
         /// <summary>
         /// The object this tween targets. Will be null if the tween represents a timer.
         /// </summary>
-        public object Target { get; private set; }
-		
-		private Tween(object target, float duration, float delay, TweenerImpl parent)
-		{
-            this.Target = target;
+        public object Target { get; }
+
+        private Tween(object target, float duration, float delay, IRemoveTweens remover) {
+            Target = target;
             Duration = duration;
             Delay = delay;
-            Parent = parent;
-            Remover = parent;
-            
-			varHash = new Dictionary<string, int>();
-			vars = new List<MemberAccessor>();
-			lerpers = new List<MemberLerper>();
-			start = new List<object>();
-			end = new List<object>();
-			behavior = MemberLerper.Behavior.None;
-		}
+            Remover = remover;
 
-		private void AddLerp(MemberLerper lerper, MemberAccessor info, object from, object to)
-		{
-			varHash.Add(info.MemberName, vars.Count);
-			vars.Add(info);
-			
-			start.Add(from);
-			end.Add(to);
-			
-			lerpers.Add(lerper);
-		}
-		
+            varHash = new Dictionary<string, int>();
+            vars = new List<MemberAccessor>();
+            lerpers = new List<MemberLerper>();
+            start = new List<object>();
+            end = new List<object>();
+            behavior = MemberLerper.Behavior.None;
+        }
+
+        private void AddLerp(MemberLerper lerper, MemberAccessor info, object from, object to) {
+            varHash.Add(info.MemberName, vars.Count);
+            vars.Add(info);
+
+            start.Add(from);
+            end.Add(to);
+
+            lerpers.Add(lerper);
+        }
+
         private void Update(float elapsed) {
             int i = 0;
             bool doReverse = false;
@@ -147,9 +139,11 @@ namespace Glide
             }
 
             i = vars.Count;
-            while (i-- > 0) {
-                if (vars[i] != null) {
-                    vars[i].Value = lerperSet[i].Interpolate(t, vars[i].Value, behavior);
+            if (this.Target is object target) {
+                while (i-- > 0) {
+                    if (vars[i] != null) {
+                        vars[i].SetValue(target, lerperSet[i].Interpolate(t, vars[i].GetValue(target), behavior));
+                    }
                 }
             }
 
@@ -166,235 +160,217 @@ namespace Glide
                 complete();
             }
         }
-		
-#region Behavior
-		/// <summary>
-		/// Apply target values to a starting point before tweening.
-		/// </summary>
-		/// <param name="values">The values to apply, in an anonymous type ( new { prop1 = 100, prop2 = 0} ).</param>
-		/// <returns>A reference to this.</returns>
-		public Tween From(object values)
-		{
-			var props = values.GetType().GetProperties();
-			for (int i = 0; i < props.Length; ++i)
-			{
-				var property = props[i];
-				var propValue = property.GetValue(values, null);
-				
-				int index = -1;
-				if (varHash.TryGetValue(property.Name, out index))
-				{
-					//	if we're already tweening this value, adjust the range
-					start[index] = propValue;
-				}
-				
-				//	if we aren't tweening this value, just set it
-				var info = new MemberAccessor(this.Target, property.Name, true);
-				info.Value = propValue;
-			}
-			
-			return this;
-		}
-		
-		/// <summary>
-		/// Set the easing function.
-		/// </summary>
-		/// <param name="ease">The Easer to use.</param>
-		/// <returns>A reference to this.</returns>
-		public Tween Ease(Func<float, float> ease)
-		{
-			this.ease = ease;
-			return this;
-		}
-		
-		/// <summary>
-		/// Set a function to call when the tween begins (useful when using delays). Can be called multiple times for compound callbacks.
-		/// </summary>
-		/// <param name="callback">The function that will be called when the tween starts, after the delay.</param>
-		/// <returns>A reference to this.</returns>
-		public Tween OnBegin(Action callback)
-		{
-			if (begin == null) begin = callback;
-			else begin += callback;
-			return this;
-		}
-		
-		/// <summary>
-		/// Set a function to call when the tween finishes. Can be called multiple times for compound callbacks.
-		/// If the tween repeats infinitely, this will be called each time; otherwise it will only run when the tween is finished repeating.
-		/// </summary>
-		/// <param name="callback">The function that will be called on tween completion.</param>
-		/// <returns>A reference to this.</returns>
-		public Tween OnComplete(Action callback)
-		{
-			if (complete == null) complete = callback;
-			else complete += callback;
-			return this;
-		}
+
+        #region Behavior
+        /// <summary>
+        /// Apply target values to a starting point before tweening.
+        /// </summary>
+        /// <param name="values">The values to apply, in an anonymous type ( new { prop1 = 100, prop2 = 0} ).</param>
+        /// <returns>A reference to this.</returns>
+        public Tween From(object values) {
+
+            if (this.Target is object target) {
+                var props = values.GetType().GetProperties();
+                for (int i = 0; i < props.Length; ++i) {
+                    var property = props[i];
+                    var propValue = property.GetValue(values, null);
+
+                    int index = -1;
+                    if (varHash.TryGetValue(property.Name, out index)) {
+                        //	if we're already tweening this value, adjust the range
+                        start[index] = propValue;
+                    }
+
+                    //	if we aren't tweening this value, just set it
+                    var info = new MemberAccessor(target, property.Name, true);
+                    info.SetValue(target, propValue);
+                }
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Set the easing function.
+        /// </summary>
+        /// <param name="ease">The Easer to use.</param>
+        /// <returns>A reference to this.</returns>
+        public Tween Ease(Func<float, float> ease) {
+            this.ease = ease;
+            return this;
+        }
+
+        /// <summary>
+        /// Set a function to call when the tween begins (useful when using delays). Can be called multiple times for compound callbacks.
+        /// </summary>
+        /// <param name="callback">The function that will be called when the tween starts, after the delay.</param>
+        /// <returns>A reference to this.</returns>
+        public Tween OnBegin(Action callback) {
+            if (begin == null) begin = callback;
+            else begin += callback;
+            return this;
+        }
+
+        /// <summary>
+        /// Set a function to call when the tween finishes. Can be called multiple times for compound callbacks.
+        /// If the tween repeats infinitely, this will be called each time; otherwise it will only run when the tween is finished repeating.
+        /// </summary>
+        /// <param name="callback">The function that will be called on tween completion.</param>
+        /// <returns>A reference to this.</returns>
+        public Tween OnComplete(Action callback) {
+            if (complete == null) complete = callback;
+            else complete += callback;
+            return this;
+        }
 
         public Tween OnRepeat(Action callback) {
             if (repeat == null) repeat = callback;
             else repeat += callback;
             return this;
         }
-		
-		/// <summary>
-		/// Set a function to call as the tween updates. Can be called multiple times for compound callbacks.
-		/// </summary>
-		/// <param name="callback">The function to use.</param>
-		/// <returns>A reference to this.</returns>
-		public Tween OnUpdate(Action callback)
-		{
-			if (update == null) update = callback;
-			else update += callback;
-			return this;
-		}
-		
-		/// <summary>
-		/// Enable repeating.
-		/// </summary>
-		/// <param name="times">Number of times to repeat. Leave blank or pass a negative number to repeat infinitely.</param>
-		/// <returns>A reference to this.</returns>
-		public Tween Repeat(int times = -1)
-		{
-			repeatCount = times;
-			return this;
-		}
-		
-		/// <summary>
-		/// Set a delay for when the tween repeats.
-		/// </summary>
-		/// <param name="delay">How long to wait before repeating.</param>
-		/// <returns>A reference to this.</returns>
-		public Tween RepeatDelay(float delay)
-		{
-			repeatDelay = delay;
-			return this;
-		}
-		
-		/// <summary>
-		/// Sets the tween to reverse every other time it repeats. Repeating must be enabled for this to have any effect.
-		/// </summary>
-		/// <returns>A reference to this.</returns>
-		public Tween Reflect()
-		{
-			behavior |= MemberLerper.Behavior.Reflect;
-			return this;
-		}
-		
-		/// <summary>
-		/// Swaps the start and end values of the tween.
-		/// </summary>
-		/// <returns>A reference to this.</returns>
-		public Tween Reverse()
-		{	
-			int i = vars.Count;			
-			while (i --> 0)
-			{
-				var s = start[i];
-				var e = end[i];
-				
-				//	Set start to end and end to start
-				start[i] = e;
-				end[i] = s;
-				
-				lerpers[i].Initialize(e, s, behavior);
-			}
-			
-			return this;
-		}
-		
-		/// <summary>
-		/// Whether this tween handles rotation.
-		/// </summary>
-		/// <returns>A reference to this.</returns>
-		public Tween Rotation(RotationUnit unit = RotationUnit.Degrees)
-		{
-			behavior |= MemberLerper.Behavior.Rotation;
-			behavior |= (unit == RotationUnit.Degrees) ? MemberLerper.Behavior.RotationDegrees : MemberLerper.Behavior.RotationRadians;
 
-			return this;
-		}
-		
-		/// <summary>
-		/// Whether tweened values should be rounded to integer values.
-		/// </summary>
-		/// <returns>A reference to this.</returns>
-		public Tween Round()
-		{
-			behavior |= MemberLerper.Behavior.Round;
-			return this;
-		}
-#endregion
-				
-#region Control
-		/// <summary>
-		/// Cancel tweening given properties.
-		/// </summary>
-		/// <param name="properties"></param>
-		public void Cancel(params string[] properties)
-		{
-			var canceled = 0;
-			for (int i = 0; i < properties.Length; ++i)
-			{
-				var index = 0;
-				if (!varHash.TryGetValue(properties[i], out index))
-					continue;
-				
-				varHash.Remove(properties[i]);
-				vars[index] = null;
-				lerpers[index] = null;
-				start[index] = null;
-				end[index] = null;
-				
-				canceled++;
-			}
-			
-			if (canceled == vars.Count)
-				Cancel();
-		}
-		
-		/// <summary>
-		/// Remove tweens from the tweener without calling their complete functions.
-		/// </summary>
-		public void Cancel()
-		{
+        /// <summary>
+        /// Set a function to call as the tween updates. Can be called multiple times for compound callbacks.
+        /// </summary>
+        /// <param name="callback">The function to use.</param>
+        /// <returns>A reference to this.</returns>
+        public Tween OnUpdate(Action callback) {
+            if (update == null) update = callback;
+            else update += callback;
+            return this;
+        }
+
+        /// <summary>
+        /// Enable repeating.
+        /// </summary>
+        /// <param name="times">Number of times to repeat. Leave blank or pass a negative number to repeat infinitely.</param>
+        /// <returns>A reference to this.</returns>
+        public Tween Repeat(int times = -1) {
+            repeatCount = times;
+            return this;
+        }
+
+        /// <summary>
+        /// Set a delay for when the tween repeats.
+        /// </summary>
+        /// <param name="delay">How long to wait before repeating.</param>
+        /// <returns>A reference to this.</returns>
+        public Tween RepeatDelay(float delay) {
+            repeatDelay = delay;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the tween to reverse every other time it repeats. Repeating must be enabled for this to have any effect.
+        /// </summary>
+        /// <returns>A reference to this.</returns>
+        public Tween Reflect() {
+            behavior |= MemberLerper.Behavior.Reflect;
+            return this;
+        }
+
+        /// <summary>
+        /// Swaps the start and end values of the tween.
+        /// </summary>
+        /// <returns>A reference to this.</returns>
+        public Tween Reverse() {
+            int i = vars.Count;
+            while (i-- > 0) {
+                var s = start[i];
+                var e = end[i];
+
+                //	Set start to end and end to start
+                start[i] = e;
+                end[i] = s;
+
+                lerpers[i].Initialize(e, s, behavior);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Whether this tween handles rotation.
+        /// </summary>
+        /// <returns>A reference to this.</returns>
+        public Tween Rotation(RotationUnit unit = RotationUnit.Degrees) {
+            behavior |= MemberLerper.Behavior.Rotation;
+            behavior |= (unit == RotationUnit.Degrees) ? MemberLerper.Behavior.RotationDegrees : MemberLerper.Behavior.RotationRadians;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Whether tweened values should be rounded to integer values.
+        /// </summary>
+        /// <returns>A reference to this.</returns>
+        public Tween Round() {
+            behavior |= MemberLerper.Behavior.Round;
+            return this;
+        }
+        #endregion
+
+        #region Control
+        /// <summary>
+        /// Cancel tweening given properties.
+        /// </summary>
+        /// <param name="properties"></param>
+        public void Cancel(params string[] properties) {
+            var canceled = 0;
+            for (int i = 0; i < properties.Length; ++i) {
+                var index = 0;
+                if (!varHash.TryGetValue(properties[i], out index))
+                    continue;
+
+                varHash.Remove(properties[i]);
+                vars[index] = null;
+                lerpers[index] = null;
+                start[index] = null;
+                end[index] = null;
+
+                canceled++;
+            }
+
+            if (canceled == vars.Count)
+                Cancel();
+        }
+
+        /// <summary>
+        /// Remove tweens from the tweener without calling their complete functions.
+        /// </summary>
+        public void Cancel() {
             Remover.Remove(this);
-		}
-		
-		/// <summary>
-		/// Assign tweens their final value and remove them from the tweener.
-		/// </summary>
-		public void CancelAndComplete()
-		{
-			time = Time = Duration;
-			update = null;
+        }
+
+        /// <summary>
+        /// Assign tweens their final value and remove them from the tweener.
+        /// </summary>
+        public void CancelAndComplete() {
+            time = Time = Duration;
+            update = null;
             Remover.Remove(this);
-		}
-		
-		/// <summary>
-		/// Set tweens to pause. They won't update and their delays won't tick down.
-		/// </summary>
-		public void Pause()
-		{
+        }
+
+        /// <summary>
+        /// Set tweens to pause. They won't update and their delays won't tick down.
+        /// </summary>
+        public void Pause() {
             this.Paused = true;
-		}
-		
-		/// <summary>
-		/// Toggle tweens' paused value.
-		/// </summary>
-		public void PauseToggle()
-		{
+        }
+
+        /// <summary>
+        /// Toggle tweens' paused value.
+        /// </summary>
+        public void PauseToggle() {
             this.Paused = !this.Paused;
-		}
-		
-		/// <summary>
-		/// Resumes tweens from a paused state.
-		/// </summary>
-		public void Resume()
-		{
+        }
+
+        /// <summary>
+        /// Resumes tweens from a paused state.
+        /// </summary>
+        public void Resume() {
             this.Paused = false;
-		}
-#endregion
-	}
+        }
+        #endregion
+    }
 }

--- a/Blish HUD/Library/Glide/Tweener.cs
+++ b/Blish HUD/Library/Glide/Tweener.cs
@@ -1,393 +1,321 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
+﻿namespace Glide {
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
 
-namespace Glide
-{
-	public class Tweener : Tween.TweenerImpl {};
-	
-	public partial class Tween
-	{
-		private interface IRemoveTweens	//	lol get it
-		{
-			void Remove(Tween t);
-		}
-		
-		public class TweenerImpl : IRemoveTweens
-	    {
-	        static TweenerImpl()
-	        {
-	            registeredLerpers = new Dictionary<Type, ConstructorInfo>();
-				var numericTypes = new Type[] {
-					typeof(Int16),
-					typeof(Int32),
-					typeof(Int64),
-					typeof(UInt16),
-					typeof(UInt32),
-					typeof(UInt64),
-					typeof(Single),
-					typeof(Double),
+    public class Tweener : Tween.TweenerImpl { };
+
+    public partial class Tween {
+        private interface IRemoveTweens //	lol get it
+        {
+            void Remove(Tween t);
+        }
+
+        public class TweenerImpl : IRemoveTweens {
+            static TweenerImpl() {
+                registeredLerpers = new Dictionary<Type, ConstructorInfo>();
+                var numericTypes = new Type[] {
+                    typeof(Int16),
+                    typeof(Int32),
+                    typeof(Int64),
+                    typeof(UInt16),
+                    typeof(UInt32),
+                    typeof(UInt64),
+                    typeof(Single),
+                    typeof(Double),
                     typeof(byte)
-				};
-	            
-	            for (int i = 0; i < numericTypes.Length; i++)
-	            	SetLerper<NumericLerper>(numericTypes[i]);
-	        }
-	        
-	        /// <summary>
-	        /// Associate a Lerper class with a property type.
-	        /// </summary>
-	        /// <typeparam name="TLerper">The Lerper class to use for properties of the given type.</typeparam>
-	        /// <param name="propertyType">The type of the property to associate the given Lerper with.</param>
-	        public static void SetLerper<TLerper>(Type propertyType) where TLerper : MemberLerper, new()
-			{
-	        	SetLerper(typeof(TLerper), propertyType);
-			}
-	        
-	        /// <summary>
-	        /// Associate a Lerper type with a property type.
-	        /// </summary>
-	        /// <param name="lerperType">The type of the Lerper to use for properties of the given type.</param>
-	        /// <param name="propertyType">The type of the property to associate the given Lerper with.</param>
-	        public static void SetLerper(Type lerperType, Type propertyType)
-	        {
-	        	registeredLerpers[propertyType] = lerperType.GetConstructor(Type.EmptyTypes);
-	        }
-	
-	        protected TweenerImpl()
-	        {
-	            tweens = new Dictionary<object, List<Tween>>();
-	            toRemove = new List<Tween>();
-	            toAdd = new List<Tween>();
-	            allTweens = new List<Tween>();
-	        }
-	        
-	        private static Dictionary<Type, ConstructorInfo> registeredLerpers;
-	        private Dictionary<object, List<Tween>> tweens;
-	        private List<Tween> toRemove, toAdd, allTweens;
-	
-	        /// <summary>
-	        /// <para>Tweens a set of properties on an object.</para>
-	        /// <para>To tween instance properties/fields, pass the object.</para>
-	        /// <para>To tween static properties/fields, pass the type of the object, using typeof(ObjectType) or object.GetType().</para>
-	        /// </summary>
-	        /// <param name="target">The object or type to tween.</param>
-	        /// <param name="values">The values to tween to, in an anonymous type ( new { prop1 = 100, prop2 = 0} ).</param>
-	        /// <param name="duration">Duration of the tween in seconds.</param>
-	        /// <param name="delay">Delay before the tween starts, in seconds.</param>
-	        /// <param name="overwrite">Whether pre-existing tweens should be overwritten if this tween involves the same properties.</param>
-	        /// <returns>The tween created, for setting properties on.</returns>
-	        public Tween Tween<T>(T target, object values, float duration, float delay = 0, bool overwrite = true) where T : class
-	        {
-	        	if (target == null)
-	        		throw new ArgumentNullException("target");
-	        	
-	        	//	Prevent tweening on structs if you cheat by casting target as Object
-	        	var targetType = target.GetType();
-	        	if (targetType.IsValueType)
-	        		throw new Exception("Target of tween cannot be a struct!");
-	        	
-	            var tween = new Tween(target, duration, delay, this);
-	            toAdd.Add(tween);
-	
-	            if (values == null) // valid in case of manual timer
-	                return tween;
-	            
-	            var props = values.GetType().GetProperties();
-	            for (int i = 0; i < props.Length; ++i)
-	            {
-	            	List<Tween> library = null;
-	            	if (overwrite && tweens.TryGetValue(target, out library))
-	            	{
-	            		for (int j = 0; j < library.Count; j++)
-	            			library[j].Cancel(props[i].Name);
-	            	}
-	            	
-	            	var property = props[i];
-	                var info = new MemberAccessor(target, property.Name);
-	                var to = new MemberAccessor(values, property.Name, false);
-	                var lerper = CreateLerper(info.MemberType);
-	                
-	                tween.AddLerp(lerper, info, info.Value, to.Value);
-	            }
-	
-	        	AddAndRemove();
-	            return tween;
-	        }
-	        
-	        /// <summary>
-	        /// Starts a simple timer for setting up callback scheduling.
-	        /// </summary>
-	        /// <param name="duration">How long the timer will run for, in seconds.</param>
-	        /// <param name="delay">How long to wait before starting the timer, in seconds.</param>
-	        /// <returns>The tween created, for setting properties.</returns>
-	        public Tween Timer(float duration, float delay = 0)
-	        {
-	            var tween = new Tween(null, duration, delay, this);
-	            AddAndRemove();
-	        	toAdd.Add(tween);
-	            return tween;
-	        }
-	        
-	        /// <summary>
-	        /// Remove tweens from the tweener without calling their complete functions.
-	        /// </summary>
-	        public void Cancel()
-	        {
-	        	toRemove.AddRange(allTweens);
-	        }
-	
-	        /// <summary>
-	        /// Assign tweens their final value and remove them from the tweener.
-	        /// </summary>
-	        public void CancelAndComplete()
-	        {
-	        	for (int i = 0; i < allTweens.Count; ++i)
-	        		allTweens[i].CancelAndComplete();
-	        }
-	
-	        /// <summary>
-	        /// Set tweens to pause. They won't update and their delays won't tick down.
-	        /// </summary>
-	        public void Pause()
-	        {
-	        	for (int i = 0; i < allTweens.Count; ++i)
-	        	{
-	        		var tween = allTweens[i];
-	        		tween.Pause();
-	        	}
-	        }
-	
-	        /// <summary>
-	        /// Toggle tweens' paused value.
-	        /// </summary>
-	        public void PauseToggle()
-	        {
-	        	for (int i = 0; i < allTweens.Count; ++i)
-	        	{
-	        		var tween = allTweens[i];
-	        		tween.PauseToggle();
-	        	}
-	        }
-	
-	        /// <summary>
-	        /// Resumes tweens from a paused state.
-	        /// </summary>
-	        public void Resume()
-	        {
-	        	for (int i = 0; i < allTweens.Count; ++i)
-	        	{
-	        		var tween = allTweens[i];
-	        		tween.Resume();
-	        	}
-	        }
-	
-	        /// <summary>
-	        /// Updates the tweener and all objects it contains.
-	        /// </summary>
-	        /// <param name="secondsElapsed">Seconds elapsed since last update.</param>
-	        public void Update(float secondsElapsed) {
-                var tweens = allTweens.ToArray();
+                };
 
-	        	for (int i = 0; i < tweens.Length; ++i) {
-                    tweens[i]?.Update(secondsElapsed);
+                for (int i = 0; i < numericTypes.Length; i++) {
+                    SetLerper<NumericLerper>(numericTypes[i]);
                 }
-	
-	            AddAndRemove();
-	        }
-	
-			private MemberLerper CreateLerper(Type propertyType)
-			{
-				ConstructorInfo lerper = null;
-				if (!registeredLerpers.TryGetValue(propertyType, out lerper))
-					throw new Exception(string.Format("No Lerper found for type {0}.", propertyType.FullName));
-				
-				return (MemberLerper) lerper.Invoke(null);
-			}
-	
-	        void IRemoveTweens.Remove(Tween tween)
-	        {
-	            toRemove.Add(tween);
-	        }
-	
-	        private void AddAndRemove()
-	        {
-	            for (int i = 0; i < toAdd.Count; ++i)
-	            {
-	            	var tween = toAdd[i];
-	                allTweens.Add(tween);
-	            	if (tween.Target == null) continue;	//	don't sort timers by target
-	            	
-	            	List<Tween> list = null;
-	            	if (!tweens.TryGetValue(tween.Target, out list))
-	            		tweens[tween.Target] = list = new List<Tween>();
-	
-	                list.Add(tween);
-	            }
-	
-	            for (int i = 0; i < toRemove.Count; ++i)
-	            {
-	            	var tween = toRemove[i];
-	                allTweens.Remove(tween);
-	                if (tween.Target == null) continue; // see above
-	                
-	                List<Tween> list = null;
-	                if (tweens.TryGetValue(tween.Target, out list))
-	                {
-	                    list.Remove(tween);
-	                    if (list.Count == 0)
-	                    {
-	                        tweens.Remove(tween.Target);
-	                    }
-	                }
-	                
-	                allTweens.Remove(tween);
-	            }
-	
-	            toAdd.Clear();
-	            toRemove.Clear();
-	        }
-	
-	        #region Target control
-	        /// <summary>
-	        /// Cancel all tweens with the given target.
-	        /// </summary>
-	        /// <param name="target">The object being tweened that you want to cancel.</param>
-	        public void TargetCancel(object target)
-	        {
-	            List<Tween> list;
-	            if (tweens.TryGetValue(target, out list))
-	            {
-	            	for (int i = 0; i < list.Count; ++i)
-	            		list[i]?.Cancel();
-	            }
-	        }
-	        
-	        /// <summary>
-	        /// Cancel tweening named properties on the given target.
-	        /// </summary>
-	        /// <param name="target">The object being tweened that you want to cancel properties on.</param>
-	        /// <param name="properties">The properties to cancel.</param>
-	        public void TargetCancel(object target, params string[] properties)
-	        {
-	            List<Tween> list;
-	            if (tweens.TryGetValue(target, out list))
-	            {
-	            	for (int i = 0; i < list.Count; ++i)
-	            		list[i]?.Cancel(properties);
-	            }
-	        }
-	
-	        /// <summary>
-	        /// Cancel, complete, and call complete callbacks for all tweens with the given target..
-	        /// </summary>
-	        /// <param name="target">The object being tweened that you want to cancel and complete.</param>
-	        public void TargetCancelAndComplete(object target)
-	        {
-	            List<Tween> list;
-	            if (tweens.TryGetValue(target, out list))
-	            {
-	                for (int i = 0; i < list.Count; ++i)
-	                	list[i]?.CancelAndComplete();
-	            }
-	        }
-	
-	
-	        /// <summary>
-	        /// Pause all tweens with the given target.
-	        /// </summary>
-	        /// <param name="target">The object being tweened that you want to pause.</param>
-	        public void TargetPause(object target)
-	        {
-	            List<Tween> list;
-	            if (tweens.TryGetValue(target, out list))
-	            {
-	                for (int i = 0; i < list.Count; ++i)
-	                	list[i]?.Pause();
-	            }
-	        }
-	
-	        /// <summary>
-	        /// Toggle the pause state of all tweens with the given target.
-	        /// </summary>
-	        /// <param name="target">The object being tweened that you want to toggle pause.</param>
-	        public void TargetPauseToggle(object target)
-	        {
-	            List<Tween> list;
-	            if (tweens.TryGetValue(target, out list))
-	            {
-	                for (int i = 0; i < list.Count; ++i)
-	                	list[i]?.PauseToggle();
-	            }
-	        }
-	
-	        /// <summary>
-	        /// Resume all tweens with the given target.
-	        /// </summary>
-	        /// <param name="target">The object being tweened that you want to resume.</param>
-	        public void TargetResume(object target)
-	        {
-	            List<Tween> list;
-	            if (tweens.TryGetValue(target, out list))
-	            {
-	                for (int i = 0; i < list.Count; ++i)
-	                	list[i]?.Resume();
-	            }
-	        }
-	        #endregion
-	        
-			private class NumericLerper : MemberLerper
-			{
-				float from, to, range;
-				
-				public override void Initialize(object fromValue, object toValue, Behavior behavior)
-				{
-					from = Convert.ToSingle(fromValue);
-					to = Convert.ToSingle(toValue);
-					range = to - from;
-					
-					if ((behavior & Behavior.Rotation) == Behavior.Rotation)
-					{
-						float angle = from;
-						if ((behavior & Behavior.RotationRadians) == Behavior.RotationRadians)
-							angle *= DEG;
-						
-						if (angle < 0)
-							angle = 360 + angle;
-						
-						float r = angle + range;
-						float d = r - angle;
-						float a = (float) Math.Abs(d);
-						
-						if (a >= 180) range = (360 - a) * (d > 0 ? -1 : 1);
-						else range = d;
-					}
-				}
-				
-				public override object Interpolate(float t, object current, Behavior behavior)
-				{
-					var value = from + range * t;
-					if ((behavior & Behavior.Rotation) == Behavior.Rotation)
-					{
-						if ((behavior & Behavior.RotationRadians) == Behavior.RotationRadians)
-							value *= DEG;
-						
-						value %= 360.0f;
-							
-						if (value < 0)
-							value += 360.0f;
-						
-						if ((behavior & Behavior.RotationRadians) == Behavior.RotationRadians)
-							value *= RAD;
-					}
-					
-					if ((behavior & Behavior.Round) == Behavior.Round)
-                        value = (float) Math.Round(value);
-					
-					var type = current.GetType();
-					return Convert.ChangeType(value, type);
-				}
-	        }
-	    }
-	}
+            }
+
+            /// <summary>
+            /// Associate a Lerper class with a property type.
+            /// </summary>
+            /// <typeparam name="TLerper">The Lerper class to use for properties of the given type.</typeparam>
+            /// <param name="propertyType">The type of the property to associate the given Lerper with.</param>
+            public static void SetLerper<TLerper>(Type propertyType) where TLerper : MemberLerper, new() {
+                SetLerper(typeof(TLerper), propertyType);
+            }
+
+            /// <summary>
+            /// Associate a Lerper type with a property type.
+            /// </summary>
+            /// <param name="lerperType">The type of the Lerper to use for properties of the given type.</param>
+            /// <param name="propertyType">The type of the property to associate the given Lerper with.</param>
+            public static void SetLerper(Type lerperType, Type propertyType) {
+                registeredLerpers[propertyType] = lerperType.GetConstructor(Type.EmptyTypes);
+            }
+
+            protected TweenerImpl() {
+                tweens = new ConcurrentDictionary<object, List<Tween>>();
+                toRemove = new ConcurrentQueue<Tween>();
+                toAdd = new ConcurrentQueue<Tween>();
+            }
+
+
+            private static Dictionary<Type, ConstructorInfo> registeredLerpers;
+
+            private ConcurrentDictionary<object, List<Tween>> tweens;
+            private ConcurrentQueue<Tween> toRemove;
+            private ConcurrentQueue<Tween> toAdd;
+
+            /// <summary>
+            /// <para>Tweens a set of properties on an object.</para>
+            /// <para>To tween instance properties/fields, pass the object.</para>
+            /// <para>To tween static properties/fields, pass the type of the object, using typeof(ObjectType) or object.GetType().</para>
+            /// </summary>
+            /// <param name="target">The object or type to tween.</param>
+            /// <param name="values">The values to tween to, in an anonymous type ( new { prop1 = 100, prop2 = 0} ).</param>
+            /// <param name="duration">Duration of the tween in seconds.</param>
+            /// <param name="delay">Delay before the tween starts, in seconds.</param>
+            /// <param name="overwrite">Whether pre-existing tweens should be overwritten if this tween involves the same properties.</param>
+            /// <returns>The tween created, for setting properties on.</returns>
+            public Tween Tween<T>(T target, object values, float duration, float delay = 0, bool overwrite = true) where T : class {
+                if (target == null) {
+                    throw new ArgumentNullException("target");
+                }
+
+                //	Prevent tweening on structs if you cheat by casting target as Object
+                var targetType = typeof(T);
+                if (targetType.IsValueType) {
+                    throw new Exception("Target of tween cannot be a struct!");
+                }
+
+                var tween = new Tween(target, duration, delay, this);
+                toAdd.Enqueue(tween);
+
+                if (values == null) // valid in case of manual timer
+                    return tween;
+
+                var props = values.GetType().GetProperties();
+                for (int i = 0; i < props.Length; ++i) {
+                    if (overwrite) {
+                        ForAllTweens(target, tw => tw.Cancel(props[i].Name));
+                    }
+
+                    var property = props[i];
+                    var info = new MemberAccessor(target, property.Name);
+                    var to = new MemberAccessor(values, property.Name, false);
+                    var lerper = CreateLerper(info.MemberType);
+
+                    tween.AddLerp(lerper, info, info.GetValue(target), to.GetValue(values));
+                }
+
+                AddAndRemove();
+                return tween;
+            }
+
+            /// <summary>
+            /// Starts a simple timer for setting up callback scheduling.
+            /// </summary>
+            /// <param name="duration">How long the timer will run for, in seconds.</param>
+            /// <param name="delay">How long to wait before starting the timer, in seconds.</param>
+            /// <returns>The tween created, for setting properties.</returns>
+            public Tween Timer(float duration, float delay = 0) {
+                var tween = new Tween(this, duration, delay, this);
+                toAdd.Enqueue(tween);
+                AddAndRemove();
+                return tween;
+            }
+
+            /// <summary>
+            /// Remove tweens from the tweener without calling their complete functions.
+            /// </summary>
+            public void Cancel() {
+                ForAllTweens(toRemove.Enqueue);
+            }
+
+            /// <summary>
+            /// Assign tweens their final value and remove them from the tweener.
+            /// </summary>
+            public void CancelAndComplete() {
+                ForAllTweens(tw => tw.CancelAndComplete());
+            }
+
+            /// <summary>
+            /// Set tweens to pause. They won't update and their delays won't tick down.
+            /// </summary>
+            public void Pause() {
+                ForAllTweens(tw => tw.Pause());
+            }
+
+            /// <summary>
+            /// Toggle tweens' paused value.
+            /// </summary>
+            public void PauseToggle() {
+                ForAllTweens(tw => tw.PauseToggle());
+            }
+
+            /// <summary>
+            /// Resumes tweens from a paused state.
+            /// </summary>
+            public void Resume() {
+                ForAllTweens(tw => tw.Resume());
+            }
+
+            /// <summary>
+            /// Updates the tweener and all objects it contains.
+            /// </summary>
+            /// <param name="secondsElapsed">Seconds elapsed since last update.</param>
+            public void Update(float secondsElapsed) {
+                ForAllTweens(tw => tw.Update(secondsElapsed));
+
+                AddAndRemove();
+            }
+
+            private void ForAllTweens(Action<Tween> action) {
+                foreach (object target in this.tweens.Keys) {
+                    ForAllTweens(target, action);
+                }
+            }
+
+            private void ForAllTweens(object target, Action<Tween> action) {
+                if (tweens.TryGetValue(target, out var list)) {
+                    lock (list) {
+                        foreach (Tween tween in list) {
+                            action(tween);
+                        }
+                    }
+                }
+            }
+
+            private MemberLerper CreateLerper(Type propertyType) {
+                if (!registeredLerpers.TryGetValue(propertyType, out ConstructorInfo lerper)) {
+                    throw new Exception(string.Format("No Lerper found for type {0}.", propertyType.FullName));
+                }
+
+                return (MemberLerper)lerper.Invoke(null);
+            }
+
+            void IRemoveTweens.Remove(Tween tween) {
+                toRemove.Enqueue(tween);
+            }
+
+            private void AddAndRemove() {
+                while (toAdd.TryDequeue(out Tween tween)) {
+                    List<Tween> list = tweens.GetOrAdd(tween.Target, _ => new List<Tween>(4));
+                    lock (list) {
+                        list.Add(tween);
+                    }
+                }
+
+                while (toRemove.TryDequeue(out Tween tween)) {
+                    if (tweens.TryGetValue(tween.Target, out List<Tween> list)) {
+                        lock (list) {
+                            list.Remove(tween);
+                        }
+
+                        if (!list.Any()) {
+                            tweens.TryRemove(tween.Target, out _);
+                        }
+                    }
+                }
+            }
+
+            #region Target control
+            /// <summary>
+            /// Cancel all tweens with the given target.
+            /// </summary>
+            /// <param name="target">The object being tweened that you want to cancel.</param>
+            public void TargetCancel(object target) {
+                ForAllTweens(target, tw => tw.Cancel());
+            }
+
+            /// <summary>
+            /// Cancel tweening named properties on the given target.
+            /// </summary>
+            /// <param name="target">The object being tweened that you want to cancel properties on.</param>
+            /// <param name="properties">The properties to cancel.</param>
+            public void TargetCancel(object target, params string[] properties) {
+                ForAllTweens(target, tw => tw.Cancel(properties));
+            }
+
+            /// <summary>
+            /// Cancel, complete, and call complete callbacks for all tweens with the given target..
+            /// </summary>
+            /// <param name="target">The object being tweened that you want to cancel and complete.</param>
+            public void TargetCancelAndComplete(object target) {
+                ForAllTweens(target, tw => tw.CancelAndComplete());
+            }
+
+
+            /// <summary>
+            /// Pause all tweens with the given target.
+            /// </summary>
+            /// <param name="target">The object being tweened that you want to pause.</param>
+            public void TargetPause(object target) {
+                ForAllTweens(target, tw => tw.Pause());
+            }
+
+            /// <summary>
+            /// Toggle the pause state of all tweens with the given target.
+            /// </summary>
+            /// <param name="target">The object being tweened that you want to toggle pause.</param>
+            public void TargetPauseToggle(object target) {
+                ForAllTweens(target, tw => tw.PauseToggle());
+            }
+
+            /// <summary>
+            /// Resume all tweens with the given target.
+            /// </summary>
+            /// <param name="target">The object being tweened that you want to resume.</param>
+            public void TargetResume(object target) {
+                ForAllTweens(target, tw => tw.Resume());
+            }
+            #endregion
+
+            private class NumericLerper : MemberLerper {
+                float from, to, range;
+
+                public override void Initialize(object fromValue, object toValue, Behavior behavior) {
+                    from = Convert.ToSingle(fromValue);
+                    to = Convert.ToSingle(toValue);
+                    range = to - from;
+
+                    if ((behavior & Behavior.Rotation) == Behavior.Rotation) {
+                        float angle = from;
+                        if ((behavior & Behavior.RotationRadians) == Behavior.RotationRadians)
+                            angle *= DEG;
+
+                        if (angle < 0)
+                            angle = 360 + angle;
+
+                        float r = angle + range;
+                        float d = r - angle;
+                        float a = (float)Math.Abs(d);
+
+                        if (a >= 180) range = (360 - a) * (d > 0 ? -1 : 1);
+                        else range = d;
+                    }
+                }
+
+                public override object Interpolate(float t, object current, Behavior behavior) {
+                    var value = from + range * t;
+                    if ((behavior & Behavior.Rotation) == Behavior.Rotation) {
+                        if ((behavior & Behavior.RotationRadians) == Behavior.RotationRadians)
+                            value *= DEG;
+
+                        value %= 360.0f;
+
+                        if (value < 0)
+                            value += 360.0f;
+
+                        if ((behavior & Behavior.RotationRadians) == Behavior.RotationRadians)
+                            value *= RAD;
+                    }
+
+                    if ((behavior & Behavior.Round) == Behavior.Round)
+                        value = (float)Math.Round(value);
+
+                    var type = current.GetType();
+                    return Convert.ChangeType(value, type);
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
[Discord Discussion](https://discord.com/channels/531175899588984842/536970543736291346/1111425360282800190)

Breaking change: no

This is an attempt to fix #812 - mostly by converting the main Dictionary object used by the tweener class to a ConcurrentDictionary and adding locks to inner list access.

It also swaps out the implementations of toadd/toremove to ConcurrentQueue instead of list,  as it's a more natural fit for the usecase.

There's also some minor cleanup of unused variables and formatting.