### PR TITLE
Target Framework & Packages Update

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Platforms>x64</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>WinExe</OutputType>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>Blish_HUD</RootNamespace>
     <ApplicationIcon>blishraster2_0dw_icon.ico</ApplicationIcon>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -234,30 +234,30 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncClipboardService" Version="[1.7.1]" />
-    <PackageReference Include="DynamicLanguageRuntime" Version="1.3.2" PrivateAssets="all" />
+    <PackageReference Include="AsyncClipboardService" Version="1.7.1" />
+    <PackageReference Include="DynamicLanguageRuntime" Version="1.3.4" PrivateAssets="all" />
     <PackageReference Include="EntryPoint" Version="1.3.0" PrivateAssets="all" />
-    <PackageReference Include="Flurl.Http" Version="2.4.2" PrivateAssets="all" />
+    <PackageReference Include="Flurl.Http" Version="4.0.2" PrivateAssets="all" />
     <PackageReference Include="Gapotchenko.FX.Diagnostics.Process" Version="2022.2.7" PrivateAssets="all" />
     <PackageReference Include="Gw2Sharp" Version="1.7.4" />
-    <PackageReference Include="Humanizer.Core.de" Version="2.6.2" PrivateAssets="all" />
-    <PackageReference Include="Humanizer.Core.es" Version="2.6.2" PrivateAssets="all" />
-    <PackageReference Include="Humanizer.Core.fr" Version="2.6.2" PrivateAssets="all" />
-    <PackageReference Include="JsonSubTypes" Version="1.6.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.0.1641" PrivateAssets="all" />
-    <PackageReference Include="MonoGame.Extended" Version="[3.8.0]" />
-    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8.0" PrivateAssets="all" />
-    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="[3.8.0.1641]" />
-    <PackageReference Include="NAudio.Wasapi" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="[13.0.1]" />
-    <PackageReference Include="NLog" Version="4.6.7" PrivateAssets="all" />
-    <PackageReference Include="SemanticVersioning" Version="1.2.2" PrivateAssets="all" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.14.1" PrivateAssets="all" />
-    <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
-    <PackageReference Include="protobuf-net" Version="3.0.101" PrivateAssets="all" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
+    <PackageReference Include="Humanizer.Core.de" Version="2.14.1" PrivateAssets="all" />
+    <PackageReference Include="Humanizer.Core.es" Version="2.14.1" PrivateAssets="all" />
+    <PackageReference Include="Humanizer.Core.fr" Version="2.14.1" PrivateAssets="all" />
+    <PackageReference Include="JsonSubTypes" Version="2.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
+    <PackageReference Include="MonoGame.Extended" Version="3.8.0" />
+    <PackageReference Include="MonoGame.Framework.Content.Pipeline" Version="3.8.1.303" />
+    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.1.303" />
+    <PackageReference Include="NAudio.Wasapi" Version="2.2.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NLog" Version="5.2.8" PrivateAssets="all" />
+	<PackageReference Include="SemanticVersioning" Version="2.0.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.0" PrivateAssets="all" />
+    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
+    <PackageReference Include="protobuf-net" Version="3.2.30" PrivateAssets="all" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Blish HUD/GameServices/Content/Serialization/SemVerConverter.cs
+++ b/Blish HUD/GameServices/Content/Serialization/SemVerConverter.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Newtonsoft.Json;
-using Version = SemVer.Version;
+using Version = SemanticVersioning.Version;
 
 namespace Blish_HUD.Content.Serialization {
-    public class SemVerConverter : JsonConverter<SemVer.Version> {
+    public class SemVerConverter : JsonConverter<SemanticVersioning.Version> {
 
         /// <inheritdoc />
         public override void WriteJson(JsonWriter writer, Version value, JsonSerializer serializer) {
@@ -12,7 +12,7 @@ namespace Blish_HUD.Content.Serialization {
 
         /// <inheritdoc />
         public override Version ReadJson(JsonReader reader, Type objectType, Version existingValue, bool hasExistingValue, JsonSerializer serializer) {
-             return new SemVer.Version((string)reader.Value, true);
+             return new SemanticVersioning.Version((string)reader.Value, true);
         }
 
     }

--- a/Blish HUD/GameServices/Contexts/CdnInfoContext.cs
+++ b/Blish HUD/GameServices/Contexts/CdnInfoContext.cs
@@ -148,7 +148,7 @@ namespace Blish_HUD.Contexts {
                 return await cdnUrl.GetStringAsync();
             } catch (FlurlHttpException ex) {
                 if (ex.Call.Response != null) {
-                    Logger.Warn(ex, "Failed to get CDN information from {cdnUrl}.  HTTP response status was ({httpStatusCode}) {statusReason}.", cdnUrl, (int)ex.Call.Response.StatusCode, ex.Call.Response.ReasonPhrase);
+                    Logger.Warn(ex, "Failed to get CDN information from {cdnUrl}.  HTTP response status was ({httpStatusCode}) {statusReason}.", cdnUrl, (int)ex.Call.Response.StatusCode, ex.Call.Response.ResponseMessage);
                 } else {
                     Logger.Warn(ex, "Failed to get CDN information from {cdnUrl}.  No response was received.", cdnUrl);
                 }

--- a/Blish HUD/GameServices/Debug/Contingency.cs
+++ b/Blish HUD/GameServices/Debug/Contingency.cs
@@ -99,11 +99,11 @@ namespace Blish_HUD.Debug {
                               "https://link.blishhud.com/httpaccessdenied");
         }
 
-        public static void NotifyCoreUpdateFailed(SemVer.Version version, Exception failureException) {
+        public static void NotifyCoreUpdateFailed(SemanticVersioning.Version version, Exception failureException) {
             NotifyCoreUpdateFailed(version, failureException.Message);
         }
 
-        public static void NotifyCoreUpdateFailed(SemVer.Version version, string message) {
+        public static void NotifyCoreUpdateFailed(SemanticVersioning.Version version, string message) {
             NotifyContingency(nameof(NotifyCoreUpdateFailed),
                               Strings.GameServices.Debug.ContingencyMessages.CoreUpdateFailed_Title,
                               string.Format(Strings.GameServices.Debug.ContingencyMessages.CoreUpdateFailed_Description, version, message),

--- a/Blish HUD/GameServices/Modules/Manifest.cs
+++ b/Blish HUD/GameServices/Modules/Manifest.cs
@@ -17,7 +17,7 @@ namespace Blish_HUD.Modules {
         public string Name { get; private set; }
 
         [JsonProperty("version", Required = Required.Always), JsonConverter(typeof(Content.Serialization.SemVerConverter))]
-        public SemVer.Version Version { get; private set; }
+        public SemanticVersioning.Version Version { get; private set; }
 
         [JsonProperty("namespace", Required = Required.Always)]
         public string Namespace { get; private set; }

--- a/Blish HUD/GameServices/Modules/Module.cs
+++ b/Blish HUD/GameServices/Modules/Module.cs
@@ -75,7 +75,7 @@ namespace Blish_HUD.Modules {
 
         public string Namespace => ModuleParameters.Manifest.Namespace;
 
-        public SemVer.Version Version => ModuleParameters.Manifest.Version;
+        public SemanticVersioning.Version Version => ModuleParameters.Manifest.Version;
 
         #endregion
 

--- a/Blish HUD/GameServices/Modules/ModuleDependency.cs
+++ b/Blish HUD/GameServices/Modules/ModuleDependency.cs
@@ -2,8 +2,8 @@
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using Range = SemVer.Range;
-using Version = SemVer.Version;
+using Range = SemanticVersioning.Range;
+using Version = SemanticVersioning.Version;
 
 namespace Blish_HUD.Modules {
 

--- a/Blish HUD/GameServices/Modules/ModuleDependencyCheckDetails.cs
+++ b/Blish HUD/GameServices/Modules/ModuleDependencyCheckDetails.cs
@@ -1,4 +1,4 @@
-﻿using SemVer;
+﻿using SemanticVersioning;
 
 namespace Blish_HUD.Modules {
     public struct ModuleDependencyCheckDetails {

--- a/Blish HUD/GameServices/Modules/ModulePkgRepoHandler.cs
+++ b/Blish HUD/GameServices/Modules/ModulePkgRepoHandler.cs
@@ -89,7 +89,7 @@ namespace Blish_HUD.Modules {
 
         private bool GetUpdateIsNotAcknowledged(PkgManifest modulePkg) {
             if (_acknowledgedUpdates.TryGetSetting(modulePkg.Namespace, out var setting) && setting is SettingEntry<string> acknowledgedModuleUpdate) {
-                return modulePkg.Version > new SemVer.Version(acknowledgedModuleUpdate.Value, true);
+                return modulePkg.Version > new SemanticVersioning.Version(acknowledgedModuleUpdate.Value, true);
             }
 
             return true;

--- a/Blish HUD/GameServices/Modules/Pkgs/PkgManifest.cs
+++ b/Blish HUD/GameServices/Modules/Pkgs/PkgManifest.cs
@@ -18,7 +18,7 @@ namespace Blish_HUD.Modules.Pkgs {
         public string Namespace { get; private set; }
 
         [JsonProperty("version", Required = Required.Always), JsonConverter(typeof(Content.Serialization.SemVerConverter))]
-        public SemVer.Version Version { get; private set; }
+        public SemanticVersioning.Version Version { get; private set; }
         
         [JsonProperty("contributors", Required = Required.Always)]
         public List<ModuleContributor> Contributors { get; private set; }

--- a/Blish HUD/GameServices/Modules/UI/Presenters/ManagePkgPresenter.cs
+++ b/Blish HUD/GameServices/Modules/UI/Presenters/ManagePkgPresenter.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Blish_HUD.Graphics.UI;
 using Blish_HUD.Modules.Pkgs;
 using Blish_HUD.Modules.UI.Views;
-using Version = SemVer.Version;
+using Version = SemanticVersioning.Version;
 
 namespace Blish_HUD.Modules.UI.Presenters {
     public class ManagePkgPresenter : Presenter<ManagePkgView, IGrouping<string, PkgManifest>> {

--- a/Blish HUD/GameServices/Modules/UI/Views/ManageModuleView.cs
+++ b/Blish HUD/GameServices/Modules/UI/Views/ManageModuleView.cs
@@ -5,7 +5,7 @@ using Blish_HUD.Controls;
 using Blish_HUD.Graphics.UI;
 using Blish_HUD.Modules.UI.Presenters;
 using Microsoft.Xna.Framework;
-using Version = SemVer.Version;
+using Version = SemanticVersioning.Version;
 
 namespace Blish_HUD.Modules.UI.Views {
     public class ManageModuleView : View {

--- a/Blish HUD/GameServices/Modules/UI/Views/ManagePkgView.cs
+++ b/Blish HUD/GameServices/Modules/UI/Views/ManagePkgView.cs
@@ -11,7 +11,7 @@ using Blish_HUD.Modules.Pkgs;
 using Blish_HUD.Modules.UI.Presenters;
 using Microsoft.Scripting.Utils;
 using Microsoft.Xna.Framework;
-using Version = SemVer.Version;
+using Version = SemanticVersioning.Version;
 
 namespace Blish_HUD.Modules.UI.Views {
 

--- a/Blish HUD/GameServices/Overlay/CoreVersionManifest.cs
+++ b/Blish HUD/GameServices/Overlay/CoreVersionManifest.cs
@@ -1,5 +1,5 @@
 ﻿using Newtonsoft.Json;
-using Version = SemVer.Version;
+using Version = SemanticVersioning.Version;
 
 namespace Blish_HUD.Overlay {
     public struct CoreVersionManifest {

--- a/Blish HUD/GameServices/Overlay/OverlayUpdateHandler.cs
+++ b/Blish HUD/GameServices/Overlay/OverlayUpdateHandler.cs
@@ -19,15 +19,15 @@ namespace Blish_HUD.Overlay {
 
         private CoreVersionManifest[] _availableUpdates = Array.Empty<CoreVersionManifest>();
 
-        private SettingEntry<SemVer.Version> _lastAcknowledgedUpdate;
+        private SettingEntry<SemanticVersioning.Version> _lastAcknowledgedUpdate;
         private SettingEntry<bool>           _notifyOfNewReleases;
 
         private int _releaseLoadAttemptsRemaining = 3;
 
         /// <summary>
-        /// The last update <see cref="SemVer.Version"/> that was acknowledged by the user.
+        /// The last update <see cref="SemanticVersioning.Version"/> that was acknowledged by the user.
         /// </summary>
-        public SemVer.Version LastAcknowledgedRelease {
+        public SemanticVersioning.Version LastAcknowledgedRelease {
             get => _lastAcknowledgedUpdate.Value;
             set => _lastAcknowledgedUpdate.Value = value;
         }
@@ -54,7 +54,7 @@ namespace Blish_HUD.Overlay {
         }
 
         private void DefineOverlayUpdateSettings(SettingCollection settingCollection) {
-            _lastAcknowledgedUpdate = settingCollection.DefineSetting(nameof(this.LastAcknowledgedRelease), new SemVer.Version("0.0.0"));
+            _lastAcknowledgedUpdate = settingCollection.DefineSetting(nameof(this.LastAcknowledgedRelease), new SemanticVersioning.Version("0.0.0"));
             _notifyOfNewReleases    = settingCollection.DefineSetting(nameof(this.NotifyOfNewRelease),      true);
         }
 

--- a/Blish HUD/Program.cs
+++ b/Blish HUD/Program.cs
@@ -17,7 +17,7 @@ namespace Blish_HUD {
 
         private const string APP_GUID = "{5802208e-71ca-4745-ab1b-d851bc17a460}";
 
-        public static SemVer.Version OverlayVersion { get; } = new SemVer.Version(typeof(BlishHud).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion, true);
+        public static SemanticVersioning.Version OverlayVersion { get; } = new SemanticVersioning.Version(typeof(BlishHud).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion, true);
 
         internal static bool RestartOnExit { get; set; } = false;
 

--- a/Blish HUD/_Extensions/VersionExtensions.cs
+++ b/Blish HUD/_Extensions/VersionExtensions.cs
@@ -3,7 +3,7 @@
 namespace Blish_HUD {
     internal static class VersionExtensions {
 
-        public static string BaseAndPrerelease(this SemVer.Version version) {
+        public static string BaseAndPrerelease(this SemanticVersioning.Version version) {
             return version.ToString().Split(new char[]{ '+' }, StringSplitOptions.RemoveEmptyEntries)[0];
         }
 

--- a/nspector/nspector.csproj
+++ b/nspector/nspector.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net8.0-windows</TargetFramework>
     </PropertyGroup>
     
     <ItemGroup>


### PR DESCRIPTION
## Key Points
All packages now use the latest version.
Target Framework has now been set to net8.0-windows.
SemVer was changed to SemanticVersioning due to that being the actual package that was included originally
ex.Call.Response.ReasonPhrase updated to ex.Call.Response.ResponseMessage since ReasonPhrase was replaced in newer versions

## Discussion Reference
https://discord.com/channels/531175899588984842/536970543736291346/123123123123123
(Awaiting approval to discuss in the channel)

## Is this a breaking change?
No
