### PR TITLE
fix: Cropped Module Permissions

### DIFF
--- a/Blish HUD/GameServices/Modules/UI/Views/ModulePermissionView.cs
+++ b/Blish HUD/GameServices/Modules/UI/Views/ModulePermissionView.cs
@@ -48,7 +48,7 @@ namespace Blish_HUD.Modules.UI.Views {
                 Size                = buildPanel.ContentRegion.Size,
                 Visible             = false,
                 FlowDirection       = ControlFlowDirection.TopToBottom,
-                ControlPadding      = new Vector2(14, 15),
+                ControlPadding      = new Vector2(14, 1),
                 OuterControlPadding = new Vector2(15, 13),
                 Parent              = buildPanel
             };


### PR DESCRIPTION
Decreases the vertical padding between permissions in the `ModulePermissionView` by a lot.

- fixed cropped and unreachable permissions if a certain amount of permissions are requested
- might need adjusting if at some point more permissions are added

## Discussed and disregarded alternatives
- Introducing a scrollbar to the `ModulePermissionView` main `FlowPanel`

## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/536970543736291346/1283174876751986719

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
