### PR TITLE
Add the ability to stop mouse event propagation

### DIFF
--- a/Blish HUD/Controls/Container.cs
+++ b/Blish HUD/Controls/Container.cs
@@ -210,12 +210,16 @@ namespace Blish_HUD.Controls {
             }
         }
 
-        public override Control TriggerMouseInput(MouseEventType mouseEventType, MouseState ms) {
+        public override Control TriggerMouseInput(MouseEventArgs args, MouseState ms) {
             Control thisResult  = null;
             Control childResult = null;
 
             if (CapturesInput() != CaptureType.None) {
-                thisResult = base.TriggerMouseInput(mouseEventType, ms);
+                thisResult = base.TriggerMouseInput(args, ms);
+            }
+
+            if (args.PropagationStopped) {
+                return thisResult;
             }
 
             List<Control>               children        = _children.ToList();
@@ -223,7 +227,7 @@ namespace Blish_HUD.Controls {
 
             foreach (var childControl in zSortedChildren) {
                 if (childControl.AbsoluteBounds.Contains(ms.Position) && childControl.Visible) {
-                    childResult = childControl.TriggerMouseInput(mouseEventType, ms);
+                    childResult = childControl.TriggerMouseInput(args, ms);
 
                     if (childResult != null) {
                         if (!childResult.Captures.HasFlag(CaptureType.Filter)) {
@@ -233,6 +237,10 @@ namespace Blish_HUD.Controls {
                         // Child has Filter flag so we have to pretend we didn't see it
                         childResult = null;
                     }
+                }
+
+                if (args.PropagationStopped) {
+                    break;
                 }
             }
 

--- a/Blish HUD/Controls/Control.cs
+++ b/Blish HUD/Controls/Control.cs
@@ -208,7 +208,14 @@ namespace Blish_HUD.Controls {
             if (_enabled && _clickPrimed) {
                 // Distinguish click from double-click
                 if (GameService.Overlay.CurrentGameTime.TotalGameTime.TotalMilliseconds - _lastClickTime < SystemInformation.DoubleClickTime) {
-                    OnClick(new MouseEventArgs(e.EventType, true));
+                    var doubleClickArgs = new MouseEventArgs(e.EventType, true);
+                    OnClick(doubleClickArgs);
+
+                    // Ensure that when double-click propagation is stopped, it also
+                    // stops propagating the single-click event
+                    if (doubleClickArgs.PropagationStopped) {
+                        e.StopPropagation();
+                    }
                 } else {
                     _lastClickTime = GameService.Overlay.CurrentGameTime.TotalGameTime.TotalMilliseconds;
                     OnClick(e);
@@ -810,34 +817,44 @@ namespace Blish_HUD.Controls {
             return CaptureType.Mouse;
         }
 
+        [Obsolete("This overload does not support stopping propagation, use the overload that takes MouseEventArgs.")]
         protected void TriggerMouseEvent(MouseEventType mouseEventType) {
-            switch (mouseEventType) {
+            TriggerMouseEvent(new MouseEventArgs(mouseEventType));
+        }
+
+        protected void TriggerMouseEvent(MouseEventArgs args) {
+            switch (args.EventType) {
                 case MouseEventType.LeftMouseButtonPressed:
-                    OnLeftMouseButtonPressed(new MouseEventArgs(MouseEventType.LeftMouseButtonPressed));
+                    OnLeftMouseButtonPressed(args);
                     break;
                 case MouseEventType.LeftMouseButtonReleased:
-                    OnLeftMouseButtonReleased(new MouseEventArgs(MouseEventType.LeftMouseButtonReleased));
+                    OnLeftMouseButtonReleased(args);
                     break;
                 case MouseEventType.RightMouseButtonPressed:
-                    OnRightMouseButtonPressed(new MouseEventArgs(MouseEventType.RightMouseButtonPressed));
+                    OnRightMouseButtonPressed(args);
                     break;
                 case MouseEventType.RightMouseButtonReleased:
-                    OnRightMouseButtonReleased(new MouseEventArgs(MouseEventType.RightMouseButtonReleased));
+                    OnRightMouseButtonReleased(args);
                     break;
                 case MouseEventType.MouseMoved:
-                    OnMouseMoved(new MouseEventArgs(MouseEventType.MouseMoved));
+                    OnMouseMoved(args);
                     this.MouseOver = true;
                     break;
                 case MouseEventType.MouseWheelScrolled:
-                    OnMouseWheelScrolled(new MouseEventArgs(MouseEventType.MouseWheelScrolled));
+                    OnMouseWheelScrolled(args);
                     break;
             }
         }
 
+        [Obsolete("This overload does not support stopping propagation, use the overload that takes MouseEventArgs.")]
         public virtual Control TriggerMouseInput(MouseEventType mouseEventType, MouseState ms) {
+            return TriggerMouseInput(new MouseEventArgs(mouseEventType), ms);
+        }
+
+        public virtual Control TriggerMouseInput(MouseEventArgs args, MouseState ms) {
             var inputCapture = CapturesInput();
 
-            switch (mouseEventType) {
+            switch (args.EventType) {
                 case MouseEventType.MouseMoved:
                 case MouseEventType.LeftMouseButtonPressed:
                 case MouseEventType.LeftMouseButtonReleased:
@@ -846,13 +863,13 @@ namespace Blish_HUD.Controls {
                 case MouseEventType.MouseEntered:
                 case MouseEventType.MouseLeft:
                     if (inputCapture.HasFlag(CaptureType.Mouse) || inputCapture.HasFlag(CaptureType.Filter)) {
-                        TriggerMouseEvent(mouseEventType);
+                        TriggerMouseEvent(args);
                         return this;
                     }
                     break;
                 case MouseEventType.MouseWheelScrolled:
                     if (inputCapture.HasFlag(CaptureType.MouseWheel) || inputCapture.HasFlag(CaptureType.Filter)) {
-                        TriggerMouseEvent(mouseEventType);
+                        TriggerMouseEvent(args);
                         return this;
                     }
                     break;

--- a/Blish HUD/Controls/Panel.cs
+++ b/Blish HUD/Controls/Panel.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Newtonsoft.Json;
 using System;
 using System.ComponentModel;
+using Microsoft.Xna.Framework.Input;
 
 namespace Blish_HUD.Controls {
 
@@ -144,15 +145,20 @@ namespace Blish_HUD.Controls {
 
         /// <inheritdoc />
         protected override void OnClick(MouseEventArgs e) {
-            if (!string.IsNullOrEmpty(_title) && _layoutHeaderBounds.Contains(this.RelativeMousePosition)) {
-                if (_canCollapse) {
-                    this.ToggleAccordionState();
-                }
-
-                e.StopPropagation();
+            if (_canCollapse && _layoutHeaderBounds.Contains(this.RelativeMousePosition)) {
+                this.ToggleAccordionState();
             }
 
             base.OnClick(e);
+        }
+
+        /// <inheritdoc />
+        public override Control TriggerMouseInput(MouseEventArgs args, MouseState ms) {
+            if (!string.IsNullOrEmpty(_title) && _layoutHeaderBounds.Contains(this.RelativeMousePosition)) {
+                args.StopPropagation();
+            }
+
+            return base.TriggerMouseInput(args, ms);
         }
 
         protected override void OnChildAdded(ChildChangedEventArgs e) {

--- a/Blish HUD/Controls/Panel.cs
+++ b/Blish HUD/Controls/Panel.cs
@@ -144,8 +144,12 @@ namespace Blish_HUD.Controls {
 
         /// <inheritdoc />
         protected override void OnClick(MouseEventArgs e) {
-            if (_canCollapse && _layoutHeaderBounds.Contains(this.RelativeMousePosition)) {
-                this.ToggleAccordionState();
+            if (!string.IsNullOrEmpty(_title) && _layoutHeaderBounds.Contains(this.RelativeMousePosition)) {
+                if (_canCollapse) {
+                    this.ToggleAccordionState();
+                }
+
+                e.StopPropagation();
             }
 
             base.OnClick(e);

--- a/Blish HUD/GameServices/Input/Mouse/MouseEventArgs.cs
+++ b/Blish HUD/GameServices/Input/Mouse/MouseEventArgs.cs
@@ -46,6 +46,15 @@ namespace Blish_HUD.Input {
             }
         }
 
+        internal bool PropagationStopped { get; private set; }
+
+        /// <summary>
+        /// Prevents the current mouse event from being propagated to other event listeners.
+        /// </summary>
+        public void StopPropagation() {
+            this.PropagationStopped = true;
+        }
+
         public MouseEventArgs(MouseEventType eventType) { this.EventType = eventType; }
 
         public MouseEventArgs(MouseEventType eventType, bool isDoubleClick) : this(eventType) { this.IsDoubleClick = isDoubleClick; }

--- a/Blish HUD/GameServices/Input/Mouse/MouseHandler.cs
+++ b/Blish HUD/GameServices/Input/Mouse/MouseHandler.cs
@@ -153,11 +153,13 @@ namespace Blish_HUD.Input {
 
             // Handle mouse moved
             if (prevMouseState.Position != this.State.Position) {
+                var mouseMovedArgs = new MouseEventArgs(MouseEventType.MouseMoved);
+
                 if (this.CursorIsVisible) {
-                    this.ActiveControl = GameService.Graphics.SpriteScreen.TriggerMouseInput(MouseEventType.MouseMoved, this.State);
+                    this.ActiveControl = GameService.Graphics.SpriteScreen.TriggerMouseInput(mouseMovedArgs, this.State);
                 }
 
-                this.MouseMoved?.Invoke(this, new MouseEventArgs(MouseEventType.MouseMoved));
+                this.MouseMoved?.Invoke(this, mouseMovedArgs);
             }
 
             // Handle mouse events blocked by the mouse hook
@@ -218,7 +220,7 @@ namespace Blish_HUD.Input {
 
         private void HandleMouseEvent(MouseEventArgs mouseEvent) {
             if (HandleHookedMouseEvent(mouseEvent) && this.CursorIsVisible) {
-                GameService.Graphics.SpriteScreen.TriggerMouseInput(mouseEvent.EventType, this.State);
+                GameService.Graphics.SpriteScreen.TriggerMouseInput(mouseEvent, this.State);
             }
         }
 


### PR DESCRIPTION
This PR adds the ability to stop click events (or any other mouse event) from propagating.

```diff
private void OnClick(object sender, MouseEventArgs e) {
    Console.WriteLine("Click was handled here");
+    e.StopPropagation();
}
```

This is useful when a click should be handled by a node and then stopped without propagating all the way down to leaf nodes.

An example where this is useful is in scrollable accordions. Previously, clicking the header to collapse the panel would also propagate the click to controls behind the header.

The fix for clicks on Panel headers is included in the PR.

**Before**

https://github.com/user-attachments/assets/cc088e66-29db-4536-8dba-22e8a66c2324

**After**

https://github.com/user-attachments/assets/2d7c5916-4337-4f00-9f6f-5bd6e2f7b3ac

## Discussion Reference
https://discord.com/channels/531175899588984842/536970543736291346/1330148945749475358

## Is this a breaking change?

I don't expect this change to break any modules, although I marked 2 methods as Obsolete because they did not support this change. I added new overloads to support this change. The old methods will continue to work, just without the ability to stop propagation, i.e. calling `StopPropagation()` will do nothing.
