### PR TITLE
Control collection parent fixes

### DIFF
--- a/Blish HUD/Controls/Container.cs
+++ b/Blish HUD/Controls/Container.cs
@@ -131,7 +131,7 @@ namespace Blish_HUD.Controls {
         /// </summary>
         public IEnumerable<Control> GetDescendants() {
             // Breadth-first unrolling without the inefficiency of recursion.
-            var remainingChildren = new Queue<Control>(this.Children.ToArray());
+            var remainingChildren = new Queue<Control>(this.Children);
 
             while (remainingChildren.Count > 0) {
                 var child = remainingChildren.Dequeue();
@@ -149,11 +149,7 @@ namespace Blish_HUD.Controls {
         /// Returns all child <see cref="Control"/>s of this <see cref="Container"/> of type <typeparamref name="T"/>.
         /// </summary>
         public IEnumerable<T> GetChildrenOfType<T>() {
-            foreach (var child in this.Children.ToArray()) {
-                if (child is T tChild) {
-                    yield return tChild;
-                }
-            }
+            return this.Children.OfType<T>();
         }
 
         /// <summary>
@@ -172,6 +168,7 @@ namespace Blish_HUD.Controls {
             if (evRes.Cancel) return false;
 
             _children.Add(child);
+            child.Parent = this;
 
             Invalidate();
 
@@ -195,6 +192,7 @@ namespace Blish_HUD.Controls {
             if (evRes.Cancel) return false;
 
             _children.Remove(child);
+            child.Parent = null;
 
             Invalidate();
 
@@ -205,8 +203,8 @@ namespace Blish_HUD.Controls {
         /// Safely clears all child <see cref="Control"/> from this <see cref="Container"/>.
         /// </summary>
         public void ClearChildren() {
-            while (_children.Count > 0) {
-                _children[0].Parent = null;
+            foreach (Control child in this.Children) {
+                this.RemoveChild(child);
             }
         }
 

--- a/Blish HUD/Controls/Control.cs
+++ b/Blish HUD/Controls/Control.cs
@@ -627,16 +627,21 @@ namespace Blish_HUD.Controls {
         public Container Parent {
             get => _parent;
             set {
-                var currentParent = _parent;
+                var previousParent = _parent;
+                var newParent = value;
 
-                if (SetProperty(ref _parent, value)) {
-                    currentParent?.RemoveChild(this);
-
-                    _parent = value;
-
-                    if (this.Parent == null || !this.Parent.AddChild(this)) {
-                        _parent = null;
+                if (!ReferenceEquals(previousParent, newParent)) {
+                    if (previousParent != null && !previousParent.RemoveChild(this)) {
+                        // remove parent cancelled.
+                        return;
                     }
+
+                    if (newParent != null && !newParent.AddChild(this)) {
+                        // add parent cancelled.
+                        newParent = null;
+                    }
+
+                    this.SetProperty(ref _parent, newParent);
                 }
             }
         }

--- a/Blish HUD/Controls/Panel.cs
+++ b/Blish HUD/Controls/Panel.cs
@@ -125,7 +125,9 @@ namespace Blish_HUD.Controls {
         }
 
         public void NavigateToBuiltPanel(BuildUIDelegate buildCall, object obj) {
-            this.Children.ToList().ForEach(c => c.Dispose());
+            foreach (Control child in this.Children) {
+                child.Dispose();
+            }
 
             var buildPanel = new Panel() {
                 Size = _size

--- a/Blish HUD/Controls/Scrollbar.cs
+++ b/Blish HUD/Controls/Scrollbar.cs
@@ -253,13 +253,9 @@ namespace Blish_HUD.Controls {
         private void RecalculateScrollbarSize() {
             if (_associatedContainer == null) return;
 
-            var tempContainerChidlren = _associatedContainer.Children.ToArray();
-
             _containerLowestContent = 0;
 
-            for (int i = 0; i < tempContainerChidlren.Length; i++) {
-                ref var child = ref tempContainerChidlren[i];
-
+            foreach (var child in _associatedContainer.Children) {
                 if (child.Visible) {
                     _containerLowestContent = Math.Max(_containerLowestContent, child.Bottom);
                 }

--- a/Blish HUD/Controls/_Types/ControlCollection.cs
+++ b/Blish HUD/Controls/_Types/ControlCollection.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Blish_HUD._Extensions;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,40 +14,14 @@ namespace Blish_HUD.Controls {
         // different interface, but it will be a breaking change. We should
         // revise this the next time we make a major breaking change.
 
-        private class ControlEnumerator<TEnum> : IEnumerator<TEnum> {
-
-            private readonly IEnumerator<TEnum>   _inner;
-            private readonly ReaderWriterLockSlim _rwLock;
-
-            public ControlEnumerator(IEnumerator<TEnum> inner, ReaderWriterLockSlim rwLock) {
-                _inner  = inner;
-                _rwLock = rwLock;
-            }
-
-            public bool MoveNext() {
-                return _inner.MoveNext();
-            }
-
-            public void Reset() {
-                _inner.Reset();
-            }
-
-            public object Current => _inner.Current;
-
-            TEnum IEnumerator<TEnum>.Current => _inner.Current;
-
-            public void Dispose() {
-                if (_rwLock.IsReadLockHeld)
-                    _rwLock.ExitReadLock();
-            }
-        }
-
         private readonly List<T>              _innerList;
-        private readonly ReaderWriterLockSlim _listLock = new ReaderWriterLockSlim();
+        private readonly ReaderWriterLockSlim _listLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
 
-        public bool IsReadOnly => false;
+        public bool IsReadOnly { get; } = false;
 
-        public bool IsEmpty { get; private set; } = true;
+        public bool IsEmpty {
+            get => _innerList.Count == 0;
+        }
 
         public ControlCollection() {
             _innerList = new List<T>();
@@ -54,62 +29,46 @@ namespace Blish_HUD.Controls {
 
         public ControlCollection(IEnumerable<T> existingControls) {
             _innerList = new List<T>(existingControls);
-
-            this.IsEmpty = !_innerList.Any();
         }
 
+        /// <inheritdoc/>
         public IEnumerator<T> GetEnumerator() {
-            if (!_listLock.IsReadLockHeld)
-                _listLock.EnterReadLock();
-
-            return new ControlEnumerator<T>(_innerList.GetEnumerator(), _listLock);
+            // create a copy for safe enumeration.
+            return ((IEnumerable<T>)this.ToArray()).GetEnumerator();
         }
 
+        /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator() {
             return GetEnumerator();
         }
 
+        /// <inheritdoc/>
         public void Add(T item) {
-            if (this.Contains(item) || item == null) return;
-            
-            if (!_listLock.IsWriteLockHeld)
-                _listLock.EnterWriteLock();
-            _innerList.Add(item);
-            this.IsEmpty = false;
-            _listLock.ExitWriteLock();
+            using (_listLock.EnterDisposableWriteLock()) {
+                this.Insert(this.Count, item);
+            }
         }
 
         public void AddRange(IEnumerable<T> items) {
-            if (!_listLock.IsWriteLockHeld)
-                _listLock.EnterWriteLock();
-            _innerList.AddRange(items);
-            this.IsEmpty = !_innerList.Any();
-            _listLock.ExitWriteLock();
+            using (_listLock.EnterDisposableWriteLock()) {
+                T[] newItems = items.ToArray();
+
+                foreach (T item in newItems) {
+                    this.Add(item);
+                }
+            }
         }
 
+        /// <inheritdoc/>
         public void Clear() {
-            T[] oldItems = this.ToArray();
-
-            if (!_listLock.IsWriteLockHeld)
-                _listLock.EnterWriteLock();
-            _innerList.Clear();
-            this.IsEmpty = true;
-            _listLock.ExitWriteLock();
-            
-            foreach (var item in oldItems) {
-                item.Parent = null;
+            using (_listLock.EnterDisposableWriteLock()) {
+                _innerList.Clear();
             }
         }
 
+        /// <inheritdoc/>
         public bool Contains(T item) {
-            if (!_listLock.IsReadLockHeld)
-                _listLock.EnterReadLock();
-
-            try {
-                return _innerList.Contains(item);
-            } finally {
-                _listLock.ExitReadLock();
-            }
+            return this.IndexOf(item) != -1;
         }
 
         /// <summary>
@@ -120,96 +79,88 @@ namespace Blish_HUD.Controls {
             throw new InvalidOperationException($"{nameof(CopyTo)} not supported.  If using LINQ, ensure you call .ToList or .ToArray directly on {nameof(ControlCollection<T>)} first.");
         }
 
+        /// <inheritdoc/>
         public bool Remove(T item) {
-            if (!_listLock.IsWriteLockHeld)
-                _listLock.EnterWriteLock();
+            if (item == null) {
+                return false;
+            }
 
-            try {
+            using (_listLock.EnterDisposableWriteLock()) {
                 return _innerList.Remove(item);
-            } finally {
-                this.IsEmpty = !_innerList.Any();
-                _listLock.ExitWriteLock();
             }
         }
 
+        /// <inheritdoc/>
         public int Count {
             get {
-                if (!_listLock.IsReadLockHeld)
-                    _listLock.EnterReadLock();
-
-                try {
+                using (_listLock.EnterDisposableReadLock()) {
                     return _innerList.Count;
-                } finally {
-                    _listLock.ExitReadLock();
                 }
             }
         }
 
         public List<T> ToList() {
-            if (!_listLock.IsReadLockHeld)
-                _listLock.EnterReadLock();
-
-            try {
+            using (_listLock.EnterDisposableReadLock()) {
                 return new List<T>(_innerList);
-            } finally {
-                _listLock.ExitReadLock();
             }
         }
 
         public T[] ToArray() {
-            if (!_listLock.IsReadLockHeld)
-                _listLock.EnterReadLock();
-
-            try {
-                var items = new T[_innerList.Count];
-                _innerList.CopyTo(items, 0);
-                return items;
-            } finally {
-                _listLock.ExitReadLock();
+            using (_listLock.EnterDisposableReadLock()) {
+                return _innerList.ToArray();
             }
         }
 
+        /// <inheritdoc/>
         public int IndexOf(T item) {
-            if (!_listLock.IsReadLockHeld)
-                _listLock.EnterReadLock();
+            if (item == null) {
+                return -1;
+            }
 
-            try {
-                return _innerList.Count;
-            } finally {
-                _listLock.ExitReadLock();
+            using (_listLock.EnterDisposableReadLock()) {
+                return _innerList.IndexOf(item);
             }
         }
 
+        /// <inheritdoc/>
         public void Insert(int index, T item) {
-            if (!_listLock.IsWriteLockHeld)
-                _listLock.EnterWriteLock();
-            _innerList.Insert(index, item);
-            _listLock.ExitWriteLock();
+            if (item == null) {
+                return;
+            }
+
+            using (_listLock.EnterDisposableWriteLock()) {
+                if (!this.Contains(item)) {
+                    _innerList.Insert(index, item);
+                }
+            }
         }
 
+        /// <inheritdoc/>
         public void RemoveAt(int index) {
-            if (!_listLock.IsWriteLockHeld)
-                _listLock.EnterWriteLock();
-            _innerList.RemoveAt(index);
-            _listLock.ExitWriteLock();
+            using (_listLock.EnterDisposableWriteLock()) {
+                _innerList.RemoveAt(index);
+            }
         }
 
+        /// <inheritdoc/>
         public T this[int index] {
             get {
-                if (!_listLock.IsReadLockHeld)
-                    _listLock.EnterReadLock();
-
-                try {
+                using (_listLock.EnterDisposableReadLock()) {
                     return _innerList[index];
-                } finally {
-                    _listLock.ExitReadLock();
                 }
             }
             set {
-                if (!_listLock.IsWriteLockHeld)
-                    _listLock.EnterWriteLock();
-                _innerList[index] = value;
-                _listLock.ExitWriteLock();
+                if (value == null) {
+                    return;
+                }
+
+                using (_listLock.EnterDisposableWriteLock()) {
+                    int found = this.IndexOf(value);
+
+                    if (found != -1 && found != index) {
+                        _innerList[index] = value;
+                    }
+                }
             }
         }
 

--- a/Blish HUD/Controls/_Types/ControlCollection.cs
+++ b/Blish HUD/Controls/_Types/ControlCollection.cs
@@ -1,5 +1,4 @@
-﻿using Blish_HUD._Extensions;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/Blish HUD/Controls/_Types/ControlCollection.cs
+++ b/Blish HUD/Controls/_Types/ControlCollection.cs
@@ -44,18 +44,14 @@ namespace Blish_HUD.Controls {
 
         /// <inheritdoc/>
         public void Add(T item) {
-            using (_listLock.EnterDisposableWriteLock()) {
-                this.Insert(this.Count, item);
-            }
+            this.Insert(this.Count, item);
         }
 
         public void AddRange(IEnumerable<T> items) {
-            using (_listLock.EnterDisposableWriteLock()) {
-                T[] newItems = items.ToArray();
+            T[] newItems = items.ToArray();
 
-                foreach (T item in newItems) {
-                    this.Add(item);
-                }
+            foreach (T item in newItems) {
+                this.Add(item);
             }
         }
 

--- a/Blish HUD/Controls/_Types/ControlCollection.cs
+++ b/Blish HUD/Controls/_Types/ControlCollection.cs
@@ -15,7 +15,7 @@ namespace Blish_HUD.Controls {
         // revise this the next time we make a major breaking change.
 
         private readonly List<T>              _innerList;
-        private readonly ReaderWriterLockSlim _listLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
+        private readonly ReaderWriterLockSlim _listLock = new ReaderWriterLockSlim();
 
         public bool IsReadOnly { get; } = false;
 
@@ -125,7 +125,7 @@ namespace Blish_HUD.Controls {
             }
 
             using (_listLock.EnterDisposableWriteLock()) {
-                if (!this.Contains(item)) {
+                if (!_innerList.Contains(item)) {
                     _innerList.Insert(index, item);
                 }
             }
@@ -151,7 +151,7 @@ namespace Blish_HUD.Controls {
                 }
 
                 using (_listLock.EnterDisposableWriteLock()) {
-                    int found = this.IndexOf(value);
+                    int found = _innerList.IndexOf(value);
 
                     if (found != -1 && found != index) {
                         _innerList[index] = value;

--- a/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
@@ -218,8 +218,8 @@ namespace Blish_HUD.Input {
 
                 // Close the active window or top level context menu (if any) if enabled in settings
                 if (GameService.Overlay.CloseWindowOnEscape.Value) {
-                    var activeContextMenu = GameService.Graphics.SpriteScreen.Children
-                       .OfType<ContextMenuStrip>().FirstOrDefault(c => c.Visible);
+                    var activeContextMenu = GameService.Graphics.SpriteScreen
+                        .GetChildrenOfType<ContextMenuStrip>().FirstOrDefault(c => c.Visible);
 
                     if (activeContextMenu != null) {
                         // If we found an active context menu item, close it

--- a/Blish HUD/_Extensions/ReaderWriterLockSlimExtensions.cs
+++ b/Blish HUD/_Extensions/ReaderWriterLockSlimExtensions.cs
@@ -1,0 +1,45 @@
+﻿namespace Blish_HUD._Extensions {
+    using System.Threading;
+
+    internal static class ReaderWriterLockSlimExtensions {
+
+        // These could be ref classes and use IDisposable,
+        // but a ref struct is slightly more performant,
+        // and prevents error-prone usage in async methods.
+
+        public readonly ref struct DisposableReadLock {
+            private readonly ReaderWriterLockSlim _rwl;
+
+            public DisposableReadLock(ReaderWriterLockSlim rwl) {
+                _rwl = rwl;
+                _rwl.EnterReadLock();
+            }
+
+            public void Dispose() {
+                _rwl.ExitReadLock();
+            }
+        }
+
+        public readonly ref struct DisposableWriteLock {
+            private readonly ReaderWriterLockSlim _rwl;
+
+            public DisposableWriteLock(ReaderWriterLockSlim rwl) {
+                _rwl = rwl;
+                _rwl.EnterWriteLock();
+            }
+
+            public void Dispose() {
+                _rwl.ExitWriteLock();
+            }
+        }
+
+        public static DisposableReadLock EnterDisposableReadLock(this ReaderWriterLockSlim rwl) {
+            return new DisposableReadLock(rwl);
+        }
+
+        public static DisposableWriteLock EnterDisposableWriteLock(this ReaderWriterLockSlim rwl) {
+            return new DisposableWriteLock(rwl);
+        }
+
+    }
+}

--- a/Blish HUD/_Extensions/ReaderWriterLockSlimExtensions.cs
+++ b/Blish HUD/_Extensions/ReaderWriterLockSlimExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Blish_HUD._Extensions {
+﻿namespace Blish_HUD {
     using System.Threading;
 
     internal static class ReaderWriterLockSlimExtensions {


### PR DESCRIPTION
[Discord Discussion](https://discord.com/channels/531175899588984842/536970543736291346/1112089112002965596)

Breaking change: no 

Likely fixes #886

This reworks the internals of the `ControlCollection<T>` class, with the following changes:
* `null` values are unable to be added to the collection, with short-circuits for methods when `item` is `null`
* Cancelling an `AddChild` or `RemoveChild` action from a Container should no longer cause the `Parent` property of the control in question to be in a potentially invalid state.
* Create a copy of the internal array when iterating, as with some BCL concurrent types, as we can't be sure external code will dispose of the enumerator correctly.
* Provide (internal) ReaderWriterLockSlim helper methods that allow basic read and write locks to use `using (...) { ... }` syntax rather than having to use try/finally everywhere.
* No longer clear `Parent` on controls when calling `Clear` - this should be handled by the Container as there's no guarantee that the ControlCollection is being used for parenting/hierarchy purposes.
* Update Container to explicitly set .Parent property on added or removed children.

Notes:
* I'm working on the assumption that the intended behaviour for the control collection is that it never contains nulls and never has duplicates, if either of those assumptions are incorrect then I'll need to rework this change.
* I'm unsure if the indexer setter for `ControlCollection<T>` should remove the item when attempting to set an indexed position to `null` or if it should be a noop, currently it removes the item. Additionally, if an index is set to an item that exists elsewhere in the collection, it currently overwrites the index, then removes the duplicate.