### PR TITLE
Allow searching for descriptions in repo view

### DIFF
--- a/Blish HUD/GameServices/Modules/UI/Views/ModuleRepoView.cs
+++ b/Blish HUD/GameServices/Modules/UI/Views/ModuleRepoView.cs
@@ -97,7 +97,8 @@ namespace Blish_HUD.Modules.UI.Views {
         private bool PkgSearchFilter(ViewContainer viewContainer) {
             var pkgView = viewContainer.CurrentView as ManagePkgView;
 
-            return pkgView.ModuleName.ToLowerInvariant().Contains(_searchbox.Text.ToLowerInvariant());
+            var searchText = _searchbox.Text.ToLowerInvariant();
+            return pkgView.ModuleName.ToLowerInvariant().Contains(searchText) || pkgView.ModuleDescription.ToLowerInvariant().Contains(searchText);
         }
 
         private bool PkgNeedsUpdateFilter(ViewContainer viewContainer) {


### PR DESCRIPTION
This PR implements the ability to search in the descriptions of the repo view.

In my tests it would show all relevant modules when searching for specific keywords.
If only typed a few characters there will be a lot of results but that is to be expected.

## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/536970543736291346/1288444487676203010

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
