### PR TITLE
Fix UI culture of message loop threads when language is changed

### DIFF
--- a/Blish HUD/GameServices/OverlayService.cs
+++ b/Blish HUD/GameServices/OverlayService.cs
@@ -225,8 +225,9 @@ namespace Blish_HUD {
         private void UserLocaleOnSettingChanged(object sender, ValueChangedEventArgs<Locale> e) {
             var culture = GetCultureFromGw2Locale(e.NewValue);
 
+            // Update the UI culture for the entire application domain by setting DefaultThreadCurrentUICulture
+            // DO NOT change CurrentUICulture, otherwise running threads will NOT get updated with the new default.
             CultureInfo.DefaultThreadCurrentUICulture = culture;
-            CultureInfo.CurrentUICulture              = culture;
 
             this.UserLocaleChanged?.Invoke(this, new ValueEventArgs<CultureInfo>(culture));
         }


### PR DESCRIPTION
This PR fixes an issue where changing the language of Blish HUD does not change the UI culture of the message loop thread. As a result, you might not see the correct `CurrentUICulture` in event handling code, e.g. `TextBox.TextChanged`.

## Discussion Reference
https://discord.com/channels/531175899588984842/536970543736291346/1335585457601249321

## Is this a breaking change?

Probably not.