### PR TITLE
feat: add IsAvailableChanged event to Gw2MumbleService

### DIFF
--- a/Blish HUD/GameServices/Gw2MumbleService.cs
+++ b/Blish HUD/GameServices/Gw2MumbleService.cs
@@ -16,6 +16,23 @@ namespace Blish_HUD {
 
         private readonly IGw2Client _gw2Client;
 
+        #region Events
+
+        /// <summary>
+        /// Fires when the availability status changes.
+        /// </summary>
+        public event EventHandler<ValueEventArgs<bool>> IsAvailableChanged;
+
+        private void OnIsAvailableChanged(ValueEventArgs<bool> e) => IsAvailableChanged?.Invoke(this, e);
+
+        private bool _prevIsAvailable = false;
+
+        private void HandleEvents() {
+            MumbleEventImpl.CheckAndHandleEvent(ref _prevIsAvailable, this.IsAvailable, OnIsAvailableChanged);
+        }
+
+        #endregion
+
         /// <inheritdoc cref="Gw2MumbleClient"/>
         public IGw2MumbleClient RawClient { get; private set; }
 
@@ -89,6 +106,7 @@ namespace Blish_HUD {
             this.TimeSinceTick += gameTime.ElapsedGameTime;
 
             this.RawClient.Update();
+            HandleEvents();
 
             if (this.RawClient.Tick > _prevTick) {
                 _prevTick = this.RawClient.Tick;

--- a/Blish HUD/GameServices/Gw2MumbleService.cs
+++ b/Blish HUD/GameServices/Gw2MumbleService.cs
@@ -23,9 +23,9 @@ namespace Blish_HUD {
         /// </summary>
         public event EventHandler<ValueEventArgs<bool>> IsAvailableChanged;
 
-        private void OnIsAvailableChanged(ValueEventArgs<bool?> e) => IsAvailableChanged?.Invoke(this, new ValueEventArgs<bool>(e.Value.Value));
+        private void OnIsAvailableChanged(ValueEventArgs<bool> e) => IsAvailableChanged?.Invoke(this, e);
 
-        private bool? _prevIsAvailable = null;
+        private bool _prevIsAvailable = false;
 
         private void HandleEvents() {
             MumbleEventImpl.CheckAndHandleEvent(ref _prevIsAvailable, this.IsAvailable, OnIsAvailableChanged);

--- a/Blish HUD/GameServices/Gw2MumbleService.cs
+++ b/Blish HUD/GameServices/Gw2MumbleService.cs
@@ -23,9 +23,9 @@ namespace Blish_HUD {
         /// </summary>
         public event EventHandler<ValueEventArgs<bool>> IsAvailableChanged;
 
-        private void OnIsAvailableChanged(ValueEventArgs<bool> e) => IsAvailableChanged?.Invoke(this, e);
+        private void OnIsAvailableChanged(ValueEventArgs<bool?> e) => IsAvailableChanged?.Invoke(this, new ValueEventArgs<bool>(e.Value.Value));
 
-        private bool _prevIsAvailable = false;
+        private bool? _prevIsAvailable = null;
 
         private void HandleEvents() {
             MumbleEventImpl.CheckAndHandleEvent(ref _prevIsAvailable, this.IsAvailable, OnIsAvailableChanged);


### PR DESCRIPTION
Adds an `IsAvailableChanged` event to the `Gw2MumbleService`. Implemented the same way the other mumble events are implemented.

This is useful for handling the (un)availability of the  `Gw2MumbleService`. With this change, a module can listen to the event instead of regularly checking `Gw2MumbleService.IsAvailable`.

Remark: When subscribing to the event, the user still has to check `Gw2MumbleService.IsAvailable` once, because the event only fires when the value changes, regardless of it's value at the time of subscription.

## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/536970543736291346/1235308611706687529

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No