### PR TITLE
Add masking for textboxes

### DIFF
--- a/Blish HUD/Controls/TextBox.cs
+++ b/Blish HUD/Controls/TextBox.cs
@@ -38,6 +38,16 @@ namespace Blish_HUD.Controls {
             set => SetProperty(ref _hideBackground, value);
         }
 
+        public bool Masked {
+            get => _masked;
+            set => SetProperty(ref _masked, value, true);
+        }
+
+        public char MaskingChar {
+            get => _maskingChar;
+            set => SetProperty(ref _maskingChar, value, true);
+        }
+
         protected virtual void OnEnterPressed(EventArgs e) {
             this.Focused = false;
 
@@ -98,13 +108,15 @@ namespace Blish_HUD.Controls {
         }
 
         private Rectangle CalculateHighlightRegion() {
+            var text = this.DisplayText;
+
             int selectionStart  = Math.Min(_selectionStart, _selectionEnd);
             int selectionLength = Math.Abs(_selectionStart - _selectionEnd);
 
-            if (selectionLength <= 0 || selectionStart + selectionLength > _text.Length) return Rectangle.Empty;
+            if (selectionLength <= 0 || selectionStart + selectionLength > text.Length) return Rectangle.Empty;
 
-            float highlightLeftOffset = MeasureStringWidth(_text.Substring(0, selectionStart));
-            float highlightWidth      = MeasureStringWidth(_text.Substring(selectionStart, selectionLength));
+            float highlightLeftOffset = MeasureStringWidth(text.Substring(0, selectionStart));
+            float highlightWidth      = MeasureStringWidth(text.Substring(selectionStart, selectionLength));
 
             switch (this.HorizontalAlignment)
             {
@@ -124,14 +136,15 @@ namespace Blish_HUD.Controls {
         }
 
         private Rectangle CalculateCursorRegion() {
-            float textOffset = MeasureStringWidth(_text.Substring(0, _cursorIndex));
+            var text = this.DisplayText;
+            float textOffset = MeasureStringWidth(text.Substring(0, _cursorIndex));
 
             switch (this.HorizontalAlignment) {
                 case HorizontalAlignment.Center:
-                    textOffset += (this.Width - MeasureStringWidth(_text)) / 2f - TEXT_HORIZONTALPADDING;
+                    textOffset += (this.Width - MeasureStringWidth(text)) / 2f - TEXT_HORIZONTALPADDING;
                     break;
                 case HorizontalAlignment.Right:
-                    textOffset += this.Width - MeasureStringWidth(_text) - TEXT_HORIZONTALPADDING * 2;
+                    textOffset += this.Width - MeasureStringWidth(text) - TEXT_HORIZONTALPADDING * 2;
                     break;
                 default: break;
             }

--- a/Blish HUD/Controls/TextBox.cs
+++ b/Blish HUD/Controls/TextBox.cs
@@ -38,11 +38,17 @@ namespace Blish_HUD.Controls {
             set => SetProperty(ref _hideBackground, value);
         }
 
+        /// <summary>
+        /// <inheritdoc cref="TextInputBase._masked"/>
+        /// </summary>
         public bool Masked {
             get => _masked;
             set => SetProperty(ref _masked, value, true);
         }
 
+        /// <summary>
+        /// <inheritdoc cref="TextInputBase._maskingChar"/>
+        /// </summary>
         public char MaskingChar {
             get => _maskingChar;
             set => SetProperty(ref _maskingChar, value, true);

--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -92,6 +92,10 @@ namespace Blish_HUD.Controls {
 
         protected int _maxLength = int.MaxValue;
 
+        public string DisplayText => this._masked
+                ? new string (this._maskingChar, this._text.Length) 
+                : this.Text;
+
         /// <summary>
         /// Gets or sets the maximum character length of the control.
         /// </summary>
@@ -189,6 +193,16 @@ namespace Blish_HUD.Controls {
         /// Gets the length of the text.
         /// </summary>
         public int Length => _text.Length;
+
+        /// <summary>
+        /// Gets or sets if the input should be shown as masked. Copying the content will be disabled.
+        /// </summary>
+        protected bool _masked;
+
+        /// <summary>
+        /// Gets or sets the character used for the masking.
+        /// </summary>
+        protected char _maskingChar = '*';
 
         /// Get state of modifier keys
         protected bool IsShiftDown => GameService.Input.Keyboard.ActiveModifiers.HasFlag(ModifierKeys.Shift);
@@ -587,6 +601,8 @@ namespace Blish_HUD.Controls {
         }
 
         protected virtual void HandleCopy() {
+            if (this._masked) return;
+
             if (_selectionEnd != _selectionStart) {
                 int selectStart = Math.Min(_selectionStart, _selectionEnd);
                 int selectEnd   = Math.Max(_selectionStart, _selectionEnd);
@@ -603,6 +619,8 @@ namespace Blish_HUD.Controls {
         }
 
         protected virtual void HandleCut() {
+            if (this._masked) return;
+
             HandleCopy();
             DeleteSelection();
         }
@@ -785,7 +803,7 @@ namespace Blish_HUD.Controls {
             }
 
             // Draw the text
-            spriteBatch.DrawStringOnCtrl(this, _text, _font, textRegion, _foreColor, false, false, 0, horizontalAlignment, VerticalAlignment.Top);
+            spriteBatch.DrawStringOnCtrl(this, this.DisplayText, _font, textRegion, _foreColor, false, false, 0, horizontalAlignment, VerticalAlignment.Top);
         }
 
         protected void PaintHighlight(SpriteBatch spriteBatch, Rectangle highlightRegion) {


### PR DESCRIPTION
This PR implements basic masking for textboxes.
This is useful/needed if you have password fields or other user sensitive informations inside a textbox.

This change is purely visual. No changes for all prior textbox usages.

## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

None

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
