### PR TITLE
fix: fix panel header icon texture check

### DIFF
--- a/Blish HUD/Controls/Panel.cs
+++ b/Blish HUD/Controls/Panel.cs
@@ -256,7 +256,7 @@ namespace Blish_HUD.Controls {
 
             _layoutHeaderBounds     = new Rectangle(this.ContentRegion.Left,       0, this.ContentRegion.Width,       HEADER_HEIGHT);
 
-            if (_icon?.HasTexture != null) {
+            if (_icon?.HasTexture == true) {
 
                 _layoutHeaderIconBounds = new Rectangle(_layoutHeaderBounds.Left + 3, 3, HEADER_HEIGHT - 6, HEADER_HEIGHT - 6);
                 _layoutHeaderTextBounds = new Rectangle(_layoutHeaderIconBounds.Right + 5, 0, _layoutHeaderBounds.Width - _layoutHeaderIconBounds.Width, HEADER_HEIGHT);
@@ -352,7 +352,7 @@ namespace Blish_HUD.Controls {
                 }
 
                 // Panel header icon
-                if (_icon?.HasTexture != null) {
+                if (_icon?.HasTexture == true) {
                     spriteBatch.DrawOnCtrl(this, _icon, _layoutHeaderIconBounds, Color.White);
                 }
 


### PR DESCRIPTION
Fixes a potential crash, where the `AsyncTexture2D Panel._icon` is not `null`, but it's internal `AsyncTexture2D._activeTexture2D` is `null`.

This may happen if 
- the `AsyncTexture2D` is instantiated like `new AsyncTexture2D(null)`
- `AsyncTexture2D.SwapTexture(Texture2D)` is called like `SwapTexture(null)`

## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

PM discussion

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
