### PR TITLE
Sort module repo

### DIFF
--- a/Blish HUD/GameServices/Modules/UI/Presenters/ManagePkgPresenter.cs
+++ b/Blish HUD/GameServices/Modules/UI/Presenters/ManagePkgPresenter.cs
@@ -7,7 +7,7 @@ using Blish_HUD.Modules.UI.Views;
 using Version = SemVer.Version;
 
 namespace Blish_HUD.Modules.UI.Presenters {
-    public class ManagePkgPresenter : Presenter<ManagePkgView, IGrouping<string, PkgManifest>> {
+    public class ManagePkgPresenter : Presenter<ManagePkgView, IOrderedEnumerable<PkgManifest>> {
 
         private ModuleManager _existingModule;
 
@@ -15,10 +15,10 @@ namespace Blish_HUD.Modules.UI.Presenters {
 
         private PkgManifest _selectedVersion;
 
-        public ManagePkgPresenter(ManagePkgView view, IGrouping<string, PkgManifest> model) : base(view, model) { /* NOOP */ }
+        public ManagePkgPresenter(ManagePkgView view, IOrderedEnumerable<PkgManifest> model) : base(view, model) { /* NOOP */ }
 
         protected override Task<bool> Load(IProgress<string> progress) {
-            _existingModule = GameService.Module.Modules.FirstOrDefault(m => m.Manifest.Namespace == this.Model.Key);
+            _existingModule = GameService.Module.Modules.FirstOrDefault(m => m.Manifest.Namespace == this.Model.LastOrDefault()?.Namespace);
 
             return base.Load(progress);
         }

--- a/Blish HUD/GameServices/Modules/UI/Views/ManagePkgView.cs
+++ b/Blish HUD/GameServices/Modules/UI/Views/ManagePkgView.cs
@@ -158,7 +158,7 @@ namespace Blish_HUD.Modules.UI.Views {
 
         public ManagePkgView() { /* NOOP */ }
 
-        public ManagePkgView(IGrouping<string, PkgManifest> model) {
+        public ManagePkgView(IOrderedEnumerable<PkgManifest> model) {
             this.WithPresenter(new ManagePkgPresenter(this, model));
         }
 


### PR DESCRIPTION
This PR implements default sorting by available updates in the repo view.
It also changes the sorting of the name to use the name of the latest version instead of the first. (Downloaded version order seemed random. Name was not guaranteed to be the same at each start) 

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
