### PR TITLE
Fix an issue regarding mouse button events on controls during a focus change back to the game window.

### DIFF
--- a/Blish HUD/GameServices/Input/Mouse/MouseHandler.cs
+++ b/Blish HUD/GameServices/Input/Mouse/MouseHandler.cs
@@ -189,8 +189,8 @@ namespace Blish_HUD.Input {
             // we don't necessarily have to check the previous mouse state here as an additional security as this can only be happening on the enable / disable chain right now
             // -> the previous state may also be a dangling leftover so it should even be safer to ignore it
 
-            if (_mouseEvent.EventType == MouseEventType.LeftMouseButtonReleased) {
-                var tmpState = this.State;
+            var tmpState = this.State;
+            if (mouseEvent.EventType == MouseEventType.LeftMouseButtonReleased) {
                 this.State = new MouseState(tmpState.X,
                                             tmpState.Y,
                                             tmpState.ScrollWheelValue,
@@ -201,9 +201,7 @@ namespace Blish_HUD.Input {
                                             tmpState.XButton2);
                 // currently unsure if the MouseData and Flags contained any additional information about the button state maybe requires some bitmagic .. (both seem to always be 0 right now?)
                 HandleMouseEvent(new MouseEventArgs(MouseEventType.LeftMouseButtonPressed, mouseEvent.PointX, mouseEvent.PointY, mouseEvent.MouseData, mouseEvent.Flags, mouseEvent.Time, mouseEvent.Extra));
-                this.State = tmpState;
-            } else if (_mouseEvent.EventType == MouseEventType.RightMouseButtonReleased) {
-                var tmpState = this.State;
+            } else if (mouseEvent.EventType == MouseEventType.RightMouseButtonReleased) {
                 this.State = new MouseState(tmpState.X,
                                             tmpState.Y,
                                             tmpState.ScrollWheelValue,
@@ -214,8 +212,8 @@ namespace Blish_HUD.Input {
                                             tmpState.XButton2);
                 // currently unsure if the MouseData and Flags contained any additional information about the button state maybe requires some bitmagic .. (both seem to always be 0 right now?)
                 HandleMouseEvent(new MouseEventArgs(MouseEventType.RightMouseButtonPressed, mouseEvent.PointX, mouseEvent.PointY, mouseEvent.MouseData, mouseEvent.Flags, mouseEvent.Time, mouseEvent.Extra));
-                this.State = tmpState;
             }
+            this.State = tmpState;
         }
 
         private void HandleMouseEvent(MouseEventArgs mouseEvent) {

--- a/Blish HUD/GameServices/Input/Mouse/MouseHandler.cs
+++ b/Blish HUD/GameServices/Input/Mouse/MouseHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows.Forms;
 using Blish_HUD.Controls;
+using Blish_HUD.Controls.Extern;
 using Blish_HUD.Input.WinApi;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
@@ -44,6 +45,8 @@ namespace Blish_HUD.Input {
         }
 
         private bool _cursorIsVisible = true;
+
+        private bool _recentlyEnabled = false;
 
         /// <summary>
         /// Indicates if the hardware mouse is currently visible.  When <c>false</c>,
@@ -160,20 +163,74 @@ namespace Blish_HUD.Input {
 
             // Handle mouse events blocked by the mouse hook
             if (_mouseEvent != null) {
-                if (HandleHookedMouseEvent(_mouseEvent) && this.CursorIsVisible) {
-                    GameService.Graphics.SpriteScreen.TriggerMouseInput(_mouseEvent.EventType, this.State);
+                if(_recentlyEnabled) {
+                    _recentlyEnabled = false;
+                    SimulateNonCapturePressedEvent(_mouseEvent);
                 }
 
+                HandleMouseEvent(_mouseEvent);
                 _mouseEvent = null;
             }
         }
 
+        /// <summary>
+        /// Meant to simulate missing parts of mouse events (LeftMouseButtonPressed and RightMouseButtonPressed) in case the mouse hook just got enabled. This was not an issue prior to a fix for issue #768 as e.g. the base Control just always operated with the release event.
+        /// Now that the event handling there requires a prime state setup by the respective pressed event this logic exists to simulate said event. This saves us from having to pass down a special case flag to all handlers and aims to keep behaviour consistent since
+        /// there will always be a press and release event and not sometimes just half of it. 
+        /// </summary>
+        /// <param name="mouseEvent">Current mouse event that we need to simulate the missing part for given its one of the 2 cases we even want to handle</param>
+        private void SimulateNonCapturePressedEvent(MouseEventArgs mouseEvent) {
+            // no need to worry about PositionRaw as it will be the same as the simulated event
+            // no need to worry about CameraDragging as it will be the same as the simulated event
+            // ActiveControl is not changed by the mouse event so we also dont have to worry about that one either
+
+            // need to modify the State but it's basically just a copy with changed mouse states
+
+            // we don't necessarily have to check the previous mouse state here as an additional security as this can only be happening on the enable / disable chain right now
+            // -> the previous state may also be a dangling leftover
+
+            if (_mouseEvent.EventType == MouseEventType.LeftMouseButtonReleased) {
+                var tmpState = this.State;
+                this.State = new MouseState(tmpState.X,
+                                            tmpState.Y,
+                                            tmpState.ScrollWheelValue,
+                                            Microsoft.Xna.Framework.Input.ButtonState.Pressed,
+                                            tmpState.MiddleButton,
+                                            tmpState.RightButton,
+                                            tmpState.XButton1,
+                                            tmpState.XButton2);
+                // currently unsure if the MouseData and Flags contained any additional information about the button state maybe requires some bitmagic ..
+                HandleMouseEvent(new MouseEventArgs(MouseEventType.LeftMouseButtonPressed, mouseEvent.PointX, mouseEvent.PointY, mouseEvent.MouseData, mouseEvent.Flags, mouseEvent.Time, mouseEvent.Extra));
+                this.State = tmpState;
+            } else if (_mouseEvent.EventType == MouseEventType.RightMouseButtonReleased) {
+                var tmpState = this.State;
+                this.State = new MouseState(tmpState.X,
+                                            tmpState.Y,
+                                            tmpState.ScrollWheelValue,
+                                            tmpState.LeftButton,
+                                            tmpState.MiddleButton,
+                                            Microsoft.Xna.Framework.Input.ButtonState.Pressed,
+                                            tmpState.XButton1,
+                                            tmpState.XButton2);
+                // currently unsure if the MouseData and Flags contained any additional information about the button state maybe requires some bitmagic ..
+                HandleMouseEvent(new MouseEventArgs(MouseEventType.RightMouseButtonPressed, mouseEvent.PointX, mouseEvent.PointY, mouseEvent.MouseData, mouseEvent.Flags, mouseEvent.Time, mouseEvent.Extra));
+                this.State = tmpState;
+            }
+        }
+
+        private void HandleMouseEvent(MouseEventArgs mouseEvent) {
+            if (HandleHookedMouseEvent(mouseEvent) && this.CursorIsVisible) {
+                GameService.Graphics.SpriteScreen.TriggerMouseInput(mouseEvent.EventType, this.State);
+            }
+        }
+
         public void OnEnable() {
-            /* NOOP */
+            _recentlyEnabled = true;
         }
 
         public void OnDisable() {
-            /* NOOP */
+            // shouldn't be needed even but can't hurt to tidy up a little
+            _recentlyEnabled = false;
         }
 
         public void UnsetActiveControl() {


### PR DESCRIPTION
My original intention was a separate flag that was supposed to be passed down to the event target (in this case Control.cs) to then disable the _clickPrimed flag in place. I did end up implementing a simulated mouse button press event instead to keep the behaviour more in line with normal expectations even from a developer point of view (meaning for every release there should be a press event). This also keeps the changes necessary to the MouseHandler and avoids passing around special case flags. 

If simulated events should be considered a big no no it would not be an issue to instead provide the flag as an additional event args field. 

## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/534492012263636992/1296923001756848319

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No, instead restores focus change behaviour prior to the merge of #768 
