### PR TITLE
Revised Tooltip & ContextMenuItem for GC

### DIFF
--- a/Blish HUD/Common/UI/Views/BasicTooltipView.cs
+++ b/Blish HUD/Common/UI/Views/BasicTooltipView.cs
@@ -25,8 +25,6 @@ namespace Blish_HUD.Common.UI.Views {
 
         protected override void Build(Container buildPanel) {
             _tooltipLabel.Parent = buildPanel;
-
-            buildPanel.Hidden += (sender, args) => buildPanel.Dispose();
         }
 
         private void UpdateLabelValueAndWidth(string value) {

--- a/Blish HUD/Controls/ContextMenuStrip.cs
+++ b/Blish HUD/Controls/ContextMenuStrip.cs
@@ -10,7 +10,7 @@ namespace Blish_HUD.Controls {
     /// <summary>
     /// Represents a right-click shortcut menu.  Can be assigned to <see cref="Control.Menu"/>.
     /// </summary>
-    public class ContextMenuStrip : Container {
+    public class ContextMenuStrip : ReferenceCountedContainer {
 
         private const int BORDER_PADDING = 2;
 

--- a/Blish HUD/Controls/Control.cs
+++ b/Blish HUD/Controls/Control.cs
@@ -118,6 +118,10 @@ namespace Blish_HUD.Controls {
 
         #endregion
 
+        ~Control() {
+            Dispose();
+        }
+
         static Control() {
             _defaultSpriteBatchParameters = new SpriteBatchParameters();
 
@@ -559,9 +563,14 @@ namespace Blish_HUD.Controls {
             get {
                 if (_tooltip != null && !_tooltip._disposedValue) return _tooltip;
 
-                return !string.IsNullOrWhiteSpace(_basicTooltipText)
-                    ? _tooltip = new Tooltip(new BasicTooltipView(_basicTooltipText))
-                    : null;
+                if (!string.IsNullOrWhiteSpace(_basicTooltipText)) {
+                    var tooltip = new Tooltip(new BasicTooltipView(_basicTooltipText));
+
+                    if (SetProperty(ref _tooltip, tooltip))
+                        return tooltip;
+                }
+
+                return null;
             }
             set => SetProperty(ref _tooltip, value);
         }
@@ -959,6 +968,12 @@ namespace Blish_HUD.Controls {
                     // Cancel any animations that were currently running on this object
                     Animation.Tweener.TargetCancel(this);
 
+                    //Menu will be disposed if there are no other references to it
+                    this.Tooltip = null;
+
+                    //Menu will be disposed if there are no other references to it
+                    this.Menu = null;
+
                     // Remove self from parent object
                     this.Parent = null;
 
@@ -989,8 +1004,14 @@ namespace Blish_HUD.Controls {
         protected bool SetProperty<T>(ref T property, T newValue, bool invalidateLayout = false, [CallerMemberName] string propertyName = null) {
             if (Equals(property, newValue) || propertyName == null) return false;
 
+            if(property is IReferenceCountedObject currentRefProp)
+                currentRefProp.DecrementReference();
+
             property = newValue;
 
+            if (property is IReferenceCountedObject newRefProp)
+                newRefProp.IncrementReference();
+            
             OnPropertyChanged(propertyName, invalidateLayout);
 
             return true;

--- a/Blish HUD/Controls/Control.cs
+++ b/Blish HUD/Controls/Control.cs
@@ -119,7 +119,8 @@ namespace Blish_HUD.Controls {
         #endregion
 
         ~Control() {
-            Dispose();
+            // Pass false so the managed objects are not released
+            Dispose(false);
         }
 
         static Control() {

--- a/Blish HUD/Controls/ReferenceCountedContainer.cs
+++ b/Blish HUD/Controls/ReferenceCountedContainer.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading;
+
+namespace Blish_HUD.Controls {
+    public interface IReferenceCountedObject {
+        void IncrementReference();
+        void DecrementReference();
+        bool IsSafeToDispose();
+    }
+
+    public abstract class ReferenceCountedContainer : Container, IReferenceCountedObject {
+        private int _referenceCount;
+
+        public void IncrementReference() {
+            Interlocked.Increment(ref _referenceCount);
+        }
+
+        public void DecrementReference() {
+            //Something went wrong and the reference count was not incremented
+            if(_referenceCount == 0) return;
+
+            if (Interlocked.Decrement(ref _referenceCount) == 0) {
+                Dispose();
+            }
+        }
+
+        public bool IsSafeToDispose() {
+            return _referenceCount == 0;
+        }
+
+        protected override void DisposeControl() {
+            if (!IsSafeToDispose())
+                return;
+
+            base.DisposeControl();
+        }
+    }
+}

--- a/Blish HUD/Controls/Tooltip.cs
+++ b/Blish HUD/Controls/Tooltip.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,7 +9,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Blish_HUD.Controls {
-   public class Tooltip : Container, IViewContainer {
+   public class Tooltip : ReferenceCountedContainer, IViewContainer {
         
         internal const int MOUSE_VERTICAL_MARGIN = 36;
 
@@ -49,7 +49,8 @@ namespace Blish_HUD.Controls {
 
         private static void ControlOnActiveControlChanged(object sender, ControlActivatedEventArgs e) {
             foreach (var tooltip in _allTooltips) {
-                tooltip.Hide();
+                if(tooltip.Visible)
+                    tooltip.Hide();
             }
 
             if (_prevControl != null) {
@@ -248,6 +249,9 @@ namespace Blish_HUD.Controls {
 
         protected override void DisposeControl() {
             this.CurrentView?.DoUnload();
+            
+            if(_allTooltips != null && _allTooltips.Contains(this))
+                _allTooltips.Remove(this);
 
             foreach (var control in _children) {
                 control.Resized -= Invalidate;


### PR DESCRIPTION
This PR aims to solve the issues described in: https://github.com/blish-hud/Blish-HUD/issues/941:

## Tooltip & Menu

- Inherit from a new base class ReferencedCountedContainer that will track how many times the object is used by controls.
- Are disposed when they not used by any controls (done by setting the property to null during control disposal).
- The Tooltip is also removed from the static `_allTooltips` property when the Tooltip is disposed to avoid any left-over references.

Example:
```CSHARP
var tooltip = new Tooltip()
var imageControl = new Image();
var labelControl = new Label();

imageControl.Tooltip = tooltip; //_referenceCount = 1
labelControl.Tooltip = tooltip; //_referenceCount = 2

imageControl.Dispose() //Tooltip is not disposed (_referenceCount = 1)
labelControl.Dispose() //Tooltip is disposed (_referenceCount = 0)
```

## Finalizer

A finalizer has been added to the Control class to ensure that Dispose is called when objects are collected by the GC. However, this still does not guarantee that it's disposed when the program is terminated. This is only a problem when classes derived from Control use unmanaged resources that are released by the dispose method.

## Potential problems
The DisposeControl method is not guaranteed to be called in every scenario. An example of this is when the program is terminated, because the GC may not have called the finalizer on the control at that point. This means that any unmanaged resources could linger while they should have been released by the DisposeControl method.

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
