### PR TITLE
Added overloads to specify own logger names

### DIFF
--- a/Blish HUD/GameServices/Debug/Logger.cs
+++ b/Blish HUD/GameServices/Debug/Logger.cs
@@ -7,23 +7,33 @@ namespace Blish_HUD {
 
         #region Static
 
-        private static readonly ConcurrentDictionary<Type, Logger> _loggers = new ConcurrentDictionary<Type, Logger>();
+        private static readonly ConcurrentDictionary<string, Logger> _loggers = new ConcurrentDictionary<string, Logger>();
 
         public static Logger GetLogger(Type type) {
-            return _loggers.GetOrAdd(type, (t) => new Logger(t));
+            return _loggers.GetOrAdd(type.AssemblyQualifiedName, _ => new Logger(type));
         }
 
         public static Logger GetLogger<T>() {
-            return _loggers.GetOrAdd(typeof(T), (t) => new Logger(t));
+            return _loggers.GetOrAdd(typeof(T).AssemblyQualifiedName, _ => new Logger(typeof(T)));
+        }
+
+        public static Logger GetLogger(Type callingType, string name) {
+            return _loggers.GetOrAdd($"{callingType.AssemblyQualifiedName}_{name}", _ => new Logger(name));
+        }
+
+        public static Logger GetLogger<T>(string name) {
+            return _loggers.GetOrAdd($"{typeof(T).AssemblyQualifiedName}_{name}", _ => new Logger(name));
         }
 
         #endregion
 
         private readonly NLog.Logger _internalLogger;
 
-        private Logger(Type type) {
-            _internalLogger = LogManager.GetLogger(type.FullName);
+        private Logger(string name) {
+            _internalLogger = LogManager.GetLogger(name);
         }
+
+        private Logger(Type type) : this(type.FullName) { }
 
         #region Trace
 


### PR DESCRIPTION
This PR aims to enable module developer to specify their own logger names.

My example for the need of this implementation:

The module Event Table can have an "unlimited" amount of event areas on the screen. Each area logs specific data.
Currently there is no way to know from which area this log statement comes.
The only alternative currently would be to prefix the name of the area on each logger call. This is prone the be forgotten and not the best method.


The new method allows me to specify my own name and results in logs like this:

`14:31:12.9626 | DEBUG | Estreya.BlishHUD.EventTable.Controls.EventArea - Main | Added event The Path to Ascension with occurence 28.05.2023 13:30:00` ( Note the name "Main" after the type )

The logger can be created like this:
`Logger.GetLogger<EventArea>($"{typeof(EventArea).FullName} - {this.Configuration.Name}")`


The new implementation does not break existing loggers in any way.