### PR TITLE
Load modules sorted by dependencies

### DIFF
--- a/Blish HUD/GameServices/Modules/ModuleManager.cs
+++ b/Blish HUD/GameServices/Modules/ModuleManager.cs
@@ -39,11 +39,9 @@ namespace Blish_HUD.Modules {
         /// </summary>
         public bool Enabled { get; private set; }
 
-        private bool _dependenciesAvailable => Manifest.Dependencies.TrueForAll(d => d.GetDependencyDetails().CheckResult == ModuleDependencyCheckResult.Available);
-
         public bool DependenciesMet =>
             State.IgnoreDependencies
-         || _dependenciesAvailable;
+         || this.AreDependenciesAvailable();
 
         public Manifest Manifest { get; }
 
@@ -73,10 +71,10 @@ namespace Blish_HUD.Modules {
                 return false;
 
             if (!this.DependenciesMet) {
-                Logger.Warn($"Module {this.Manifest.Namespace} can not be loaded as not all dependencies are available. Missing: {string.Join(", ", this.GetMissingDependencies().Select(md => $"{md.Namespace} ({md.GetDependencyDetails().CheckResult})"))}");
+                Logger.Warn($"Module {this.Manifest.GetDetailedName()} can not be loaded as not all dependencies are available. Missing: {string.Join(", ", this.GetMissingDependencies().Select(md => $"{md.Namespace} ({md.GetDependencyDetails().CheckResult})"))}");
                 return false;
-            } else if (!_dependenciesAvailable && this.State.IgnoreDependencies) {
-                Logger.Warn($"Module {this.Manifest.Namespace} has not all dependencies available but is set to ignore. Missing: {string.Join(", ", this.GetMissingDependencies().Select(md => $"{md.Namespace} ({md.GetDependencyDetails().CheckResult})"))}");
+            } else if (!this.AreDependenciesAvailable() && this.State.IgnoreDependencies) {
+                Logger.Warn($"Module {this.Manifest.GetDetailedName()} has not all dependencies available but is set to ignore. Missing: {string.Join(", ", this.GetMissingDependencies().Select(md => $"{md.Namespace} ({md.GetDependencyDetails().CheckResult})"))}");
             }
 
             var moduleParams = ModuleParameters.BuildFromManifest(this.Manifest, this);
@@ -150,6 +148,10 @@ namespace Blish_HUD.Modules {
             Disable();
             GameService.Module.UnregisterModule(this);
             this.DataReader.DeleteRoot();
+        }
+
+        private bool AreDependenciesAvailable() {
+            return Manifest.Dependencies.TrueForAll(d => d.GetDependencyDetails().CheckResult == ModuleDependencyCheckResult.Available);
         }
 
         private Assembly LoadPackagedAssembly(string assemblyPath) {

--- a/Blish HUD/GameServices/Modules/ModuleManager.cs
+++ b/Blish HUD/GameServices/Modules/ModuleManager.cs
@@ -73,10 +73,10 @@ namespace Blish_HUD.Modules {
                 return false;
 
             if (!this.DependenciesMet) {
-                Logger.Warn($"Module {this.Manifest.Namespace} can not be loaded as not all dependencies are available. Missing: {string.Join(", ", this.Manifest.Dependencies.Where(d => d.GetDependencyDetails().CheckResult != ModuleDependencyCheckResult.Available).Select(md => $"{md.Namespace} ({md.GetDependencyDetails().CheckResult})"))}");
+                Logger.Warn($"Module {this.Manifest.Namespace} can not be loaded as not all dependencies are available. Missing: {string.Join(", ", this.GetMissingDependencies().Select(md => $"{md.Namespace} ({md.GetDependencyDetails().CheckResult})"))}");
                 return false;
             } else if (!_dependenciesAvailable && this.State.IgnoreDependencies) {
-                Logger.Warn($"Module {this.Manifest.Namespace} has not all dependencies available but is set to ignore. Missing: {string.Join(", ", this.Manifest.Dependencies.Where(d => d.GetDependencyDetails().CheckResult != ModuleDependencyCheckResult.Available).Select(md => $"{md.Namespace} ({md.GetDependencyDetails().CheckResult})"))}");
+                Logger.Warn($"Module {this.Manifest.Namespace} has not all dependencies available but is set to ignore. Missing: {string.Join(", ", this.GetMissingDependencies().Select(md => $"{md.Namespace} ({md.GetDependencyDetails().CheckResult})"))}");
             }
 
             var moduleParams = ModuleParameters.BuildFromManifest(this.Manifest, this);
@@ -140,6 +140,10 @@ namespace Blish_HUD.Modules {
 
             this.State.Enabled = this.Enabled;
             GameService.Settings.Save();
+        }
+
+        private List<ModuleDependency> GetMissingDependencies() {
+            return this.Manifest.Dependencies.Where(d => d.GetDependencyDetails().CheckResult != ModuleDependencyCheckResult.Available).ToList();
         }
 
         public void DeleteModule() {

--- a/Blish HUD/Properties/launchSettings.json
+++ b/Blish HUD/Properties/launchSettings.json
@@ -5,7 +5,7 @@
     },
     "PowerShell HUD": {
       "commandName": "Project",
-      "commandLineArgs": "-p powershell -w ConsoleWindowClass"
+      "commandLineArgs": " --process WindowsTerminal --window \"Windows PowerShell\" "
     }
   }
 }


### PR DESCRIPTION
This PR implements module loading sorted by dependencies. 
This is needed for contexts to work properly if the context class is contained inside the module.


## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/599270434642460753/1160999293361061979

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
