### PR TITLE
Added module FatalError tooltip with the reason on LoadAsync error

### DIFF
--- a/Blish HUD/GameServices/Modules/UI/Presenters/ManageModulePresenter.cs
+++ b/Blish HUD/GameServices/Modules/UI/Presenters/ManageModulePresenter.cs
@@ -26,7 +26,7 @@ namespace Blish_HUD.Modules.UI.Presenters {
 
             this.Model.ModuleDisabled += ModelOnModuleDisabled;
 
-            this.View.EnableModuleClicked  += ViewOnEnableModuleClicked;
+            this.View.EnableModuleClicked += ViewOnEnableModuleClicked;
             this.View.DisableModuleClicked += ViewOnDisableModuleClicked;
 
             SubscribeToModuleRunState();
@@ -73,14 +73,14 @@ namespace Blish_HUD.Modules.UI.Presenters {
         private void DisplayStaticDetails() {
             // Load static details based on the manifest
 
-            this.View.ModuleName                 = this.Model.Manifest.Name;
-            this.View.ModuleNamespace            = this.Model.Manifest.Namespace;
-            this.View.ModuleDescription          = this.Model.Manifest.Description;
-            this.View.ModuleVersion              = this.Model.Manifest.Version;
+            this.View.ModuleName = this.Model.Manifest.Name;
+            this.View.ModuleNamespace = this.Model.Manifest.Namespace;
+            this.View.ModuleDescription = this.Model.Manifest.Description;
+            this.View.ModuleVersion = this.Model.Manifest.Version;
             this.View.ModuleAssemblyStateDirtied = this.Model.IsModuleAssemblyStateDirty;
 
             this.View.AuthorImage = GetModuleAuthorImage();
-            this.View.AuthorName  = GetModuleAuthor();
+            this.View.AuthorName = GetModuleAuthor();
         }
 
         private void DisplaySettingMenu() {
@@ -104,7 +104,7 @@ namespace Blish_HUD.Modules.UI.Presenters {
         }
 
         private ContextMenuStripItem BuildClearSettingsMenuItem() {
-            var clearSettings = new ContextMenuStripItem() {Text = Strings.GameServices.ModulesService.ModuleOption_ClearSettings };
+            var clearSettings = new ContextMenuStripItem() { Text = Strings.GameServices.ModulesService.ModuleOption_ClearSettings };
 
             clearSettings.BasicTooltipText = (clearSettings.Enabled = !this.Model.Enabled) == true
                                                  ? Strings.GameServices.ModulesService.ModuleOption_ClearSettings_DescriptionEnabled
@@ -119,11 +119,11 @@ namespace Blish_HUD.Modules.UI.Presenters {
             var dirs = this.Model.Manifest.Directories ?? new List<string>(0);
 
             foreach (string dir in dirs) {
-                var    dirItem = new ContextMenuStripItem() { Text = string.Format(Strings.GameServices.ModulesService.ModuleOption_OpenDir, dir.Titleize()) };
+                var dirItem = new ContextMenuStripItem() { Text = string.Format(Strings.GameServices.ModulesService.ModuleOption_OpenDir, dir.Titleize()) };
                 string dirPath = DirectoryUtil.RegisterDirectory(dir);
 
                 dirItem.BasicTooltipText = dirPath;
-                dirItem.Enabled          = Directory.Exists(dirPath);
+                dirItem.Enabled = Directory.Exists(dirPath);
 
                 dirItem.Click += delegate {
                     Process.Start("explorer.exe", $"/open, \"{dirPath}\\\"");
@@ -135,7 +135,10 @@ namespace Blish_HUD.Modules.UI.Presenters {
 
         private void DisplayStateDetails() {
             if (!GameService.Module.ModuleIsExplicitlyIncompatible(this.Model)) {
-                this.View.ModuleState = Model.ModuleInstance?.RunState ?? ModuleRunState.Unloaded;
+                var runState = Model.ModuleInstance?.RunState ?? ModuleRunState.Unloaded;
+                this.View.ModuleErrorReason = runState == ModuleRunState.FatalError ? this.Model.ModuleInstance?.ErrorReason : null;
+
+                this.View.ModuleState = runState;
 
                 GameService.Settings.Save();
             } else {
@@ -160,7 +163,7 @@ namespace Blish_HUD.Modules.UI.Presenters {
         }
 
         private void DisplayStatedOptions() {
-            this.View.CanEnable  = GetModuleCanEnable();
+            this.View.CanEnable = GetModuleCanEnable();
             this.View.CanDisable = GetModuleCanDisable();
         }
 

--- a/Blish HUD/GameServices/Modules/UI/Views/ManageModuleView.cs
+++ b/Blish HUD/GameServices/Modules/UI/Views/ManageModuleView.cs
@@ -75,6 +75,8 @@ namespace Blish_HUD.Modules.UI.Views {
             }
         }
 
+        public string ModuleErrorReason { get; set; }
+
         private ModuleRunState _moduleRunState = ModuleRunState.Unloaded;
         public ModuleRunState ModuleState {
             get => _moduleRunState;
@@ -83,7 +85,7 @@ namespace Blish_HUD.Modules.UI.Views {
 
                 var (status, color) = _moduleStatusLookup[_moduleRunState];
 
-                UpdateModuleRunState(status, color);
+                UpdateModuleRunState(status, color, _moduleRunState == ModuleRunState.FatalError ? this.ModuleErrorReason : null);
 
                 UpdateHeaderLayout();
             }
@@ -351,9 +353,10 @@ namespace Blish_HUD.Modules.UI.Views {
             _moduleStateLabel.Location   = new Point(_moduleVersionLabel.Right + 8, _moduleNameLabel.Top);
         }
 
-        private void UpdateModuleRunState(string status, Color color) {
+        private void UpdateModuleRunState(string status, Color color, string tooltip = null) {
             _moduleStateLabel.Text      = status;
             _moduleStateLabel.TextColor = color;
+            _moduleStateLabel.BasicTooltipText = tooltip;
         }
 
     }


### PR DESCRIPTION
This PR adds a tooltip in the manage module view showing the exception message on FatalError.
![image](https://github.com/blish-hud/Blish-HUD/assets/41393569/75de8b97-c15e-4fab-9f67-032945fe37bf)


## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/536970543736291346/1149364539847094344

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
