### PR TITLE
feat: disable permission UI when a module is enabled

### DIFF
--- a/Blish HUD/GameServices/Modules/UI/Presenters/ModulePermissionPresenter.cs
+++ b/Blish HUD/GameServices/Modules/UI/Presenters/ModulePermissionPresenter.cs
@@ -14,6 +14,11 @@ namespace Blish_HUD.Modules.UI.Presenters {
         protected override Task<bool> Load(IProgress<string> progress) {
             this.View.PermissionStateChanged += ViewOnPermissionStateChanged;
 
+            this.Model.ModuleEnabled += ModelOnModuleEnabled;
+            this.Model.ModuleDisabled += ModelOnModuleDisabled;
+
+            this.View.Editable = !this.Model.Enabled;
+
             return base.Load(progress);
         }
 
@@ -33,6 +38,16 @@ namespace Blish_HUD.Modules.UI.Presenters {
             GameService.Settings.Save();
         }
 
+        private void ModelOnModuleEnabled(object sender, EventArgs e) {
+            this.View.Editable = false;
+            UpdateStatus();
+        }
+
+        private void ModelOnModuleDisabled(object sender, EventArgs e) {
+            this.View.Editable = true;
+            UpdateStatus();
+        }
+
         protected override void UpdateView() {
             UpdatePermissionList();
             UpdateStatus();
@@ -47,8 +62,19 @@ namespace Blish_HUD.Modules.UI.Presenters {
         }
 
         private void UpdateStatus() {
-            // Unused at this time
+            if (Model.Enabled) {
+                this.View.SetDetails(Strings.GameServices.ModulesService.ApiPermission_NotEditable,
+                                     TitledDetailView.DetailLevel.Info);
+            } else {
+                this.View.ClearDetails();
+            }
         }
 
+        protected override void Unload() {
+            this.View.PermissionStateChanged -= ViewOnPermissionStateChanged;
+
+            this.Model.ModuleEnabled -= ModelOnModuleEnabled;
+            this.Model.ModuleDisabled -= ModelOnModuleDisabled;
+        }
     }
 }

--- a/Blish HUD/GameServices/Modules/UI/Views/ModulePermissionView.cs
+++ b/Blish HUD/GameServices/Modules/UI/Views/ModulePermissionView.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Blish_HUD.Controls;
 using Blish_HUD.Modules.UI.Presenters;
 using Gw2Sharp.WebApi.V2.Models;
@@ -12,6 +13,25 @@ namespace Blish_HUD.Modules.UI.Views {
 
         private FlowPanel _permissionFlowPanel;
         private Label     _messageLabel;
+
+        private bool[] _checkboxStates;
+
+        private bool _editable;
+
+        /// <summary>
+        /// Determines whether the displayed permissions may be edited.
+        /// </summary>
+        public bool Editable {
+            get => _editable;
+            set {
+                _editable = value;
+
+                if (_permissionFlowPanel == null || _messageLabel == null || _checkboxStates == null)
+                    return;
+
+                ResetCheckboxStates();
+            }
+        }
 
         public ModulePermissionView() { /* NOOP */ }
 
@@ -47,10 +67,12 @@ namespace Blish_HUD.Modules.UI.Views {
             _permissionFlowPanel.ClearChildren();
             _permissionFlowPanel.Hide();
 
+            _checkboxStates = permissions.Select(permission => permission.Optional).ToArray();
+
             foreach ((var permission, bool optional, string description, bool set) in permissions) {
                 var permissionCheckbox = new Checkbox() {
                     Text             = permission.ToString(),
-                    Enabled          = optional,
+                    Enabled          = optional && this.Editable,
                     BasicTooltipText = description,
                     Parent           = _permissionFlowPanel
                 };
@@ -66,5 +88,16 @@ namespace Blish_HUD.Modules.UI.Views {
             _messageLabel.Visible = !(_permissionFlowPanel.Visible = _permissionFlowPanel.Children.Count > 0);
         }
 
+        private void ResetCheckboxStates() {
+            var checkboxes = _permissionFlowPanel.GetChildrenOfType<Checkbox>().ToArray();
+            if (Editable) {
+                for (int i = 0; i < checkboxes.Length; i++)
+                    checkboxes[i].Enabled = _checkboxStates[i];
+            } else {
+                foreach (var checkbox in checkboxes) {
+                    checkbox.Enabled = false;
+                }
+            }
+        }
     }
 }

--- a/Blish HUD/Strings/GameServices/ModulesService.Designer.cs
+++ b/Blish HUD/Strings/GameServices/ModulesService.Designer.cs
@@ -79,6 +79,15 @@ namespace Blish_HUD.Strings.GameServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Permissions may only be edited, when the module is disabled..
+        /// </summary>
+        internal static string ApiPermission_NotEditable {
+            get {
+                return ResourceManager.GetString("ApiPermission_NotEditable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Optional.
         /// </summary>
         internal static string ApiPermission_Optional {

--- a/Blish HUD/Strings/GameServices/ModulesService.de.resx
+++ b/Blish HUD/Strings/GameServices/ModulesService.de.resx
@@ -265,4 +265,7 @@ Lade einige herunter und platziere sie im Modulverzeichnis.</value>
   <data name="PkgManagement_MoreInfo" xml:space="preserve">
     <value>Mehr Info</value>
   </data>
+  <data name="ApiPermission_NotEditable" xml:space="preserve">
+    <value>Berechtigungen können nur bearbeitet werden, wenn das Modul deaktiviert ist.</value>
+  </data>
 </root>

--- a/Blish HUD/Strings/GameServices/ModulesService.fr.resx
+++ b/Blish HUD/Strings/GameServices/ModulesService.fr.resx
@@ -265,4 +265,7 @@ Téléchargez des modules et placez-les dans le dossier modules.</value>
   <data name="PkgManagement_MoreInfo" xml:space="preserve">
     <value>Plus d'informations</value>
   </data>
+  <data name="ApiPermission_NotEditable" xml:space="preserve">
+    <value>Les permissions ne peuvent être modifiées que lorsque le module est désactivé.</value>
+  </data>
 </root>

--- a/Blish HUD/Strings/GameServices/ModulesService.resx
+++ b/Blish HUD/Strings/GameServices/ModulesService.resx
@@ -248,4 +248,7 @@ Download some modules and place them in the modules folder.</value>
   <data name="PkgManagement_MoreInfo" xml:space="preserve">
     <value>More Info</value>
   </data>
+  <data name="ApiPermission_NotEditable" xml:space="preserve">
+    <value>Permissions may only be edited, when the module is disabled.</value>
+  </data>
 </root>


### PR DESCRIPTION
Disables the checkmarks of the `ModulePermissionView` when a module is activated. Re-enables the (optional) checkmarks when a module is deactivated.

Uses the `Details` of the `ModulePermissionView` to inform the user why they are unable to edit the permissions (Similar to how the `ModuleDependencyView` informs the user, if a dependency is not met).

## Implementation details
- added Editable property to ModulePermissionView
- added pivate record of checkbox states to ModulePermissionView
- implemented handling of Editable property in ModulePermissionsPresenter
- implemented ModulePermissionPresenter.UpdateStatus() to inform the user of the current state
- added localization in German and French for the new status message

## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/599270434642460753/1139563750979018853

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
