### PR TITLE
Fix reading empty process

### DIFF
--- a/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/Gw2InstanceIntegration.cs
@@ -292,6 +292,8 @@ namespace Blish_HUD.GameIntegration {
         }
 
         private Process GetGw2ProcessByPID(int pid, string src) {
+            if (pid == 0) return null; // Fix reading empty process. Caused by MumbleLink mock tools.
+
             try {
                 return Process.GetProcessById(pid);
             } catch (ArgumentException) {


### PR DESCRIPTION
This PR aims to fix blish reading an empty process on startup which casues a win32 access denied exception.
( Triggering the contingency dialog. )

The cause of the empty process ids (0) are MumbleMock tools that have no process selected at the given time or just cleared the memory file setting it to the default int value of 0.


## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

None

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
