### PR TITLE
Small fixes.

### DIFF
--- a/Blish HUD/ApplicationSettings.cs
+++ b/Blish HUD/ApplicationSettings.cs
@@ -45,6 +45,7 @@ namespace Blish_HUD {
          * P, pid       - The PID of the process to overlay.
          * r, ref       - The path to the ref.dat file.
          * s, settings  - The path where Blish HUD will save settings and other files.
+         * a, progdata  - The path where Blish HUD will save non-user data.
          * w, window    - The name of the window to overlay.
          * g, startgw2  - The start mode for Gw2 (0 = don't start, 1 = start gw2, 2 = start gw2 autologin).
          */
@@ -115,6 +116,16 @@ namespace Blish_HUD {
             Help("The path where Blish HUD will save settings and other files.")
         ]
         public string UserSettingsPath { get; private set; }
+
+        public const string OPTION_PROGRAMDATA = "progdata";
+        /// <summary>
+        /// The path used by Blish HUD to store non-user data related to the application.
+        /// </summary>
+        [
+            OptionParameter(OPTION_PROGRAMDATA, 'a'),
+            Help("The path used by Blish HUD to store non-user data related to the application.")
+        ]
+        public string ProgramDataPath { get; private set; }
 
         public const string OPTION_REFPATH = "ref";
         /// <summary>

--- a/Blish HUD/Controls/Control.cs
+++ b/Blish HUD/Controls/Control.cs
@@ -191,10 +191,12 @@ namespace Blish_HUD.Controls {
         /// </summary>
         protected virtual void OnLeftMouseButtonPressed(MouseEventArgs e) {
             this.LeftMouseButtonPressed?.Invoke(this, e);
+
+            _clickPrimed = true;
         }
 
         private double _lastClickTime = 0;
-
+        private bool _clickPrimed = false;
 
         /// <summary>
         /// Called when a left mouse button release occurs on the <see cref="Control"/>.
@@ -203,7 +205,7 @@ namespace Blish_HUD.Controls {
         protected virtual void OnLeftMouseButtonReleased(MouseEventArgs e) {
             this.LeftMouseButtonReleased?.Invoke(this, e);
 
-            if (_enabled) {
+            if (_enabled && _clickPrimed) {
                 // Distinguish click from double-click
                 if (GameService.Overlay.CurrentGameTime.TotalGameTime.TotalMilliseconds - _lastClickTime < SystemInformation.DoubleClickTime) {
                     OnClick(new MouseEventArgs(e.EventType, true));
@@ -260,6 +262,8 @@ namespace Blish_HUD.Controls {
         /// </summary>
         protected virtual void OnMouseLeft(MouseEventArgs e) {
             this.MouseLeft?.Invoke(this, e);
+
+            _clickPrimed = false;
         }
 
         /// <summary>

--- a/Blish HUD/GameServices/Debug/ContingencyChecks.cs
+++ b/Blish HUD/GameServices/Debug/ContingencyChecks.cs
@@ -102,7 +102,7 @@ namespace Blish_HUD.Debug {
                         SettingValue<uint> settingValue = settingMeta.DwordValues.FirstOrDefault(val => val.Value == value);
                         string val = settingValue?.ValueName ?? value.ToString();
 
-                        errors.Add($"'{settingMeta.SettingName}' should not be '{val}'.");
+                        errors.Add(string.Format(Strings.GameServices.Debug.ContingencyMessages.NvidiaSettings_Error, settingMeta.SettingName, val));
                     }
                 }
 

--- a/Blish HUD/GameServices/Debug/ContingencyChecks.cs
+++ b/Blish HUD/GameServices/Debug/ContingencyChecks.cs
@@ -102,7 +102,7 @@ namespace Blish_HUD.Debug {
                         SettingValue<uint> settingValue = settingMeta.DwordValues.FirstOrDefault(val => val.Value == value);
                         string val = settingValue?.ValueName ?? value.ToString();
 
-                        errors.Add($"'{settingMeta.SettingName}' is '{val}'");
+                        errors.Add($"'{settingMeta.SettingName}' should not be '{val}'.");
                     }
                 }
 

--- a/Blish HUD/GameServices/GameIntegration/WinFormsIntegration.cs
+++ b/Blish HUD/GameServices/GameIntegration/WinFormsIntegration.cs
@@ -19,6 +19,7 @@ namespace Blish_HUD.GameIntegration {
         private ToolStripItem _launchGw2Tsi;
         private ToolStripItem _launchGw2AutoTsi;
         private ToolStripItem _openBlishSettingsFolder;
+        private ToolStripItem _openBlishProgramDataFolder;
         private ToolStripItem _exitTsi;
 
         /// <summary>
@@ -76,12 +77,21 @@ namespace Blish_HUD.GameIntegration {
 
             this.TrayIconMenu.Items.Add(new ToolStripSeparator());
 
+            // Open Settings Folder
             _openBlishSettingsFolder = this.TrayIconMenu.Items.Add(Strings.GameServices.GameIntegrationService.TrayIcon_OpenSettingsFolder);
 
             _openBlishSettingsFolder.Click += delegate {
                 Process.Start(DirectoryUtil.BasePath);
             };
 
+            // Open ProgamData Folder
+            _openBlishProgramDataFolder = this.TrayIconMenu.Items.Add(Strings.GameServices.GameIntegrationService.TrayIcon_OpenProgramDataFolder);
+
+            _openBlishProgramDataFolder.Click += delegate {
+                Process.Start(DirectoryUtil.ProgramData);
+            };
+
+            // ------- & Exit
             this.TrayIconMenu.Items.Add(new ToolStripSeparator());
             _exitTsi = this.TrayIconMenu.Items.Add(string.Format(Strings.Common.Action_Exit,  Strings.Common.BlishHUD));
 

--- a/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyBinding.cs
@@ -136,7 +136,7 @@ namespace Blish_HUD.Input {
         }
 
         private void CheckTrigger(ModifierKeys activeModifiers, IEnumerable<Keys> pressedKeys) {
-            if ((this.ModifierKeys & activeModifiers) == this.ModifierKeys) {
+            if (activeModifiers == this.ModifierKeys) {
                 if (this.BlockSequenceFromGw2) {
                     GameService.Input.Keyboard.StageKeyBinding(this);
                 }

--- a/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.Designer.cs
+++ b/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.Designer.cs
@@ -259,6 +259,15 @@ namespace Blish_HUD.Strings.GameServices.Debug {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; should not be &apos;{1}&apos;.
+        /// </summary>
+        internal static string NvidiaSettings_Error {
+            get {
+                return ResourceManager.GetString("NvidiaSettings_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Open NVIDIA Control Panel.
         /// </summary>
         internal static string NvidiaSettings_OpenControlPanelAction {

--- a/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.de.resx
+++ b/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.de.resx
@@ -176,4 +176,29 @@ Wenn du ein Antivirus Programm oder eine Firewall verwendest, dann füge Blish H
   <data name="CoreUpdateFailed_Description_Timeout" xml:space="preserve">
     <value>Eine weitere Instanz von Blish HUD läuft bereits. Bitte schließe diese und versuche dann erneut Blish HUD zu aktualisieren.</value>
   </data>
+  <data name="NvidiaSettings_Description" xml:space="preserve">
+    <value>Eine Ihrer NVIDIA-Einstellungen wurde auf eine Weise geändert, die nicht mit Blish HUD kompatibel ist (Blish HUD wird einen schwarzen Hintergrund haben).
+
+Diese Einstellungen müssen auf die Standardeinstellungen zurückgesetzt werden:
+{0}
+
+Siehe den verlinkten Fehlerbehebungsleitfaden für weitere Informationen zur Behebung dieses Problems.</value>
+  </data>
+  <data name="NvidiaSettings_Error" xml:space="preserve">
+    <value>'{0}' sollte nicht '{1}' sein</value>
+  </data>
+  <data name="NvidiaSettings_OpenControlPanelAction" xml:space="preserve">
+    <value>NVIDIA-Systemsteuerung öffnen</value>
+  </data>
+  <data name="NvidiaSettings_Title" xml:space="preserve">
+    <value>Inkompatible NVIDIA-Einstellungen</value>
+  </data>
+  <data name="CfaBlocking_Description" xml:space="preserve">
+    <value>Blish HUD wurde aktiv daran gehindert, in '{0}' zu speichern, was auf die Kontrollierte Ordnerzugriff-Funktion von Windows zurückzuführen zu sein scheint.
+
+Bitte erlauben Sie Blish HUD ausdrücklich in Ihren Einstellungen für den Kontrollierten Ordnerzugriff oder beachten Sie den unten verlinkten Fehlerbehebungsleitfaden.</value>
+  </data>
+  <data name="CfaBlocking_Title" xml:space="preserve">
+    <value>Blish HUD Blockiert!</value>
+  </data>
 </root>

--- a/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.fr.resx
+++ b/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.fr.resx
@@ -138,7 +138,7 @@ Relancez Blish HUD en tant qu'administrateur, ou relancez Guild Wars 2 sans le m
     <value>Blish HUD a besoin d'être re-extrait !</value>
   </data>
   <data name="MissingRef_Description" xml:space="preserve">
-    <value>Blish HUD a été incapable de localiser le fichier ref.dat. Quand vous téléchargez Blish HUD, faites attention à bien extraire tous les fichiers du zip et que tous les fichiers soient bien dans le même dossier que Blish HUD.exe</value>
+    <value>Blish HUD a été incapable de localiser le fichier ref.dat. Quand vous téléchargez Blish HUD, faites attention à bien extraire tous les fichiers du zip et que tous les fichiers soient bien dans le même dossier que Blish HUD.exe.</value>
   </data>
   <data name="FileSaveAccessDenied_Title" xml:space="preserve">
     <value>Blish HUD a été bloqué lors de la sauvegarde de données !</value>
@@ -175,5 +175,30 @@ Si vous avez un anti-virus ou utilisez un pare-feu tiers, merci de vérifier que
   </data>
   <data name="CoreUpdateFailed_Description_Timeout" xml:space="preserve">
     <value>Il y a d'autres instances de Blish HUD de lancée. Merci de fermer les autres instances avant de relancer Blish HUD pour finir la mise à jour.</value>
+  </data>
+  <data name="NvidiaSettings_Error" xml:space="preserve">
+    <value>'{0}' ne devrait pas être '{1}'</value>
+  </data>
+  <data name="NvidiaSettings_Description" xml:space="preserve">
+    <value>Un de vos paramètres NVIDIA a été modifié de manière incompatible avec Blish HUD (Blish HUD aura un fond noir).
+
+Ces paramètres doivent être réinitialisés par défaut :
+{0}
+
+Consultez le guide de dépannage lié pour plus d'informations sur la façon de résoudre ce problème.</value>
+  </data>
+  <data name="NvidiaSettings_OpenControlPanelAction" xml:space="preserve">
+    <value>Ouvrir le panneau de contrôle NVIDIA</value>
+  </data>
+  <data name="NvidiaSettings_Title" xml:space="preserve">
+    <value>Paramètres NVIDIA Incompatibles</value>
+  </data>
+  <data name="CfaBlocking_Description" xml:space="preserve">
+    <value>Blish HUD a été bloqué activement pour enregistrer dans '{0}' par ce qui semble être la fonctionnalité d'accès aux dossiers contrôlés de Windows.
+
+Veuillez autoriser explicitement Blish HUD dans vos paramètres d'accès aux dossiers contrôlés ou consultez le guide de dépannage ci-dessous.</value>
+  </data>
+  <data name="CfaBlocking_Title" xml:space="preserve">
+    <value>Blish HUD Bloqué !</value>
   </data>
 </root>

--- a/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.resx
+++ b/Blish HUD/Strings/GameServices/Debug/ContingencyMessages.resx
@@ -209,4 +209,7 @@ See the linked troubleshooting guide for more information on how to resolve this
 
 You can reference the guide linked below for further assistance.</value>
   </data>
+  <data name="NvidiaSettings_Error" xml:space="preserve">
+    <value>'{0}' should not be '{1}'</value>
+  </data>
 </root>

--- a/Blish HUD/Strings/GameServices/GameIntegrationService.Designer.cs
+++ b/Blish HUD/Strings/GameServices/GameIntegrationService.Designer.cs
@@ -19,7 +19,7 @@ namespace Blish_HUD.Strings.GameServices {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class GameIntegrationService {
@@ -75,6 +75,15 @@ namespace Blish_HUD.Strings.GameServices {
         internal static string TrayIcon_LaunchGuildWars2 {
             get {
                 return ResourceManager.GetString("TrayIcon_LaunchGuildWars2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open ProgramData folder.
+        /// </summary>
+        internal static string TrayIcon_OpenProgramDataFolder {
+            get {
+                return ResourceManager.GetString("TrayIcon_OpenProgramDataFolder", resourceCulture);
             }
         }
         

--- a/Blish HUD/Strings/GameServices/GameIntegrationService.de.resx
+++ b/Blish HUD/Strings/GameServices/GameIntegrationService.de.resx
@@ -126,4 +126,7 @@
   <data name="TrayIcon_OpenSettingsFolder" xml:space="preserve">
     <value>Öffne Einstellungsverzeichnis</value>
   </data>
+  <data name="TrayIcon_OpenProgramDataFolder" xml:space="preserve">
+    <value>ProgramData-Ordner öffnen</value>
+  </data>
 </root>

--- a/Blish HUD/Strings/GameServices/GameIntegrationService.fr.resx
+++ b/Blish HUD/Strings/GameServices/GameIntegrationService.fr.resx
@@ -126,4 +126,7 @@
   <data name="TrayIcon_OpenSettingsFolder" xml:space="preserve">
     <value>Ouvrir le dossier des paramètres</value>
   </data>
+  <data name="TrayIcon_OpenProgramDataFolder" xml:space="preserve">
+    <value>Ouvrir le dossier ProgramData</value>
+  </data>
 </root>

--- a/Blish HUD/Strings/GameServices/GameIntegrationService.resx
+++ b/Blish HUD/Strings/GameServices/GameIntegrationService.resx
@@ -126,4 +126,7 @@
   <data name="TrayIcon_OpenSettingsFolder" xml:space="preserve">
     <value>Open settings folder</value>
   </data>
+  <data name="TrayIcon_OpenProgramDataFolder" xml:space="preserve">
+    <value>Open ProgramData folder</value>
+  </data>
 </root>

--- a/Blish HUD/_Utils/DirectoryUtil.cs
+++ b/Blish HUD/_Utils/DirectoryUtil.cs
@@ -14,7 +14,9 @@ namespace Blish_HUD {
 
         private const string MUSIC_DIR = @"Guild Wars 2\Music";
 
-        private const string CACHE_DIR = @"Blish HUD\cache";
+        private const string PROGRAMDATA_DIR = "Blish HUD";
+
+        private const string CACHE_DIR = @"cache";
 
         /// <summary>
         /// The current root application save path used for saving settings, letting modules save data, etc.
@@ -35,7 +37,13 @@ namespace Blish_HUD {
         public static string MusicPath { get; }
 
         /// <summary>
-        /// The path used by Blish HUD to store shared cache data.  This is kept in %ProgramData% by default.
+        /// The path used by Blish HUD to store non-user data related to the application.  This is kept in '%ProgramData%\Blish HUD' by default.
+        /// This directory should likely not contain module data.
+        /// </summary>
+        public static string ProgramData { get; set; }
+
+        /// <summary>
+        /// The path used by Blish HUD to store shared cache data.  This is kept in \cache under <see cref="ProgramData"/>.
         /// </summary>
         public static string CachePath { get; }
 
@@ -43,7 +51,7 @@ namespace Blish_HUD {
             // Prepare user documents directory
             // Check if Blish directory contains "Settings" folder
             // in that case override MyDocuments location as default for portability
-            // --settings cli argument has still priority
+            // --settings cli argument still has priority
             if (Directory.Exists(Path.Combine(Directory.GetCurrentDirectory(), "Settings"))) {
                 BasePath = ApplicationSettings.Instance.UserSettingsPath
                         ?? Path.Combine(Directory.GetCurrentDirectory(), "Settings");
@@ -54,11 +62,15 @@ namespace Blish_HUD {
                                         ADDON_DIR);
             }
 
-            CreateDir(BasePath);
+            // Directories under ProgramData
+            CreateDir(ProgramData = ApplicationSettings.Instance.ProgramDataPath
+                                 ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData,
+                                                                           Environment.SpecialFolderOption.DoNotVerify), PROGRAMDATA_DIR));
 
-            // Cache path is shared and not kept within the standard settings folder.
-            CreateDir(CachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData,
-                                                                         Environment.SpecialFolderOption.DoNotVerify), CACHE_DIR));
+            CreateDir(CachePath = Path.Combine(ProgramData, CACHE_DIR));
+
+            // Directories under documents
+            CreateDir(BasePath);
 
             CreateDir(ScreensPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments,
                                                                            Environment.SpecialFolderOption.DoNotVerify), SCREENS_DIR));


### PR DESCRIPTION
- Revised the Nvidia warming message to make it more obvious what the ask is.
- Added "Open ProgramData folder" option to the tray icon.
- Fixed #862 by ensuring the modifiers must match exactly and not just be a subset.
- Fixed #768 Click events from firing unless the mouse started the click on the control (we still trigger the click event on mouse up as intended).
