### PR TITLE
Graphics setting changes.

### DIFF
--- a/Blish HUD/ApplicationSettings.cs
+++ b/Blish HUD/ApplicationSettings.cs
@@ -142,9 +142,8 @@ namespace Blish_HUD {
         /// </summary>
         [
             Option(OPTION_UNLOCKFPS, 'F'),
-            Help("Deprecated as of v0.8.0.  Instead use the 'Frame Limiter' setting found in the Blish HUD graphics settings section.")
+            Help("Unlocks the frame limit allowing Blish HUD to render as fast as possible.  This will cause higher CPU and GPU utilization.")
         ]
-        [Obsolete("Deprecated as of v0.8.0.  Instead use the 'Frame Limiter' setting found in the Blish HUD graphics settings section.")]
         public bool UnlockFps { get; private set; }
 
         #endregion

--- a/Blish HUD/GameServices/Graphics/FramerateMethod.cs
+++ b/Blish HUD/GameServices/Graphics/FramerateMethod.cs
@@ -1,12 +1,16 @@
-﻿namespace Blish_HUD.Graphics {
+﻿using System.ComponentModel;
+
+namespace Blish_HUD.Graphics {
 
     public enum FramerateMethod : int {
-        Custom         = -1,
-        SyncWithGame   = 0,
-        LockedTo30Fps  = 1,
-        LockedTo60Fps  = 2,
-        LockedTo90Fps  = 3,
-        Unlimited      = 4,
+        Custom        = -1,
+        SyncWithGame  = 0,
+        LockedTo30Fps = 1,
+        LockedTo60Fps = 2,
+        LockedTo90Fps = 3,
+        [Description("Match Monitor Refresh Rate")]
+        Unlimited     = 4,
+        TrueUnlimited = 5,
     }
 
 }

--- a/Blish HUD/GameServices/GraphicsService.cs
+++ b/Blish HUD/GameServices/GraphicsService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -173,7 +174,6 @@ namespace Blish_HUD {
         public SettingCollection GraphicsSettings { get; private set; }
 
         private SettingEntry<FramerateMethod> _frameLimiterSetting;
-        private SettingEntry<bool>            _enableVsyncSetting;
         private SettingEntry<bool>            _smoothCharacterPositionSetting;
         private SettingEntry<DpiMethod>       _dpiScalingMethodSetting;
         private SettingEntry<ManualUISize>    _UISizeSetting;
@@ -183,11 +183,6 @@ namespace Blish_HUD {
                        ? FramerateMethod.Custom
                        : _frameLimiterSetting.Value;
             set => _frameLimiterSetting.Value = value;
-        }
-
-        public bool EnableVsync {
-            get => _enableVsyncSetting.Value;
-            set => _enableVsyncSetting.Value = value;
         }
 
         public bool SmoothCharacterPosition {
@@ -259,19 +254,13 @@ namespace Blish_HUD {
                                                           () => Strings.GameServices.GraphicsService.Setting_FramerateLimiter_DisplayName,
                                                           () => Strings.GameServices.GraphicsService.Setting_FramerateLimiter_Description);
 
-            _enableVsyncSetting = settings.DefineSetting("EnableVsync",
-                                                         true,
-                                                         () => Strings.GameServices.GraphicsService.Setting_Vsync_DisplayName,
-                                                         () => Strings.GameServices.GraphicsService.Setting_Vsync_Description);
-
             if (_frameLimiterSetting.Value == FramerateMethod.SyncWithGame || _frameLimiterSetting.Value == FramerateMethod.Custom) {
                 // SyncWithGame is no longer supported.  It causes more problems than it solves.
                 // We revert to the default settings for both the framerate limiter and vsync.
 
                 // Likewise, Custom framerates are only possible via launch option currently.
                 // Old versions could enable it, so this fixes that.
-                _frameLimiterSetting.Value = FramerateMethod.LockedTo90Fps;
-                _enableVsyncSetting.Value  = true;
+                _frameLimiterSetting.Value = FramerateMethod.LockedTo60Fps;
             }
 
             _smoothCharacterPositionSetting = settings.DefineSetting("EnableCharacterPositionBuffer",
@@ -279,65 +268,62 @@ namespace Blish_HUD {
                                                                      () => Strings.GameServices.GraphicsService.Setting_SmoothCharacterPosition_DisplayName,
                                                                      () => Strings.GameServices.GraphicsService.Setting_SmoothCharacterPosition_Description);
 
-            _dpiScalingMethodSetting =        settings.DefineSetting(nameof(DpiScalingMethod),
+            _dpiScalingMethodSetting = settings.DefineSetting(nameof(DpiScalingMethod),
                                                                      DpiMethod.SyncWithGame,
                                                                      () => Strings.GameServices.GraphicsService.Setting_DPIScaling_DisplayName,
                                                                      () => Strings.GameServices.GraphicsService.Setting_DPIScaling_Description);
 
-            _UISizeSetting =                  settings.DefineSetting(nameof(UIScalingMethod),
+            _UISizeSetting = settings.DefineSetting(nameof(UIScalingMethod),
                                                                      ManualUISize.SyncWithGame,
                                                                      () => Strings.GameServices.GraphicsService.Setting_UIScaling_DisplayName,
                                                                      () => Strings.GameServices.GraphicsService.Setting_UIScaling_Description);
-
-
+            
             _frameLimiterSetting.SettingChanged += FrameLimiterSettingMethodChanged;
-            _enableVsyncSetting.SettingChanged  += EnableVsyncChanged;
+            FrameLimiterSettingMethodChanged(_frameLimiterSetting, new ValueChangedEventArgs<FramerateMethod>(_frameLimiterSetting.Value, _frameLimiterSetting.Value));
 
-            EnableVsyncChanged(_enableVsyncSetting, new ValueChangedEventArgs<bool>(_enableVsyncSetting.Value, _enableVsyncSetting.Value));
-            FrameLimiterSettingMethodChanged(_enableVsyncSetting, new ValueChangedEventArgs<FramerateMethod>(_frameLimiterSetting.Value, _frameLimiterSetting.Value));
+            _frameLimiterSetting.SetExcluded(FramerateMethod.Custom, FramerateMethod.SyncWithGame, FramerateMethod.TrueUnlimited);
 
-            _frameLimiterSetting.SetExcluded(FramerateMethod.Custom, FramerateMethod.SyncWithGame);
-
+            // User has specified a custom FPS target via launch arg
             if (ApplicationSettings.Instance.TargetFramerate > 0) {
-                // Disable frame limiter setting and update description - user has manually specified via launch arg
                 _frameLimiterSetting.SetDisabled();
                 _frameLimiterSetting.GetDescriptionFunc = () => Strings.GameServices.GraphicsService.Setting_FramerateLimiter_Description + Strings.GameServices.GraphicsService.Setting_FramerateLimiter_Locked_Description;
 
-                FrameLimiterSettingMethodChanged(_enableVsyncSetting, new ValueChangedEventArgs<FramerateMethod>(FramerateMethod.Custom, FramerateMethod.Custom));
+                FrameLimiterSettingMethodChanged(_frameLimiterSetting, new ValueChangedEventArgs<FramerateMethod>(FramerateMethod.Custom, FramerateMethod.Custom));
+            }
+
+            // User has unlocked the FPS via launch arg
+            if (ApplicationSettings.Instance.UnlockFps) {
+                // Disable frame limiter setting and update description - user has unlocked the FPS via launch arg
+                _frameLimiterSetting.SetDisabled();
+                _frameLimiterSetting.GetDescriptionFunc = () => Strings.GameServices.GraphicsService.Setting_FramerateLimiter_Description + Strings.GameServices.GraphicsService.Setting_FramerateLimiter_Locked_Description;
+
+                FrameLimiterSettingMethodChanged(_frameLimiterSetting, new ValueChangedEventArgs<FramerateMethod>(FramerateMethod.TrueUnlimited, FramerateMethod.TrueUnlimited));
             }
         }
 
-        private void EnableVsyncChanged(object sender, ValueChangedEventArgs<bool> e) {
-            GraphicsDeviceManager.SynchronizeWithVerticalRetrace = e.NewValue;
-            GraphicsDeviceManager.ApplyChanges();
-        }
-
         private void FrameLimiterSettingMethodChanged(object sender, ValueChangedEventArgs<FramerateMethod> e) {
-            switch (e.NewValue) {
-                case FramerateMethod.Custom: // Only enabled via launch options
-                    BlishHud.Instance.IsFixedTimeStep   = true;
-                    BlishHud.Instance.TargetElapsedTime = TimeSpan.FromSeconds(1d / ApplicationSettings.Instance.TargetFramerate);
-                    break;
-                case FramerateMethod.SyncWithGame:
-                    BlishHud.Instance.IsFixedTimeStep   = false;
-                    BlishHud.Instance.TargetElapsedTime = TimeSpan.FromMilliseconds(1);
-                    break;
-                case FramerateMethod.LockedTo30Fps:
-                    BlishHud.Instance.IsFixedTimeStep   = true;
-                    BlishHud.Instance.TargetElapsedTime = TimeSpan.FromSeconds(1d / 30d);
-                    break;
-                case FramerateMethod.LockedTo60Fps:
-                    BlishHud.Instance.IsFixedTimeStep   = true;
-                    BlishHud.Instance.TargetElapsedTime = TimeSpan.FromSeconds(1d / 60d);
-                    break;
-                case FramerateMethod.LockedTo90Fps:
-                    BlishHud.Instance.IsFixedTimeStep   = true;
-                    BlishHud.Instance.TargetElapsedTime = TimeSpan.FromSeconds(1d / 90d);
-                    break;
-                case FramerateMethod.Unlimited:
-                    BlishHud.Instance.IsFixedTimeStep   = false;
-                    BlishHud.Instance.TargetElapsedTime = TimeSpan.FromMilliseconds(1);
-                    break;
+            bool currentVsync = GraphicsDeviceManager.SynchronizeWithVerticalRetrace;
+
+            var frameRateLookup = new Dictionary<FramerateMethod, (bool IsFixedTimeStep, TimeSpan TargetElapsedTime, bool VSync)> {
+                { FramerateMethod.Custom,        (true, TimeSpan.FromSeconds(1d / ApplicationSettings.Instance.TargetFramerate), false) }, // Only enabled with launch args
+                { FramerateMethod.SyncWithGame,  (false, TimeSpan.FromMilliseconds(1), false) }, // Deprecated
+                { FramerateMethod.LockedTo30Fps, (true, TimeSpan.FromSeconds(1d / 30d), false) },
+                { FramerateMethod.LockedTo60Fps, (true, TimeSpan.FromSeconds(1d / 60d), false) },
+                { FramerateMethod.LockedTo90Fps, (true, TimeSpan.FromSeconds(1d / 90d), false) },
+                { FramerateMethod.Unlimited,     (false, TimeSpan.FromMilliseconds(1), true) }, // Unlimited with vsync (safe)
+                { FramerateMethod.TrueUnlimited, (false, TimeSpan.FromMilliseconds(1), false) } // Unlimited without vsync (unsafe)
+            };
+
+            if (frameRateLookup.TryGetValue(e.NewValue, out var settings)) {
+                BlishHud.Instance.IsFixedTimeStep = settings.IsFixedTimeStep;
+                BlishHud.Instance.TargetElapsedTime = settings.TargetElapsedTime;
+                if (settings.VSync != currentVsync) {
+                    GraphicsDeviceManager.SynchronizeWithVerticalRetrace = settings.VSync;
+                    GraphicsDeviceManager.ApplyChanges();
+                }
+            } else {
+                // Shouldn't be possible unless settings are manually modified
+                Logger.Warn($"Attempted to set the frame rate limiter to invalid value '{e.NewValue}'.  No changes to the frame limiter were made.");
             }
         }
 

--- a/Blish HUD/GameServices/Overlay/UI/Views/OverlaySettingsView.cs
+++ b/Blish HUD/GameServices/Overlay/UI/Views/OverlaySettingsView.cs
@@ -28,10 +28,10 @@ namespace Blish_HUD.Overlay.UI.Views {
         }
 
         private void BuildOverlaySettings(Panel rootPanel) {
-            GetStandardPanel(rootPanel, Strings.GameServices.OverlayService.OverlaySettingsSection).Show(new SettingsView(GameService.Overlay.OverlaySettings));
-            GetStandardPanel(rootPanel, Strings.GameServices.OverlayService.OverlayDynamicHUDSection).Show(new SettingsView(GameService.Overlay.DynamicHUDSettings));
-            GetStandardPanel(rootPanel, Strings.GameServices.GraphicsService.GraphicsSettingsSection).Show(new SettingsView(GameService.Graphics.GraphicsSettings));
-            GetStandardPanel(rootPanel, Strings.GameServices.DebugService.DebugSettingsSection).Show(new SettingsView(GameService.Debug.DebugSettings));
+            GetStandardPanel(rootPanel, Strings.Common.BlishHUD + " " + Strings.GameServices.OverlayService.OverlaySettingsSection).Show(new SettingsView(GameService.Overlay.OverlaySettings));
+            GetStandardPanel(rootPanel, Strings.Common.BlishHUD + " " + Strings.GameServices.OverlayService.OverlayDynamicHUDSection).Show(new SettingsView(GameService.Overlay.DynamicHUDSettings));
+            GetStandardPanel(rootPanel, Strings.Common.BlishHUD + " " + Strings.GameServices.GraphicsService.GraphicsSettingsSection).Show(new SettingsView(GameService.Graphics.GraphicsSettings));
+            GetStandardPanel(rootPanel, Strings.Common.BlishHUD + " " + Strings.GameServices.DebugService.DebugSettingsSection).Show(new SettingsView(GameService.Debug.DebugSettings));
         }
 
     }

--- a/Blish HUD/Strings/GameServices/GraphicsService.Designer.cs
+++ b/Blish HUD/Strings/GameServices/GraphicsService.Designer.cs
@@ -19,7 +19,7 @@ namespace Blish_HUD.Strings.GameServices {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class GraphicsService {
@@ -106,7 +106,7 @@ namespace Blish_HUD.Strings.GameServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (Disabled because Blish HUD was started with --maxfps specified).
+        ///   Looks up a localized string similar to (Disabled because Blish HUD was started with --maxfps/--unlockfps specified).
         /// </summary>
         internal static string Setting_FramerateLimiter_Locked_Description {
             get {
@@ -148,24 +148,6 @@ namespace Blish_HUD.Strings.GameServices {
         internal static string Setting_UIScaling_DisplayName {
             get {
                 return ResourceManager.GetString("Setting_UIScaling_DisplayName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Enabling Vsync limits the frame rate of Blish HUD to the monitor refresh rate to prevent screen tearing..
-        /// </summary>
-        internal static string Setting_Vsync_Description {
-            get {
-                return ResourceManager.GetString("Setting_Vsync_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Enable Vsync.
-        /// </summary>
-        internal static string Setting_Vsync_DisplayName {
-            get {
-                return ResourceManager.GetString("Setting_Vsync_DisplayName", resourceCulture);
             }
         }
     }

--- a/Blish HUD/Strings/GameServices/GraphicsService.de.resx
+++ b/Blish HUD/Strings/GameServices/GraphicsService.de.resx
@@ -121,19 +121,13 @@
     <value>Grafikoptionen</value>
   </data>
   <data name="Setting_FramerateLimiter_Locked_Description" xml:space="preserve">
-    <value>(Deaktiviert, da Blish HUD mit --maxfps gestartet wurde)</value>
+    <value>(Deaktiviert, da Blish HUD mit --maxfps/--unlockfps gestartet wurde)</value>
   </data>
   <data name="Setting_FramerateLimiter_DisplayName" xml:space="preserve">
     <value>FPS-Limitierung</value>
   </data>
   <data name="Setting_FramerateLimiter_Description" xml:space="preserve">
     <value>Diese Methode bestimmte die Bildrate mit der Blish HUD ausgeführt wird.</value>
-  </data>
-  <data name="Setting_Vsync_DisplayName" xml:space="preserve">
-    <value>Vertikale Synchronisierung</value>
-  </data>
-  <data name="Setting_Vsync_Description" xml:space="preserve">
-    <value>Passt die Bildfrequenz von Blish HUD an die Bildwiederholungsrate des Monitors an. Hilft Artefakte aufzulösen, kann aber zu künstlich niedriger Bildwiederholungsrate führen.</value>
   </data>
   <data name="Setting_SmoothCharacterPosition_DisplayName" xml:space="preserve">
     <value>Weiche Charakterposition</value>

--- a/Blish HUD/Strings/GameServices/GraphicsService.fr.resx
+++ b/Blish HUD/Strings/GameServices/GraphicsService.fr.resx
@@ -126,14 +126,8 @@
   <data name="Setting_FramerateLimiter_Description" xml:space="preserve">
     <value>La méthode utilisée pour déterminer la fréquence d'image que Blish HUD devrait utiliser.</value>
   </data>
-  <data name="Setting_Vsync_DisplayName" xml:space="preserve">
-    <value>Activer la synchronisation verticale</value>
-  </data>
-  <data name="Setting_Vsync_Description" xml:space="preserve">
-    <value>Activer la synchronisation verticale limite la fréquence d'images de Blish HUD au taux de raffraîchissement de l'écran pour empêcher les problèmes de coupure d'image.</value>
-  </data>
   <data name="Setting_FramerateLimiter_Locked_Description" xml:space="preserve">
-    <value>(Désactivé car Blish HUD a été lancé avec le paramètre --maxfps)</value>
+    <value>(Désactivé car Blish HUD a été lancé avec le paramètre --maxfps/--unlockfps)</value>
   </data>
   <data name="Setting_SmoothCharacterPosition_DisplayName" xml:space="preserve">
     <value>Position du personnage lissée</value>

--- a/Blish HUD/Strings/GameServices/GraphicsService.resx
+++ b/Blish HUD/Strings/GameServices/GraphicsService.resx
@@ -127,14 +127,8 @@
   <data name="Setting_FramerateLimiter_Description" xml:space="preserve">
     <value>The method used to determine the framerate that Blish HUD should run at.</value>
   </data>
-  <data name="Setting_Vsync_DisplayName" xml:space="preserve">
-    <value>Enable Vsync</value>
-  </data>
-  <data name="Setting_Vsync_Description" xml:space="preserve">
-    <value>Enabling Vsync limits the frame rate of Blish HUD to the monitor refresh rate to prevent screen tearing.</value>
-  </data>
   <data name="Setting_FramerateLimiter_Locked_Description" xml:space="preserve">
-    <value>(Disabled because Blish HUD was started with --maxfps specified)</value>
+    <value>(Disabled because Blish HUD was started with --maxfps/--unlockfps specified)</value>
   </data>
   <data name="Setting_SmoothCharacterPosition_DisplayName" xml:space="preserve">
     <value>Smooth Character Position</value>


### PR DESCRIPTION
- Makes the overlay settings more clear by indicating that the settings are for Blish HUD (some users would mistake the graphics settings as somehow applying to the game).
- Remove the option to toggle vsync (it is now always off unless framerate is set to `Unlimited`).
- Added new hidden frame limiter setting which is enabled using the old `--unlockfps` launch arg which truly unlocks the FPS (intended for things like module development).

![image](https://github.com/blish-hud/Blish-HUD/assets/1950594/ff655b32-de81-4e79-8fb6-3214551da581)

As part of migrating to this version, the previous vsync settings are ignored and unlimited has been migrated to `Match Monitor Refresh Rate`).
