### PR TITLE
MousePosition updates propogate when scrolling a container

### DIFF
--- a/Blish HUD/Controls/Container.cs
+++ b/Blish HUD/Controls/Container.cs
@@ -77,7 +77,11 @@ namespace Blish_HUD.Controls {
         /// </summary>
         public int VerticalScrollOffset {
             get => _verticalScrollOffset;
-            set => SetProperty(ref _verticalScrollOffset, value);
+            set { 
+                if (SetProperty(ref _verticalScrollOffset, value) && this.MouseOver) {
+                    Input.Mouse.RecalculateActiveControl();
+                } 
+            }
         }
 
         private int _horizontalScrollOffset;
@@ -87,7 +91,11 @@ namespace Blish_HUD.Controls {
         /// </summary>
         public int HorizontalScrollOffset {
             get => _horizontalScrollOffset;
-            set => SetProperty(ref _horizontalScrollOffset, value);
+            set {
+                if (SetProperty(ref _horizontalScrollOffset, value) && this.MouseOver) {
+                    Input.Mouse.RecalculateActiveControl();
+                }
+            }
         }
 
         private SizingMode _widthSizingMode = SizingMode.Standard;

--- a/Blish HUD/Controls/Tooltip.cs
+++ b/Blish HUD/Controls/Tooltip.cs
@@ -51,7 +51,7 @@ namespace Blish_HUD.Controls {
             Input.Mouse.MouseMoved += HandleMouseMoved;
         }
 
-        private static void HandleMouseMoved(object sender, MouseEventArgs e) {
+        private static void ShowOrUpdateTooltip() {
             if (ActiveControl?.Tooltip != null && GameService.Input.Mouse.CursorIsVisible) {
                 ActiveControl.Tooltip.CurrentControl = ActiveControl;
                 UpdateTooltipPosition(ActiveControl.Tooltip);
@@ -60,6 +60,10 @@ namespace Blish_HUD.Controls {
                     ActiveControl.Tooltip.Show();
                 }
             }
+        }
+
+        private static void HandleMouseMoved(object sender, MouseEventArgs e) {
+            ShowOrUpdateTooltip();
         }
 
         private static Control _prevControl;
@@ -77,6 +81,8 @@ namespace Blish_HUD.Controls {
             if (_prevControl != null) {
                 e.ActivatedControl.Hidden   += ActivatedControlOnHidden;
                 e.ActivatedControl.Disposed += ActivatedControlOnHidden;
+
+                ShowOrUpdateTooltip();
             }
         }
 

--- a/Blish HUD/GameServices/Input/Mouse/MouseHandler.cs
+++ b/Blish HUD/GameServices/Input/Mouse/MouseHandler.cs
@@ -173,6 +173,16 @@ namespace Blish_HUD.Input {
         }
 
         /// <summary>
+        /// Forces a re-evaluation of the current mouse state against the UI.
+        /// Useful when UI elements move (like scrolling) without the mouse moving.
+        /// </summary>
+        public void RecalculateActiveControl() {
+            if (this.CursorIsVisible) {
+                this.ActiveControl = GameService.Graphics.SpriteScreen.TriggerMouseInput(MouseEventType.MouseMoved, this.State);
+            }
+        }
+
+        /// <summary>
         /// Meant to simulate missing parts of mouse events (LeftMouseButtonPressed and RightMouseButtonPressed) in case the mouse hook just got enabled. This was not an "issue" prior to a fix for issue #768 as e.g. the base control just always operated with the release event.
         /// Now that the event handling there requires a primed state setup by the respective pressed event this logic exists to simulate said event. This saves us from having to pass down a special case flag to the handlers and aims to keep behaviour consistent since
         /// there will always be a press and release event and not sometimes just half of it. 


### PR DESCRIPTION
In the current version of Blish HUD, tooltips and hovered elements continue to think that they are hovered even after scrolled out of view.  This is because the MouseMove event is relied on heavily for when to hide/show tooltips and when triggering MouseEnter/MouseLeave on controls.  This makes the UI feel unresponsive while scrolling (the mouse is not technically moving, but the active controls below it might be).

Current experience:

https://github.com/user-attachments/assets/b6bd6921-9122-4d05-9491-7fc3d884790b

Notice how the tooltip gets stuck and controls that end up under the mouse don't acknowledge that the mouse is over them until the mouse moves.

After these changes:

https://github.com/user-attachments/assets/65037f71-e5c2-463d-b06c-cd0ed564dbb3

https://github.com/user-attachments/assets/2650bfbb-a84f-4ee1-9a26-ea4cd2f6cf4f



