### PR TITLE
Sort module menu items

### DIFF
--- a/Blish HUD/GameServices/ModuleService.cs
+++ b/Blish HUD/GameServices/ModuleService.cs
@@ -326,14 +326,23 @@ namespace Blish_HUD {
 
         private          MenuItem                            _rootModuleSettingsMenuItem;
         private readonly Dictionary<MenuItem, ModuleManager> _moduleMenus = new Dictionary<MenuItem, ModuleManager>();
+
+        private IOrderedEnumerable<KeyValuePair<MenuItem, ModuleManager>> GetSortedMenuItems() {
+            return _moduleMenus.OrderBy(c => c.Value.Manifest.Name);
+        }
         
         private void RegisterModuleMenuInSettings(ModuleManager moduleManager) {
             var moduleMi = new ModuleMenuItem(moduleManager) {
-                BasicTooltipText = moduleManager.Manifest.Description,
-                Parent           = _rootModuleSettingsMenuItem
+                BasicTooltipText = moduleManager.Manifest.Description
             };
 
             _moduleMenus.Add(moduleMi, moduleManager);
+
+            _rootModuleSettingsMenuItem.ClearChildren();
+
+            foreach (var menuItemPair in this.GetSortedMenuItems()) {
+                menuItemPair.Key.Parent = _rootModuleSettingsMenuItem;
+            }
         }
 
         private void UnregisterModuleMenuInSettings(ModuleManager moduleManager) {
@@ -342,7 +351,7 @@ namespace Blish_HUD {
                     _moduleMenus.Remove(moduleMenuPair.Key);
 
                     MenuItem toSelect = moduleMenuPair.Key.Selected
-                        ? _moduleMenus.FirstOrDefault().Key ?? _rootModuleSettingsMenuItem
+                        ? this.GetSortedMenuItems().FirstOrDefault().Key ?? _rootModuleSettingsMenuItem
                         : null;
 
                     moduleMenuPair.Key.Parent = null;

--- a/Blish HUD/GameServices/ModuleService.cs
+++ b/Blish HUD/GameServices/ModuleService.cs
@@ -328,7 +328,15 @@ namespace Blish_HUD {
         private readonly Dictionary<MenuItem, ModuleManager> _moduleMenus = new Dictionary<MenuItem, ModuleManager>();
 
         private IOrderedEnumerable<KeyValuePair<MenuItem, ModuleManager>> GetSortedMenuItems() {
-            return _moduleMenus.OrderBy(c => c.Value.Manifest.Name);
+            return _moduleMenus.OrderByDescending(c => c.Value.Enabled).ThenBy(c => c.Value.Manifest.Name);
+        }
+
+        internal void SortMenuItems() {
+            _rootModuleSettingsMenuItem.ClearChildren();
+
+            foreach (var menuItemPair in this.GetSortedMenuItems()) {
+                menuItemPair.Key.Parent = _rootModuleSettingsMenuItem;
+            }
         }
         
         private void RegisterModuleMenuInSettings(ModuleManager moduleManager) {
@@ -338,11 +346,7 @@ namespace Blish_HUD {
 
             _moduleMenus.Add(moduleMi, moduleManager);
 
-            _rootModuleSettingsMenuItem.ClearChildren();
-
-            foreach (var menuItemPair in this.GetSortedMenuItems()) {
-                menuItemPair.Key.Parent = _rootModuleSettingsMenuItem;
-            }
+            this.SortMenuItems();
         }
 
         private void UnregisterModuleMenuInSettings(ModuleManager moduleManager) {

--- a/Blish HUD/GameServices/Modules/ModuleManager.cs
+++ b/Blish HUD/GameServices/Modules/ModuleManager.cs
@@ -113,6 +113,8 @@ namespace Blish_HUD.Modules {
             this.State.Enabled = this.Enabled;
             GameService.Settings.Save();
 
+            GameService.Module.SortMenuItems();
+
             return this.Enabled;
         }
 
@@ -142,6 +144,8 @@ namespace Blish_HUD.Modules {
 
             this.State.Enabled = this.Enabled;
             GameService.Settings.Save();
+
+            GameService.Module.SortMenuItems();
         }
 
         public void DeleteModule() {


### PR DESCRIPTION
This PR aims to add sorting to the module menu items.
In the current implementation it will sort the modules by the enabled state (desc) and then by name (asc).
This will result in disabled modules being at the bottom of the list and enabled at the top. Both sorted by name (asc).

## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/534490472224391169/1219116477999743056

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
