### PR TITLE
feat: add ModuleLoaded event to ModuleManager

### DIFF
--- a/Blish HUD/GameServices/Modules/ModuleManager.cs
+++ b/Blish HUD/GameServices/Modules/ModuleManager.cs
@@ -18,6 +18,12 @@ namespace Blish_HUD.Modules {
         public event EventHandler<EventArgs> ModuleEnabled;
         public event EventHandler<EventArgs> ModuleDisabled;
 
+        public event EventHandler<EventArgs> ModuleLoaded;
+
+        public void OnModuleLoaded(object _, EventArgs e) {
+            this.ModuleLoaded?.Invoke(this, e);
+        }
+
         private Assembly _moduleAssembly;
         
         private bool _forceAllowDependency = false;
@@ -84,6 +90,8 @@ namespace Blish_HUD.Modules {
                             _dirtyNamespaces.Add(this.Manifest.Namespace);
                         }
 
+                        this.ModuleInstance.ModuleLoaded += OnModuleLoaded;
+
                         this.Enabled = true;
 
                         try {
@@ -112,6 +120,10 @@ namespace Blish_HUD.Modules {
             if (!this.Enabled) return;
 
             this.Enabled = false;
+
+            if (this.ModuleInstance != null) {
+                this.ModuleInstance.ModuleLoaded -= OnModuleLoaded;
+            }
 
             try {
                 this.ModuleInstance?.Dispose();
@@ -246,7 +258,9 @@ namespace Blish_HUD.Modules {
             GameService.Module.UnregisterModule(this);
 
             this.ModuleEnabled = null;
-            this.ModuleEnabled = null;
+            this.ModuleDisabled = null;
+
+            this.ModuleLoaded = null;
 
             _moduleAssembly = null;
 


### PR DESCRIPTION
Pass on the `Module.ModuleLoaded` event to a new `ModuleManager.ModuleLoaded` event, when the module is enabled.

This makes it easier to ensure load order for dependent modules when accessing the parent module. Right now there's no straightforward way of doing this.
 Related to #923.

Just because i stumbled over it, there is also a one line fix in here:
fix: set ModuleDisabled to null when disposing ModuleManager

## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/599270434642460753/1228126988640718858

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
