### PR TITLE
Allow prerelease versions to update to newer non-prerelease versions.

### DIFF
--- a/Blish HUD/GameServices/Overlay/OverlayUpdateHandler.cs
+++ b/Blish HUD/GameServices/Overlay/OverlayUpdateHandler.cs
@@ -42,7 +42,7 @@ namespace Blish_HUD.Overlay {
         /// <summary>
         /// The highest version release.  Will include prereleases only if <see cref="PrereleasesVisible"/> is <c>true</c>.
         /// </summary>
-        public CoreVersionManifest LatestRelease => _availableUpdates.Where(manifest => manifest.IsPrerelease == GameService.Overlay.ShowPreviews.Value)
+        public CoreVersionManifest LatestRelease => _availableUpdates.Where(manifest => GameService.Overlay.ShowPreviews.Value || !manifest.IsPrerelease)
                                                                      .OrderByDescending(manifest => manifest.Version)
                                                                      .FirstOrDefault();
 


### PR DESCRIPTION
If a user currently has prereleases enabled, a newer non-preview release will not be included in the list of available releases.

For now, I'm accounting for this by listing v1.3.0 as both a preview and non-preview release so all clients find it as the latest version, but going forward this fix will ensure that a user with prereleases enabled will still be prompted to update to newer non-preview release versions.

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
