### PR TITLE
Panel scrollbar improvements

### DIFF
--- a/Blish HUD/Controls/Scrollbar.cs
+++ b/Blish HUD/Controls/Scrollbar.cs
@@ -234,13 +234,7 @@ namespace Blish_HUD.Controls {
         }
 
         public override void RecalculateLayout() {
-            var lastVal = _scrollbarPercent;
             RecalculateScrollbarSize();
-
-            if (lastVal != _scrollbarPercent && _associatedContainer != null) {
-                this.ScrollDistance       = 0;
-                this.TargetScrollDistance = 0;
-            }
 
             _upArrowBounds   = new Rectangle(this.Width / 2 - _textureUpArrow.Width   / 2, 0,                                                                                                 _textureUpArrow.Width,   _textureUpArrow.Height);
             _downArrowBounds = new Rectangle(this.Width / 2 - _textureDownArrow.Width / 2, this.Height                                                            - _textureDownArrow.Height, _textureDownArrow.Width, _textureDownArrow.Height);
@@ -253,12 +247,12 @@ namespace Blish_HUD.Controls {
         private void RecalculateScrollbarSize() {
             if (_associatedContainer == null) return;
 
-            var tempContainerChidlren = _associatedContainer.Children.ToArray();
+            var tempContainerChildren = _associatedContainer.Children.ToArray();
 
             _containerLowestContent = 0;
 
-            for (int i = 0; i < tempContainerChidlren.Length; i++) {
-                ref var child = ref tempContainerChidlren[i];
+            for (int i = 0; i < tempContainerChildren.Length; i++) {
+                ref var child = ref tempContainerChildren[i];
 
                 if (child.Visible) {
                     _containerLowestContent = Math.Max(_containerLowestContent, child.Bottom);


### PR DESCRIPTION
This PR contains three changes related to the panel scrollbar:
- Add a ScrollDistance property to panel
- Add a ScrollToChild method to panel
- Automatically update the scrollbar position

### ScrollDistance
There is currently no way easily access the scrollbar position. This new property will make it easier to get and set the scrollbar distance.

Usage:
```CSHARP
panel.ScrollDistance = 0.5f;
```

### ScrollToChild
New method that will update the scrollbar distance based on the location of a child control inside the panel.

Usage:
```CSHARP
var panel = new FlowPanel()
{
    Parent = buildPanel,
    Width = 100,
    Height = 100,
    CanScroll = true,
};

var row1 = new ViewContainer()
{
    Parent = panel,
    Size = new Point(100, 100)
};

var row2 = new ViewContainer()
{
    Parent = panel,
    Size = new Point(100, 100)
};

panel.ScrollToChild(row2)
```

### Automatically update the scrollbar position
The scrollbar will reset when the content inside the panel is resized. That means the scroll position resets when opening menu items. With the changes in this PR, the panel will now correctly calculate the scrollbar position after resizing.

Before:
https://github.com/user-attachments/assets/578d4a2f-e938-45f6-a7f8-7e0cb4846c42

After:
https://github.com/user-attachments/assets/4e6820ec-22da-477b-9d3d-5a44e15071bc



## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/599270434642460753/1289759568175431721

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
