### PR TITLE
Fix: permission status message

### DIFF
--- a/Blish HUD/GameServices/Modules/UI/Presenters/ModulePermissionPresenter.cs
+++ b/Blish HUD/GameServices/Modules/UI/Presenters/ModulePermissionPresenter.cs
@@ -62,7 +62,7 @@ namespace Blish_HUD.Modules.UI.Presenters {
         }
 
         private void UpdateStatus() {
-            if (Model.Enabled) {
+            if (this.Model.Enabled && this.Model.Manifest.ApiPermissions.Any()) {
                 this.View.SetDetails(Strings.GameServices.ModulesService.ApiPermission_NotEditable,
                                      TitledDetailView.DetailLevel.Info);
             } else {

--- a/Blish HUD/GameServices/Modules/UI/Presenters/ModulePermissionPresenter.cs
+++ b/Blish HUD/GameServices/Modules/UI/Presenters/ModulePermissionPresenter.cs
@@ -62,7 +62,7 @@ namespace Blish_HUD.Modules.UI.Presenters {
         }
 
         private void UpdateStatus() {
-            if (this.Model.Enabled && this.Model.Manifest.ApiPermissions.Any()) {
+            if (Model.Enabled) {
                 this.View.SetDetails(Strings.GameServices.ModulesService.ApiPermission_NotEditable,
                                      TitledDetailView.DetailLevel.Info);
             } else {


### PR DESCRIPTION
Hides the status message that indicates that permissions may not be edited while a module is enabled, if no permissions are requested.

## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/536970543736291346/1283705561543868466

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
