### PR TITLE
Fixed self update for certain zip files.

### DIFF
--- a/Blish HUD/GameServices/Overlay/SelfUpdater/SelfUpdateUtil.cs
+++ b/Blish HUD/GameServices/Overlay/SelfUpdater/SelfUpdateUtil.cs
@@ -67,13 +67,16 @@ namespace Blish_HUD.Overlay.SelfUpdater {
 
             var applicationDir = Directory.GetCurrentDirectory();
 
-            var rootDirs  = unpacker.Entries.Where(entry => string.IsNullOrWhiteSpace(entry.Name)  && entry.FullName.IndexOf('/') == entry.FullName.Length - 1);
+            var rootDirs  = unpacker.Entries
+                .Select(entry => entry.FullName.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries))
+                .Where(parts => parts.Length > 1)
+                .Select(parts => parts[0] + "/")
+                .Distinct()
+                .ToList();
             var allFiles  = unpacker.Entries.Where(entry => !string.IsNullOrWhiteSpace(entry.Name) && !string.Equals(entry.Name, FILE_EXE));
             var rootFiles = allFiles.Where(entry => !entry.FullName.Contains("/"));
 
-            foreach (var dir in rootDirs) {
-                string dirPath = Path.Combine(applicationDir, dir.FullName);
-
+            foreach (var dirPath in rootDirs) {
                 if (Directory.Exists(dirPath)) {
                     Directory.Delete(dirPath, true);
                 }


### PR DESCRIPTION
I previously assumed that all zip files included entries for the directories.  This assumption was incorrect.  As it turns out, this is optional, and some utilities do not give directories their own entry.

This new logic ensures that regardless of how the zip is packed, we correctly get a list of the root directories to delete.