### PR TITLE
Initial implementation of the event bus service

### DIFF
--- a/Blish HUD/GameServices/EventBusService.cs
+++ b/Blish HUD/GameServices/EventBusService.cs
@@ -1,0 +1,115 @@
+﻿using Blish_HUD.ArcDps;
+using Blish_HUD.GameServices.Modules.Managers;
+using Gw2Sharp.WebApi.V2.Models;
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blish_HUD.GameServices {
+    public class EventBusService : GameService {
+        protected static readonly Logger Logger = Logger.GetLogger<EventBusService>();
+
+        private ConcurrentDictionary<string, ConcurrentBag<Func<object, Task>>> _subscriptions;
+
+        protected override void Initialize() {
+            this._subscriptions = new ConcurrentDictionary<string, ConcurrentBag<Func<object, Task>>>();
+        }
+
+        protected override void Load() { }
+
+        protected override void Unload() {
+            this._subscriptions.Clear();
+            this._subscriptions = null;
+        }
+
+        protected override void Update(GameTime gameTime) { }
+
+        /// <summary>
+        ///     Sends the content to all subscribers for the specified event.
+        /// </summary>
+        /// <param name="moduleNamespace">The namespace of the module.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="content">To content to send to all subscribers.</param>
+        /// <param name="silentNoSubscribers">False, if an exception should be thrown if no subscribers are found; Otherwise false.</param>
+        /// <returns>The task that represents the current method.</returns>
+        /// <exception cref="InvalidOperationException">If the service is in an invalid state.</exception>
+        internal async Task SendToSubscribers(string moduleNamespace, string eventId, object content, bool silentNoSubscribers = true) {
+            if (this._subscriptions == null) throw new InvalidOperationException($"The {typeof(EventBusService).Name} is currently in an invalid state.");
+
+            var identifier = this.GetIdentifier(moduleNamespace, eventId);
+
+            var tasks = new List<Task>();
+
+            if ((!_subscriptions.TryGetValue(identifier, out var subscriberFunctions) || subscriberFunctions == null || subscriberFunctions.Count == 0) && !silentNoSubscribers) {
+                throw new Exception("No module listens to this event.");
+            }
+
+            if (subscriberFunctions != null) {
+                foreach (var subscriberFunction in subscriberFunctions) {
+                    tasks.Add(Task.Run(async () => {
+                        try {
+                            await subscriberFunction?.Invoke(content);
+                        } catch (Exception ex) {
+                            // Failed to execute subscriber, don't throw.
+                            Logger.Warn(ex, $"Failed to execute subscriber for event \"{identifier}\".");
+                        }
+                    }));
+                }
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        private string GetIdentifier(string moduleNamespace, string eventId) {
+            return $"{moduleNamespace}_{eventId}";
+        }
+
+        /// <summary>
+        ///     Subscribe to an event to handle cases another module triggers.
+        /// </summary>
+        /// <param name="moduleNamespace">The namespace of the module.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="action">The action which should be executed when the event is dispatched.</param>
+        /// <exception cref="InvalidOperationException">If the service is in an invalid state.</exception>
+        public void Subscribe(string moduleNamespace, string eventId, Func<object, Task> action) {
+            if (this._subscriptions == null) throw new InvalidOperationException($"The {typeof(EventBusService).Name} is currently in an invalid state.");
+
+            var identifier = this.GetIdentifier(moduleNamespace, eventId);
+
+            if (!this._subscriptions.ContainsKey(identifier)) {
+                this._subscriptions.TryAdd(identifier, new ConcurrentBag<Func<object, Task>>());
+            }
+
+            this._subscriptions[identifier].Add(action);
+        }
+
+        /// <summary>
+        ///     Unsubscribes all listeners for the given event. This should be used when a module self registers listeners and wants to prevent collisions on disable and enable again.
+        /// </summary>
+        /// <param name="moduleNamespace">The namespace of the module.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <exception cref="InvalidOperationException">If the service is in an invalid state.</exception>
+        internal void Unsubscribe(string moduleNamespace, string eventId) {
+            if (this._subscriptions == null) throw new InvalidOperationException($"The {typeof(EventBusService).Name} is currently in an invalid state.");
+
+            var identifier = this.GetIdentifier(moduleNamespace, eventId);
+
+            _ = this._subscriptions.TryRemove(identifier, out _);
+        }
+
+        /// <summary>
+        ///     Calls a function inside a different module.
+        /// </summary>
+        /// <param name="moduleNamespace">The namespace of the module.</param>
+        /// <param name="eventId">The event id.</param>
+        /// <param name="content">The content to send to all subscribers.</param>
+        /// <returns>The task that represents the current method.</returns>
+        public async Task Dispatch(string moduleNamespace, string eventId, object content) {
+            await this.SendToSubscribers(moduleNamespace, eventId, content, false); // Don't call this silent. We want the caller to handle this unexpected case.
+        }
+    }
+}

--- a/Blish HUD/GameServices/GameService.cs
+++ b/Blish HUD/GameServices/GameService.cs
@@ -17,10 +17,11 @@ namespace Blish_HUD {
             Graphics        = new GraphicsService(),
             Overlay         = new OverlayService(),
             GameIntegration = new GameIntegrationService(),
-            ArcDpsV2          = new ArcDpsServiceV2(), // This needs to be initialized bf the V1
+            ArcDpsV2        = new ArcDpsServiceV2(), // This needs to be initialized bf the V1
             ArcDps          = new ArcDpsService(),
             Contexts        = new ContextsService(),
-            Module          = new ModuleService()
+            Module          = new ModuleService(),
+            EventBus        = new EventBusService(),
         };
 
         public static IReadOnlyList<GameService> All => _allServices;
@@ -97,6 +98,7 @@ namespace Blish_HUD {
         public static readonly ArcDpsServiceV2        ArcDpsV2;
         public static readonly ContextsService        Contexts;
         public static readonly ModuleService          Module;
+        public static readonly EventBusService        EventBus;
 
         #endregion
 

--- a/Blish HUD/GameServices/Modules/Managers/EventBusManager.cs
+++ b/Blish HUD/GameServices/Modules/Managers/EventBusManager.cs
@@ -1,0 +1,50 @@
+﻿using Blish_HUD.Modules;
+using Blish_HUD.Modules.Managers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Policy;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blish_HUD.GameServices.Modules.Managers {
+    public class EventBusManager : IDisposable {
+        protected static readonly Logger Logger = Logger.GetLogger<EventBusManager>();
+        private List<string> _selfSubscribedEvents = new List<string>();
+
+        private readonly string _moduleNamespace;
+
+        internal static EventBusManager GetModuleInstance(ModuleManager module) {
+            return new EventBusManager(module.Manifest.Namespace);
+        }
+
+        private EventBusManager(string moduleNamespace) {
+            this._moduleNamespace = moduleNamespace;
+        }
+
+        /// <inheritdoc cref="EventBusService.Dispatch(string, string, object)"/>
+        public async Task Dispatch(string eventId, object content, bool silentNoSubscribers = true) {
+            await GameService.EventBus.SendToSubscribers(this._moduleNamespace, eventId, content, silentNoSubscribers);
+        }
+
+        /// <inheritdoc cref="EventBusService.Subscribe(string, string, Func{object, Task})"/>
+        public void Subscribe(string eventId, Func<object, Task> action) {
+            GameService.EventBus.Subscribe(this._moduleNamespace, eventId, action);
+
+            this._selfSubscribedEvents?.Add(eventId);
+        }
+
+        /// <summary>
+        ///     Unsubscribes all event subscribers that got registered by this module instance.
+        /// </summary>
+        public void Dispose() {
+            if (this._selfSubscribedEvents != null) {
+                foreach (var eventId in this._selfSubscribedEvents) {
+                    GameService.EventBus.Unsubscribe(this._moduleNamespace, eventId);
+                }
+
+                this._selfSubscribedEvents.Clear();
+            }
+        }
+    }
+}

--- a/Blish HUD/GameServices/Modules/ModuleParameters.cs
+++ b/Blish HUD/GameServices/Modules/ModuleParameters.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Blish_HUD.GameServices.Modules.Managers;
 using Blish_HUD.Modules.Managers;
 
 namespace Blish_HUD.Modules {
@@ -13,6 +14,7 @@ namespace Blish_HUD.Modules {
         private ContentsManager    _contentsManager;
         private DirectoriesManager _directoriesManager;
         private Gw2ApiManager      _gw2ApiManager;
+        private EventBusManager    _eventBusManager;
 
         public Manifest Manifest => _manifest;
 
@@ -23,6 +25,8 @@ namespace Blish_HUD.Modules {
         public DirectoriesManager DirectoriesManager => _directoriesManager;
 
         public Gw2ApiManager Gw2ApiManager => _gw2ApiManager;
+
+        public EventBusManager EventBusManager => _eventBusManager;
 
         internal static ModuleParameters BuildFromManifest(Manifest manifest, ModuleManager module) {
             switch (manifest.ManifestVersion) {
@@ -44,7 +48,8 @@ namespace Blish_HUD.Modules {
                 _settingsManager    = SettingsManager.GetModuleInstance(module),
                 _contentsManager    = ContentsManager.GetModuleInstance(module),
                 _directoriesManager = DirectoriesManager.GetModuleInstance(module),
-                _gw2ApiManager      = Gw2ApiManager.GetModuleInstance(module)
+                _gw2ApiManager      = Gw2ApiManager.GetModuleInstance(module),
+                _eventBusManager    = EventBusManager.GetModuleInstance(module)
             };
 
             if (builtModuleParameters._gw2ApiManager == null) {
@@ -68,6 +73,7 @@ namespace Blish_HUD.Modules {
 
         public void Dispose() {
             _contentsManager?.Dispose();
+            _eventBusManager?.Dispose();
         }
 
     }


### PR DESCRIPTION
This PR aims to provide an event bus communication channel for cross module interaction within blish core.
Each event identifier is based on the modules namespace and an event id (string) which can be freely choosen.

The content is typed as an object to allow module devs to accept any kind of data.

The actions which are executed for subscribers are designed with async tasks in mind. 
Upon dispatching an event, all subscribers are executed in parallel.

If the registering module is dispatching an event but there are no subscribers no exception is thrown.
If the calling module is trying to dispatch an event to the registering module an exception is thrown if there are no subscribers. (Registering module is disabled or the event simple does not exist)

## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/599270434642460753/1265237773019779142

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
