### PR TITLE
Wrap Debug logger in async target to avoid blocking calling thread

### DIFF
--- a/Blish HUD/GameServices/DebugService.cs
+++ b/Blish HUD/GameServices/DebugService.cs
@@ -134,8 +134,13 @@ namespace Blish_HUD {
                 }
             };
 
-            _logConfiguration.AddTarget(logDebug);
-            _logConfiguration.AddRule(LogLevel.Debug, LogLevel.Fatal, logDebug);
+            // MethodCallTarget is synchronous and also quite slow, wrap it in an async target to avoid blocking the main thread
+            var asyncDebug = new AsyncTargetWrapper("asyncdebug", logDebug) {
+                ForceLockingQueue = false
+            };
+
+            _logConfiguration.AddTarget(asyncDebug);
+            _logConfiguration.AddRule(LogLevel.Debug, LogLevel.Fatal, asyncDebug);
         }
 
         public static void UpdateLogLevel(LogLevel newLogLevel) {


### PR DESCRIPTION
NLog's `MethodCallTarget` is pretty slow (4-5x slower than directly calling `Debugger.Log` on my machine) and ever so slightly slows down all modules while a debugger is attached, or when the user has enabled debug logging in the overlay settings.

Wrapping the debug target in an async target speeds up `Logger` methods dramatically and avoids blocking the calling thread, which is pretty important because calls to `Debugger.Log` are synchronized by a `lock` statement during debugging. (The lock only affects debugging sessions.)

This fix primarily helps speed up debugging code with verbose logging, but it also benefits users who play with debug logging enabled for whatever reason.

## Discussion Reference
https://discord.com/channels/531175899588984842/536970543736291346/1458955030781624447

## Is this a breaking change?
No
