### PR TITLE
Update System.Text.Json 5.0.0 (transitive reference) -> 9.0.0 (direct…

### DIFF
--- a/Blish HUD/Blish HUD.csproj
+++ b/Blish HUD/Blish HUD.csproj
@@ -258,6 +258,7 @@
     <PackageReference Include="protobuf-net" Version="3.0.101" PrivateAssets="all" />
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
+    <PackageReference Include="System.Text.Json" Version="[9.0.0]" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Discussion Reference
https://discord.com/channels/531175899588984842/599270434642460753/1307336003156971574

## Is this a breaking change?

(AI generated)

**Polymorphic Serialization**: Polymorphism for object types with custom converters was disabled in .NET 7. All object values now rely on the custom converter, requiring explicit type specification for polymorphism.

**Source Generator Behavior**: Reflection fallback in source-generated serializers was removed, requiring explicit annotation for all serialized types.

**JsonSerializerOptions Copying**: Copying JsonSerializerOptions now preserves the JsonSerializerContext, affecting reuse scenarios.

## Justification

Currently, System.Text.Json 5.0.0 is already present as a transitive dependency of Gw2Sharp, but this version is obsolete and missing newer features like polymorphic serialization, which is a feature I want to use in my module.

Rather than updating Gw2Sharp and then updating Blish HUD, it seems appropriate to me that Blish HUD should dictate which version of the library is available. It's not possible to choose a different version as a module author. (Gw2Sharp may continue to target `>=5.0.0` for broadest compatibility, I don't think it is affected by the breaking changes above.)

I have made sure that Blish HUD still runs with this newer package version. However, existing modules that use System.Text.Json might be affected by the breaking changes. This is a general problem with the Blish module ecosystem, not specific to this change.

Also consider the performance improvements made to System.Text.Json in the last 4 major versions. This update should make Blish HUD somewhat more efficient.