### PR TITLE
#945 Add utc offset to log timestamps

### DIFF
--- a/Blish HUD/GameServices/DebugService.cs
+++ b/Blish HUD/GameServices/DebugService.cs
@@ -37,7 +37,7 @@ namespace Blish_HUD {
 
         private static LoggingConfiguration _logConfiguration;
 
-        private const string STRUCLOG_TIME      = "${date:universalTime=false:format=HH\\:mm\\:ss.mmm K}"; // Default culture is invariant
+        private const string STRUCLOG_TIME      = "${date:universalTime=false:format=HH\\:mm\\:ss.ffff K}"; // Default culture is invariant
         private const string STRUCLOG_LEVEL     = "${level:uppercase=true:padding=-5}";
         private const string STRUCLOG_LOGGER    = "${logger}";
         private const string STRUCLOG_MESSAGE   = "${message}";

--- a/Blish HUD/GameServices/DebugService.cs
+++ b/Blish HUD/GameServices/DebugService.cs
@@ -37,7 +37,7 @@ namespace Blish_HUD {
 
         private static LoggingConfiguration _logConfiguration;
 
-        private const string STRUCLOG_TIME      = "${time:invariant=true}";
+        private const string STRUCLOG_TIME      = "${date:universalTime=false:format=HH\\:mm\\:ss.mmm K}"; // Default culture is invariant
         private const string STRUCLOG_LEVEL     = "${level:uppercase=true:padding=-5}";
         private const string STRUCLOG_LOGGER    = "${logger}";
         private const string STRUCLOG_MESSAGE   = "${message}";


### PR DESCRIPTION
This PR adds the timezone information to the log timestamps.

The new format results in timestamps like this: `20:03:20.03 +01:00 | INFO  | Blish_HUD.Program | Running PreRelease "local-dev"`


## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/536970543736291346/1216456887579574363

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No, except someone parses the log in a way that breaks with the new syntax
