### PR TITLE
Fix window title margin when emblem is not set

### DIFF
--- a/Blish HUD/Controls/WindowBase2.cs
+++ b/Blish HUD/Controls/WindowBase2.cs
@@ -24,6 +24,12 @@ namespace Blish_HUD.Controls {
 
         private const int STANDARD_MARGIN = 16; // Standard margin used to space the "X" button, etc.
 
+        /// <summary>
+        /// Returns the title offset based on whether an emblem is present.
+        /// Uses STANDARD_MARGIN when no emblem to avoid large gap at the left.
+        /// </summary>
+        private int TitleOffset => _emblem != null ? STANDARD_TITLEOFFSET : STANDARD_MARGIN;
+
         private const int SIDEBAR_WIDTH  = 46;
         private const int SIDEBAR_OFFSET = 3; // Used to account for the small edge of transparency at the bottom of the titlebar and between the sidebar and the window background
 
@@ -440,7 +446,7 @@ namespace Blish_HUD.Controls {
             if (!string.IsNullOrWhiteSpace(this.Title) && !string.IsNullOrWhiteSpace(this.Subtitle)) {
                 int titleTextWidth = (int) Content.DefaultFont32.MeasureString(this.Title).Width;
 
-                _subtitleDrawBounds = _leftTitleBarDrawBounds.OffsetBy(STANDARD_TITLEOFFSET + titleTextWidth + STANDARD_SUBTITLEOFFSET, 0);
+                _subtitleDrawBounds = _leftTitleBarDrawBounds.OffsetBy(TitleOffset + titleTextWidth + STANDARD_SUBTITLEOFFSET, 0);
             }
 
             // Emblem bounds
@@ -703,7 +709,7 @@ namespace Blish_HUD.Controls {
 
         private void PaintTitleText(SpriteBatch spriteBatch) {
             if (!string.IsNullOrWhiteSpace(this.Title)) {
-                spriteBatch.DrawStringOnCtrl(this, this.Title, Content.DefaultFont32, _leftTitleBarDrawBounds.OffsetBy(STANDARD_TITLEOFFSET, 0), ContentService.Colors.ColonialWhite);
+                spriteBatch.DrawStringOnCtrl(this, this.Title, Content.DefaultFont32, _leftTitleBarDrawBounds.OffsetBy(TitleOffset, 0), ContentService.Colors.ColonialWhite);
 
                 if (!string.IsNullOrWhiteSpace(this.Subtitle)) {
                     spriteBatch.DrawStringOnCtrl(this, this.Subtitle, Content.DefaultFont16, _subtitleDrawBounds, Color.White);


### PR DESCRIPTION
When a window has no emblem set, the title text was still offset by STANDARD_TITLEOFFSET (80px), leaving a large gap on the left side.

This adds a TitleOffset property that uses STANDARD_MARGIN (16px) when no emblem is present, providing proper alignment for emblem-less windows.

## Discussion Reference
_All new features must be discussed prior to code review.  This is to ensure that the implementation aligns with other design considerations.  Please link to the Discord discussion:_

https://discord.com/channels/531175899588984842/536970543736291346/1460072186500087818

## Is this a breaking change?
_Breaking changes require additional review prior to merging.  If you answer yes, please explain what breaking changes have been made._

No
