### PR TITLE
feature: Word-wrap functionality for MultilineTextBox

### DIFF
--- a/Blish HUD/Controls/MultilineTextBox.cs
+++ b/Blish HUD/Controls/MultilineTextBox.cs
@@ -29,7 +29,11 @@ namespace Blish_HUD.Controls {
         /// </summary>
         public bool DisableWordWrap {
             get => _disableWordWrap;
-            set => SetProperty(ref _disableWordWrap, value);
+            set {
+                if (SetProperty(ref _disableWordWrap, value)) {
+                   RecalculateLayout();
+                }
+            }
         }
 
         private char[] _wrapCharacters;
@@ -40,7 +44,11 @@ namespace Blish_HUD.Controls {
         /// </summary>
         public char[] WrapCharacters {
             get => _wrapCharacters ?? Array.Empty<char>();
-            set => SetProperty(ref _wrapCharacters, value);
+            set {
+                if (SetProperty(ref _wrapCharacters, value)) {
+                    RecalculateLayout();
+                }
+            }
         }
 
         public MultilineTextBox() {
@@ -278,10 +286,10 @@ namespace Blish_HUD.Controls {
         }
 
         public override void RecalculateLayout() {
+            _displayText = ProcessDisplayText(_text);
             _textRegion       = CalculateTextRegion();
             _highlightRegions = CalculateHighlightRegions();
             _cursorRegion     = CalculateCursorRegion();
-            _displayText = ProcessDisplayText(_text);
         }
 
         protected override void HandleDelete() {

--- a/Blish HUD/Controls/MultilineTextBox.cs
+++ b/Blish HUD/Controls/MultilineTextBox.cs
@@ -22,6 +22,27 @@ namespace Blish_HUD.Controls {
         /// </summary>
         public int[] DisplayNewLineIndices => _displayNewLineIndices;
 
+        private bool _disableWordWrap;
+
+        /// <summary>
+        /// Determines whether the automatic word-wrap will be disabled.
+        /// </summary>
+        public bool DisableWordWrap {
+            get => _disableWordWrap;
+            set => SetProperty(ref _disableWordWrap, value);
+        }
+
+        private char[] _wrapCharacters;
+
+        /// <summary>
+        /// The characters, that are used to wrap a word, if it does not fit the current line
+        /// it's on.
+        /// </summary>
+        public char[] WrapCharacters {
+            get => _wrapCharacters ?? Array.Empty<char>();
+            set => SetProperty(ref _wrapCharacters, value);
+        }
+
         public MultilineTextBox() {
             _multiline = true;
             _maxLength = 524288;
@@ -105,7 +126,12 @@ namespace Blish_HUD.Controls {
         /// Applies word-wrap to the <paramref name="value"/>.
         /// </summary>
         protected string ApplyWordWrap(string value) {
-            string displayText = DrawUtil.WrapText(_font, value, this._textRegion.Width, out int[] newLineIndices);
+            if (DisableWordWrap) {
+                _displayNewLineIndices = Array.Empty<int>();
+                return value;
+            }
+
+            string displayText = DrawUtil.WrapText(_font, value, this._textRegion.Width, WrapCharacters, out int[] newLineIndices);
             _displayNewLineIndices = newLineIndices;
 
             return displayText;

--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -90,6 +90,14 @@ namespace Blish_HUD.Controls {
             set => SetText(value, false);
         }
 
+        protected string _displayText = string.Empty;
+
+        /// <summary>
+        /// The displayed text. Inheriting classes may process the
+        /// <see cref="Text"/> via <see cref="ProcessDisplayText(string)"/>.
+        /// </summary>
+        public string DisplayText => _displayText;
+
         protected int _maxLength = int.MaxValue;
 
         /// <summary>
@@ -485,9 +493,19 @@ namespace Blish_HUD.Controls {
                 _redoStack.Reset();
             }
 
+            _displayText = ProcessDisplayText(value);
+
             OnTextChanged(new ValueChangedEventArgs<string>(prevText, value));
 
             return true;
+        }
+
+        /// <summary>
+        /// Processes the <see cref="Text"/> before it is displayed. Result will be
+        /// used to set <see cref="DisplayText"/>.
+        /// </summary>
+        protected virtual string ProcessDisplayText(string value) {
+            return value;
         }
 
         public override void UnsetFocus() {
@@ -785,7 +803,7 @@ namespace Blish_HUD.Controls {
             }
 
             // Draw the text
-            spriteBatch.DrawStringOnCtrl(this, _text, _font, textRegion, _foreColor, false, false, 0, horizontalAlignment, VerticalAlignment.Top);
+            spriteBatch.DrawStringOnCtrl(this, _displayText, _font, textRegion, _foreColor, false, false, 0, horizontalAlignment, VerticalAlignment.Top);
         }
 
         protected void PaintHighlight(SpriteBatch spriteBatch, Rectangle highlightRegion) {

--- a/Blish HUD/_Utils/DrawUtil.cs
+++ b/Blish HUD/_Utils/DrawUtil.cs
@@ -43,48 +43,171 @@ namespace Blish_HUD {
             sb.DrawString(sf, text, new Vector2(xPos, yPos), clr);
         }
 
+        /// <summary>
+        /// Wraps a <paramref name="word"/>, if it does not fit into the <paramref name="maxLineWidth"/>
+        /// accounting for the given <paramref name="offset"/>.
+        /// </summary>
+        /// <remarks>
+        /// Will prioritize wrapping a word at any of the given <paramref name="preferredWrapCharacters"/>,
+        /// but will wrap in the middle of the word if none of them occur.
+        /// </remarks>
+        /// <param name="spriteFont"></param>
+        /// <param name="word"></param>
+        /// <param name="offset"></param>
+        /// <param name="maxLineWidth"></param>
+        /// <param name="preferredWrapCharacters"></param>
+        /// <param name="newLineIndices"></param>
+        /// <returns>The <paramref name="word"/> with new line characters at appropriate
+        /// positions to make it fit into the <paramref name="maxLineWidth"/>.</returns>
+        private static string WrapWord(BitmapFont spriteFont, string word, float offset, float maxLineWidth, char[] preferredWrapCharacters, out int[] newLineIndices) {
+            newLineIndices = Array.Empty<int>();
+            if (string.IsNullOrEmpty(word)) return string.Empty;
+
+            if (offset + spriteFont.MeasureString(word).Width <= maxLineWidth) return word;
+
+            StringBuilder resultBuilder = new StringBuilder();
+
+            List<int> indices = new List<int>();
+            bool didSplitCharacterOccur = false;
+
+            StringBuilder partBuilder = new StringBuilder();
+
+            // this is neccessary, because measuring each character individually and
+            // adding them up, results in a significant higher value that measuring the whole line
+            float currentLineWithNewCharacterWidth;
+            string currentLineCharacters = string.Empty;
+
+            for (int i = 0; i < word.Length; i++) {
+                if (indices.Any()) {
+                    offset = 0;
+                }
+
+                char character = word[i];
+                currentLineCharacters += character;
+                currentLineWithNewCharacterWidth = spriteFont.MeasureString(currentLineCharacters).Width + offset;
+
+                if (currentLineWithNewCharacterWidth < maxLineWidth) {
+                    partBuilder.Append(character);
+                    
+                    if (preferredWrapCharacters.Contains(character)) {
+                        resultBuilder.Append(partBuilder);
+                        partBuilder.Clear();
+                        didSplitCharacterOccur = true;
+                    }
+                } else {
+
+                    int characterOffset = 0;
+
+                    if (!didSplitCharacterOccur) {
+                        resultBuilder.Append(partBuilder);
+                        resultBuilder.Append('\n');
+                        currentLineCharacters = string.Empty;
+                    }
+                    else {
+                        resultBuilder.Append('\n');
+                        resultBuilder.Append(partBuilder);
+                        currentLineCharacters = partBuilder.ToString(); 
+
+                        characterOffset = partBuilder.Length;
+                    }
+
+                    indices.Add(i + indices.Count() - characterOffset);
+
+                    partBuilder.Clear();
+                    partBuilder.Append(character);
+                    currentLineCharacters += character;
+
+                    didSplitCharacterOccur = false;
+                }
+            }
+
+            if (partBuilder.Length != 0) {
+                resultBuilder.Append(partBuilder);
+            }
+
+            newLineIndices = indices.ToArray();
+            return resultBuilder.ToString();
+        }
+
         private static string WrapTextSegment(BitmapFont spriteFont, string text, float maxLineWidth) {
             return WrapTextSegment(spriteFont, text, maxLineWidth, out _);
         }
 
-        /// <remarks>
-        /// Source: https://stackoverflow.com/a/15987581/595437
-        /// (slightly modified)
-        /// </remarks>
         private static string WrapTextSegment(BitmapFont spriteFont, string text, float maxLineWidth, out int[] newLineIndices) {
+            return WrapTextSegment(spriteFont, text, maxLineWidth, Array.Empty<char>(), out newLineIndices);
+        }
+
+        /// <remarks>
+        /// Original source: https://stackoverflow.com/a/15987581/595437
+        /// (modified)
+        /// </remarks>
+        private static string WrapTextSegment(BitmapFont spriteFont, string text, float maxLineWidth, char[] preferredWrapCharacters, out int[] newLineIndices) {
             newLineIndices = Array.Empty<int>();
             if (string.IsNullOrEmpty(text)) return string.Empty;
 
             string[] words = text.Split(' ');
             var sb = new StringBuilder();
-            float lineWidth = 0f;
+            float currentLineWidth = 0f;
             float spaceWidth = spriteFont.MeasureString(" ").Width;
 
             List<int> indices = new List<int>();
-            int characterIndex = 0;
+            int processedCharacters = 0;
 
             for (int i = 0; i < words.Length; i++) {
                 string word = words[i];
-                Vector2 size = spriteFont.MeasureString(word);
+                float wordWidth = spriteFont.MeasureString(word).Width;
 
-                if (lineWidth + size.X < maxLineWidth) {
+                if (currentLineWidth + wordWidth < maxLineWidth) {
                     sb.Append(word);
-                    lineWidth += size.X;
+                    currentLineWidth += wordWidth;
                     if (i < words.Length - 1) {
                         sb.Append(" ");
-                        lineWidth += spaceWidth;
+                        currentLineWidth += spaceWidth;
+                        processedCharacters++;
                     }
                 } else {
-                    sb.Append("\n" + word);
-                    lineWidth = size.X;
+                    string wrappedWord = WrapWord(spriteFont, word, currentLineWidth, maxLineWidth, preferredWrapCharacters, out int[] wordNewLineIndices);
+
+                    string firstPart = wrappedWord;
+                    string lastPart = wrappedWord;
+
+                    if (wordNewLineIndices.Length != 0) {
+                        firstPart = wrappedWord.Substring(0, wordNewLineIndices.First());
+                        lastPart = wrappedWord.Substring(wordNewLineIndices.Last() + 1);
+                    }
+
+                    // words should only every be broken in the middle of the word (no wrap character
+                    // in the first part), if they started on their own line.
+                    if (preferredWrapCharacters.Any(character => firstPart.Contains(character)) || currentLineWidth == 0) {
+                        sb.Append(wrappedWord);
+                        currentLineWidth = spriteFont.MeasureString(lastPart).Width;
+
+                        int indexOffset = processedCharacters + indices.Count();
+
+                        foreach (int wordIndex in wordNewLineIndices) {
+                            indices.Add(wordIndex + indexOffset);
+                        }
+                    } else {
+                        string wrappedWordOnNextLine = WrapWord(spriteFont, word, 0, maxLineWidth, preferredWrapCharacters, out int[] wordOnNextLineNewLineIndices);
+                        sb.Append('\n');
+                        indices.Add(processedCharacters + indices.Count());
+                        sb.Append(wrappedWordOnNextLine);
+                        currentLineWidth = spriteFont.MeasureString(wrappedWordOnNextLine.Split('\n').Last()).Width;
+
+                        int indexOffset = processedCharacters + indices.Count();
+
+                        foreach (int wordIndex in wordOnNextLineNewLineIndices) {
+                            indices.Add(wordIndex + indexOffset);
+                        }
+                    }
+
                     if (i < words.Length - 1) {
                         sb.Append(" ");
-                        lineWidth += spaceWidth;
+                        processedCharacters++;
+                        currentLineWidth += spaceWidth;
                     }
-                    indices.Add(characterIndex);
-                    characterIndex++;
                 }
-                characterIndex += word.Length + 1;
+                processedCharacters += word.Length;
             }
 
             newLineIndices = indices.ToArray();
@@ -96,31 +219,37 @@ namespace Blish_HUD {
         }
 
         public static string WrapText(BitmapFont spriteFont, string text, float maxLineWidth, out int[] newLineIndices) {
+            return WrapText(spriteFont, text, maxLineWidth, Array.Empty<char>(), out newLineIndices);
+        }
+
+        public static string WrapText(BitmapFont spriteFont, string text, float maxLineWidth, char[] preferredWrapCharacters, out int[] newLineIndices) {
             newLineIndices = Array.Empty<int>();
             if (string.IsNullOrEmpty(text)) return "";
 
             var sb = new StringBuilder();
             List<int> indices = new List<int>();
-            int lineStart = 0;
+            int processedCharacters = 0;
 
             string[] lines = text.Split('\n');
             for (int i = 0; i < lines.Length; i++) {
-                sb.Append(WrapTextSegment(spriteFont, lines[i], maxLineWidth, out int[] localNewLineIndices));
-                foreach (int localIndex in localNewLineIndices) {
-                    indices.Add(localIndex + lineStart);
+                sb.Append(WrapTextSegment(spriteFont, lines[i], maxLineWidth, preferredWrapCharacters, out int[] segmentNewLineIndices));
+
+                int indexOffset = processedCharacters + indices.Count();
+
+                foreach (int segmentIndex in segmentNewLineIndices) {
+                    indices.Add(segmentIndex + indexOffset);
                 }
 
-                lineStart += lines[i].Length;
+                processedCharacters += lines[i].Length;
 
                 if (i < lines.Length - 1) {
                     sb.Append('\n');
-                    lineStart++;
+                    processedCharacters++;
                 }
             }
 
             newLineIndices = indices.ToArray();
             return sb.ToString();
         }
-
     }
 }

--- a/Blish HUD/_Utils/DrawUtil.cs
+++ b/Blish HUD/_Utils/DrawUtil.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Text;
 using Blish_HUD.Controls;
+using System.Collections.Generic;
 
 namespace Blish_HUD {
     public static class DrawUtil {
@@ -42,32 +43,83 @@ namespace Blish_HUD {
             sb.DrawString(sf, text, new Vector2(xPos, yPos), clr);
         }
 
-        /// <remarks> Source: https://stackoverflow.com/a/15987581/595437 </remarks>
         private static string WrapTextSegment(BitmapFont spriteFont, string text, float maxLineWidth) {
-            string[] words      = text.Split(' ');
-            var      sb         = new StringBuilder();
-            float    lineWidth  = 0f;
-            float    spaceWidth = spriteFont.MeasureString(" ").Width;
+            return WrapTextSegment(spriteFont, text, maxLineWidth, out _);
+        }
 
-            foreach (string word in words) {
+        /// <remarks>
+        /// Source: https://stackoverflow.com/a/15987581/595437
+        /// (slightly modified)
+        /// </remarks>
+        private static string WrapTextSegment(BitmapFont spriteFont, string text, float maxLineWidth, out int[] newLineIndices) {
+            newLineIndices = Array.Empty<int>();
+            if (string.IsNullOrEmpty(text)) return string.Empty;
+
+            string[] words = text.Split(' ');
+            var sb = new StringBuilder();
+            float lineWidth = 0f;
+            float spaceWidth = spriteFont.MeasureString(" ").Width;
+
+            List<int> indices = new List<int>();
+            int characterIndex = 0;
+
+            for (int i = 0; i < words.Length; i++) {
+                string word = words[i];
                 Vector2 size = spriteFont.MeasureString(word);
 
                 if (lineWidth + size.X < maxLineWidth) {
-                    sb.Append(word + " ");
-                    lineWidth += size.X + spaceWidth;
+                    sb.Append(word);
+                    lineWidth += size.X;
+                    if (i < words.Length - 1) {
+                        sb.Append(" ");
+                        lineWidth += spaceWidth;
+                    }
                 } else {
-                    sb.Append("\n" + word + " ");
-                    lineWidth = size.X + spaceWidth;
+                    sb.Append("\n" + word);
+                    lineWidth = size.X;
+                    if (i < words.Length - 1) {
+                        sb.Append(" ");
+                        lineWidth += spaceWidth;
+                    }
+                    indices.Add(characterIndex);
+                    characterIndex++;
                 }
+                characterIndex += word.Length + 1;
             }
 
+            newLineIndices = indices.ToArray();
             return sb.ToString();
         }
 
         public static string WrapText(BitmapFont spriteFont, string text, float maxLineWidth) {
+            return WrapText(spriteFont, text, maxLineWidth, out _);
+        }
+
+        public static string WrapText(BitmapFont spriteFont, string text, float maxLineWidth, out int[] newLineIndices) {
+            newLineIndices = Array.Empty<int>();
             if (string.IsNullOrEmpty(text)) return "";
 
-            return string.Join("\n", text.Split('\n').Select(s => WrapTextSegment(spriteFont, s, maxLineWidth)));
+            var sb = new StringBuilder();
+            List<int> indices = new List<int>();
+            int lineStart = 0;
+
+            string[] lines = text.Split('\n');
+            for (int i = 0; i < lines.Length; i++) {
+                sb.Append(WrapTextSegment(spriteFont, lines[i], maxLineWidth, out int[] localNewLineIndices));
+                foreach (int localIndex in localNewLineIndices) {
+                    indices.Add(localIndex + lineStart);
+                }
+
+                lineStart += lines[i].Length;
+
+                if (i < lines.Length - 1) {
+                    sb.Append('\n');
+                    lineStart++;
+                }
+            }
+
+            newLineIndices = indices.ToArray();
+            return sb.ToString();
         }
 
     }


### PR DESCRIPTION
Adds word-wrap functionality to the`MultilineTextBox`. Related to #620.

- Adds a `DisplayText` property that may be manipulated by inheriting classes of `TextInputBase`. The current `Text` property retains its functionality while the `DisplayText` makes it possible to change the text that is drawn onto the `Control`.
- Implements the new `DisplayText` property in `MultilineTextBox` to apply a word-wrap.

### notable behaviour changes
- with the current implementation, all `MultilineTextBox`es will have word-wrap applied to them. See "open questions" below for alternatives.
- `DrawUtil.WrapTextSegment()` stops adding an additional space character to the end of the text segment. The previous behaviour is assumed to be a bug. This change affects Blish Core in 3 places (`SpriteBatchExtensions.DrawStringOnCtrl()`, `FormattedLabel.InitializeRectangles()` and `LabelBase.GetTextDimensions()`). The consequences at the time of writing are unclear and need to be tested. It's also unclear if any modules rely on that method.

### open questions
- Should word-wrap just be the new implementation of the `MultilineTextBox` (as it is implemented in this PR), or is it desirable to have a property `AutoWordWrap` or something like that on the `MultilineTextBox` so the current behaviour is still possible?
- If a property like that is wanted, should the default be the current or the new implementation?
- What should happen if a word is so long, that it won't fit in a line? Break in the middle of the word, or just let it overflow like it currently does?

### Implementation details
- added `DisplayText` property to `TextInputBase`
- added virtual `ProcessDisplayText()` method to `TextInputBase`
- modified `TextInputBase` to draw new `DisplayText` instead of `Text`

- added `WrapText()` and `WrapTextSegment()` overloads to `DrawUtil` with out parameter that contains the indices of the added new line characters
- modified `DrawUtil.WrapTextSegment()` to stop adding an additional space character to the end of the text segement

- added `DisplayNewLineIndices` property to `MultilineTextBox`
- added `GetCursorIndexFromDisplayIndex()` and `GetDisplayIndexFromCursorIndex()` methods to `MultilineTextBox` to switch between cursorIndex and displayIndex
- modified `MoveLine()`, `GetCursorIndexFromPosition()`, `CalculateHighlightRegions()` and `CalculateCursorRegion()` in `MultilineTextBox` to be based of the `DisplayText` instead of `Text`
- implemented new virtual `ProcessDisplayText()` override in `MultilineTextBox`
- added `ApplyWordWrap()` method in `MultilineTextBox`
- modified `GetSplitIndex()` in `MultilineTextBox` to return the line and character based on the `DisplayText` instead of the `Text`
- modified `RecalculateLayout()` in `MultilineTextBox` to include recalculation of the `DisplayText`
- added `HandleDelete` override in `MultilineTextBox` to include a recalculation of the layout after characters were deleted

## notable Cons
- This implementation basically keeps 2 copies of almost identical strings in memory for all `TextInputBase` subclasses.

## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/536970543736291346/1285731312056930339

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
