### PR TITLE
Load assets from disk first and then try background update

### DIFF
--- a/Blish HUD/GameServices/Content/DatAssetCache.cs
+++ b/Blish HUD/GameServices/Content/DatAssetCache.cs
@@ -68,19 +68,18 @@ namespace Blish_HUD.Content {
         private async Task<Stream> DownloadMetadata() {
             string metadataCache = Path.Combine(_assetCachePath, METADATA_FILE);
 
-            var metadataStream = Stream.Null;
-
             try {
                 byte[] rawMetadata = await $"{ASSETSERV_HOST}/{METADATA_FILE}".GetBytesAsync();
 
                 File.WriteAllBytes(metadataCache, rawMetadata);
-                metadataStream = new MemoryStream(rawMetadata);
-                Logger.Info("Metadata update successful");
-            } catch (Exception ex) {
-                Logger.Warn(ex, "Failed to load asset metadata.");
-            }
+                Logger.Debug("Metadata update successful");
 
-            return metadataStream;
+                return new MemoryStream(rawMetadata);
+            } catch (Exception ex) {
+                Logger.Info(ex, "Failed to load asset metadata.");
+
+                return Stream.Null;
+            }
         }
 
         private void EarlyLoad() {
@@ -91,14 +90,14 @@ namespace Blish_HUD.Content {
                 // Open local file and run background update
                 using Stream localMetadataStream = File.Open(metadataCache, FileMode.Open, FileAccess.Read, FileShare.Read);
                 ProcessMetadataStream(localMetadataStream);
-                Logger.Info("Local metadata loaded, trying background update");
+                Logger.Debug("Local metadata loaded, trying background update");
 
                 _ = Task.Run(async () =>
                 {
                     try {
                         using var _ = await DownloadMetadata().ConfigureAwait(false);
                     } catch (Exception ex) {
-                        Logger.Warn(ex, "Background metadata refresh failed");
+                        Logger.Info(ex, "Background metadata refresh failed");
                     }
                 });
             } else {
@@ -111,7 +110,7 @@ namespace Blish_HUD.Content {
 
         private void ProcessMetadataStream(Stream metadataStream) {
             if (metadataStream.Length == 0) {
-                Logger.Warn("Failed to load asset metadata.  Textures won't be loaded.");
+                Logger.Info("Failed to load asset metadata. Textures won't be loaded.");
 
                 _textureReferences = new Dictionary<int, TextureReference>(0);
                 _textureSizes = Array.Empty<Point>();

--- a/Blish HUD/GameServices/Content/DatAssetCache.cs
+++ b/Blish HUD/GameServices/Content/DatAssetCache.cs
@@ -85,27 +85,25 @@ namespace Blish_HUD.Content {
         private void EarlyLoad() {
             string metadataCache = Path.Combine(_assetCachePath, METADATA_FILE);
 
-            // Check if metadata cache exists locally
+            // Use either existing metadata cache or fallback to ref.dat
             if (File.Exists(metadataCache)) {
-                // Open local file and run background update
                 using Stream localMetadataStream = File.Open(metadataCache, FileMode.Open, FileAccess.Read, FileShare.Read);
                 ProcessMetadataStream(localMetadataStream);
                 Logger.Debug("Local metadata loaded, trying background update");
-
-                _ = Task.Run(async () =>
-                {
-                    try {
-                        using var _ = await DownloadMetadata().ConfigureAwait(false);
-                    } catch (Exception ex) {
-                        Logger.Info(ex, "Background metadata refresh failed");
-                    }
-                });
             } else {
-                // No local cache - wait for the download
-                Logger.Warn("Local metadata not found, downloading");
-                using Stream metadataStream = DownloadMetadata().GetAwaiter().GetResult();
+                using Stream metadataStream = LoadFallbackMetadataStream();
                 ProcessMetadataStream(metadataStream);
+                Logger.Debug("Falling back to ref.dat, trying background update");
             }
+
+            // Try background update of metadata cache
+            _ = Task.Run(async () => {
+                try {
+                    using var _ = await DownloadMetadata().ConfigureAwait(false);
+                } catch (Exception ex) {
+                    Logger.Info(ex, "Background metadata refresh failed");
+                }
+            });
         }
 
         private void ProcessMetadataStream(Stream metadataStream) {

--- a/Blish HUD/GameServices/Content/DatAssetCache.cs
+++ b/Blish HUD/GameServices/Content/DatAssetCache.cs
@@ -65,31 +65,48 @@ namespace Blish_HUD.Content {
             return Stream.Null;
         }
 
-        private Stream LoadMetadataStream() {
+        private async Task<Stream> LoadMetadataStream() {
             string metadataCache = Path.Combine(_assetCachePath, METADATA_FILE);
 
             var metadataStream = Stream.Null;
 
             try {
                 // We block for this on purpose
-                byte[] rawMetadata = $"{ASSETSERV_HOST}/{METADATA_FILE}".GetBytesAsync().GetAwaiter().GetResult();
+                byte[] rawMetadata = await $"{ASSETSERV_HOST}/{METADATA_FILE}".GetBytesAsync();
 
                 File.WriteAllBytes(metadataCache, rawMetadata);
                 metadataStream = new MemoryStream(rawMetadata);
+                Logger.Info("Metadata update successful");
             } catch (Exception ex) {
-                Logger.Warn(ex, "Failed to load asset metadata.  Will attempt to load from local cache instead");
-                metadataStream = File.Exists(metadataCache)
-                                     // Use the last one successfully downloaded
-                                     ? File.Open(metadataCache, FileMode.Open, FileAccess.Read, FileShare.Read)
-                                     // Yikes, use the one we ship with
-                                     : LoadFallbackMetadataStream(); 
+                Logger.Warn(ex, "Failed to load asset metadata.");
             }
 
             return metadataStream;
         }
 
         private void EarlyLoad() {
-            using var metadataStream = LoadMetadataStream();
+            string metadataCache = Path.Combine(_assetCachePath, METADATA_FILE);
+            var metadataStream = Stream.Null;
+
+            // Check if metadata cache exists locally
+            if (File.Exists(metadataCache)) {
+                // Open local file and kick off background update
+                metadataStream = File.Open(metadataCache, FileMode.Open, FileAccess.Read, FileShare.Read);
+                Logger.Info("Local metadata loaded, trying background update");
+
+                _ = Task.Run(async () =>
+                {
+                    try {
+                        using var _ = await LoadMetadataStream().ConfigureAwait(false);
+                    } catch (Exception ex) {
+                        Logger.Warn(ex, "Background metadata refresh failed");
+                    }
+                });
+            } else {
+                // No cache - wait for the download
+                Logger.Warn("Local metadata not found, downloading");
+                metadataStream = LoadMetadataStream().GetAwaiter().GetResult();
+            }
 
             if (metadataStream.Length == 0) {
                 Logger.Warn("Failed to load asset metadata.  Textures won't be loaded.");

--- a/Blish HUD/GameServices/Content/DatAssetCache.cs
+++ b/Blish HUD/GameServices/Content/DatAssetCache.cs
@@ -65,13 +65,12 @@ namespace Blish_HUD.Content {
             return Stream.Null;
         }
 
-        private async Task<Stream> LoadMetadataStream() {
+        private async Task<Stream> DownloadMetadata() {
             string metadataCache = Path.Combine(_assetCachePath, METADATA_FILE);
 
             var metadataStream = Stream.Null;
 
             try {
-                // We block for this on purpose
                 byte[] rawMetadata = await $"{ASSETSERV_HOST}/{METADATA_FILE}".GetBytesAsync();
 
                 File.WriteAllBytes(metadataCache, rawMetadata);
@@ -97,7 +96,7 @@ namespace Blish_HUD.Content {
                 _ = Task.Run(async () =>
                 {
                     try {
-                        using var _ = await LoadMetadataStream().ConfigureAwait(false);
+                        using var _ = await DownloadMetadata().ConfigureAwait(false);
                     } catch (Exception ex) {
                         Logger.Warn(ex, "Background metadata refresh failed");
                     }
@@ -105,7 +104,7 @@ namespace Blish_HUD.Content {
             } else {
                 // No local cache - wait for the download
                 Logger.Warn("Local metadata not found, downloading");
-                using Stream metadataStream = LoadMetadataStream().GetAwaiter().GetResult();
+                using Stream metadataStream = DownloadMetadata().GetAwaiter().GetResult();
                 ProcessMetadataStream(metadataStream);
             }
         }

--- a/Blish HUD/GameServices/Content/DatAssetCache.cs
+++ b/Blish HUD/GameServices/Content/DatAssetCache.cs
@@ -86,12 +86,12 @@ namespace Blish_HUD.Content {
 
         private void EarlyLoad() {
             string metadataCache = Path.Combine(_assetCachePath, METADATA_FILE);
-            var metadataStream = Stream.Null;
 
             // Check if metadata cache exists locally
             if (File.Exists(metadataCache)) {
-                // Open local file and kick off background update
-                metadataStream = File.Open(metadataCache, FileMode.Open, FileAccess.Read, FileShare.Read);
+                // Open local file and run background update
+                using Stream localMetadataStream = File.Open(metadataCache, FileMode.Open, FileAccess.Read, FileShare.Read);
+                ProcessMetadataStream(localMetadataStream);
                 Logger.Info("Local metadata loaded, trying background update");
 
                 _ = Task.Run(async () =>
@@ -103,23 +103,26 @@ namespace Blish_HUD.Content {
                     }
                 });
             } else {
-                // No cache - wait for the download
+                // No local cache - wait for the download
                 Logger.Warn("Local metadata not found, downloading");
-                metadataStream = LoadMetadataStream().GetAwaiter().GetResult();
+                using Stream metadataStream = LoadMetadataStream().GetAwaiter().GetResult();
+                ProcessMetadataStream(metadataStream);
             }
+        }
 
+        private void ProcessMetadataStream(Stream metadataStream) {
             if (metadataStream.Length == 0) {
                 Logger.Warn("Failed to load asset metadata.  Textures won't be loaded.");
 
-                _textureReferences   = new Dictionary<int, TextureReference>(0);
-                _textureSizes        = Array.Empty<Point>();
+                _textureReferences = new Dictionary<int, TextureReference>(0);
+                _textureSizes = Array.Empty<Point>();
                 _transparentTextures = Array.Empty<Texture2D>();
 
                 return;
             }
 
-            using var gzipStream     = new GZipStream(metadataStream, CompressionMode.Decompress);
-            using var parser         = new BinaryReader(gzipStream);
+            using var gzipStream = new GZipStream(metadataStream, CompressionMode.Decompress);
+            using var parser = new BinaryReader(gzipStream);
 
             // BinaryReader to keep things fairly readable
 
@@ -127,14 +130,14 @@ namespace Blish_HUD.Content {
 
             int sizeCount = parser.ReadInt32();
 
-            _textureSizes        = new Point[sizeCount];
+            _textureSizes = new Point[sizeCount];
             _transparentTextures = new Texture2D[sizeCount];
 
             for (int sizeIndex = 0; sizeIndex < sizeCount; sizeIndex++) {
-                int width  = parser.ReadInt32();
+                int width = parser.ReadInt32();
                 int height = parser.ReadInt32();
 
-                _textureSizes[sizeIndex]        = new Point(width, height);
+                _textureSizes[sizeIndex] = new Point(width, height);
                 _transparentTextures[sizeIndex] = new Texture2D(BlishHud.Instance.GraphicsDevice /* This is safe since we're loading early on the main thread */, width, height);
                 _transparentTextures[sizeIndex].SetData(Enumerable.Repeat(Color.Transparent, width * height).ToArray());
 

--- a/Blish HUD/GameServices/Content/DatAssetCache.cs
+++ b/Blish HUD/GameServices/Content/DatAssetCache.cs
@@ -76,7 +76,7 @@ namespace Blish_HUD.Content {
 
                 return new MemoryStream(rawMetadata);
             } catch (Exception ex) {
-                Logger.Info(ex, "Failed to load asset metadata.");
+                Logger.Warn(ex, "Failed to load asset metadata.");
 
                 return Stream.Null;
             }
@@ -101,14 +101,14 @@ namespace Blish_HUD.Content {
                 try {
                     using var _ = await DownloadMetadata().ConfigureAwait(false);
                 } catch (Exception ex) {
-                    Logger.Info(ex, "Background metadata refresh failed");
+                    Logger.Warn(ex, "Background metadata refresh failed");
                 }
             });
         }
 
         private void ProcessMetadataStream(Stream metadataStream) {
             if (metadataStream.Length == 0) {
-                Logger.Info("Failed to load asset metadata. Textures won't be loaded.");
+                Logger.Warn("Failed to load asset metadata. Textures won't be loaded.");
 
                 _textureReferences = new Dictionary<int, TextureReference>(0);
                 _textureSizes = Array.Empty<Point>();


### PR DESCRIPTION
## Discussion Reference
https://discord.com/channels/531175899588984842/536970543736291346/1463924298103263334

## Is this a breaking change?
No

Following a discussion about recent problems with Cloudflare and Deutsche Telekom, metadata will be loaded from disk first and updated in the background instead of waiting for the download to finish, every time Blish HUD loads.