### PR TITLE
Introduce new MeasureStringLogical & Fix Cursor/Highlight Positions

### DIFF
--- a/Blish HUD/Controls/MultilineTextBox.cs
+++ b/Blish HUD/Controls/MultilineTextBox.cs
@@ -125,7 +125,7 @@ namespace Blish_HUD.Controls {
 
             if (lineSpans == 0) {
                 float highlightLeftOffset = MeasureStringWidth(lines[startIndex.Line].Substring(0, startIndex.Character));
-                float highlightWidth      = MeasureStringWidth(lines[startIndex.Line].Substring(startIndex.Character, selectionLength));
+                float highlightWidth      = MeasureStringWidth(lines[startIndex.Line].Substring(startIndex.Character, selectionLength)) + 1;
 
                 regions[0] = new Rectangle(_textRegion.Left + (int)highlightLeftOffset,
                                            _textRegion.Top + (startIndex.Line * _font.LineHeight),
@@ -134,29 +134,29 @@ namespace Blish_HUD.Controls {
             } else {
                 // First line
                 float firstHighlightLeftOffset = MeasureStringWidth(lines[startIndex.Line].Substring(0, startIndex.Character));
-                float firstHighlightWidth      = MeasureStringWidth(lines[startIndex.Line].Substring(startIndex.Character));
+                float firstHighlightWidth      = MeasureStringWidth(lines[startIndex.Line].Substring(startIndex.Character)) + 1;
 
                 regions[0] = new Rectangle(_textRegion.Left + (int) firstHighlightLeftOffset,
                                            _textRegion.Top  + (startIndex.Line * _font.LineHeight),
-                                           (int) firstHighlightWidth,
+                                           (int)firstHighlightWidth,
                                            _font.LineHeight - 1);
 
                 // Middle lines
                 for (int i = startIndex.Line + 1; i < endIndex.Line; i++) {
-                    float fullWidth = MeasureStringWidth(lines[i]);
+                    float fullWidth = MeasureStringWidth(lines[i]) + 1;
 
                     regions[i - startIndex.Line] = new Rectangle(_textRegion.Left,
                                                                  _textRegion.Top  + (i * _font.LineHeight),
-                                                                 (int) fullWidth,
+                                                                 (int)fullWidth,
                                                                  _font.LineHeight - 1);
                 }
 
                 // Last line
-                float lastHighlightWidth = MeasureStringWidth(lines[endIndex.Line].Substring(0, endIndex.Character));
+                float lastHighlightWidth = MeasureStringWidth(lines[endIndex.Line].Substring(0, endIndex.Character)) + 1;
 
                 regions[lineSpans] = new Rectangle(_textRegion.Left,
                                                    _textRegion.Top  + (endIndex.Line * _font.LineHeight),
-                                                   (int) lastHighlightWidth,
+                                                   (int)lastHighlightWidth,
                                                    _font.LineHeight - 1);
             }
 

--- a/Blish HUD/Controls/MultilineTextBox.cs
+++ b/Blish HUD/Controls/MultilineTextBox.cs
@@ -127,7 +127,7 @@ namespace Blish_HUD.Controls {
                 float highlightLeftOffset = MeasureStringWidth(lines[startIndex.Line].Substring(0, startIndex.Character));
                 float highlightWidth      = MeasureStringWidth(lines[startIndex.Line].Substring(startIndex.Character, selectionLength));
 
-                regions[0] = new Rectangle(_textRegion.Left + (int)highlightLeftOffset - 1,
+                regions[0] = new Rectangle(_textRegion.Left + (int)highlightLeftOffset,
                                            _textRegion.Top + (startIndex.Line * _font.LineHeight),
                                            (int)highlightWidth,
                                            _font.LineHeight - 1);
@@ -136,7 +136,7 @@ namespace Blish_HUD.Controls {
                 float firstHighlightLeftOffset = MeasureStringWidth(lines[startIndex.Line].Substring(0, startIndex.Character));
                 float firstHighlightWidth      = MeasureStringWidth(lines[startIndex.Line].Substring(startIndex.Character));
 
-                regions[0] = new Rectangle(_textRegion.Left + (int) firstHighlightLeftOffset - 1,
+                regions[0] = new Rectangle(_textRegion.Left + (int) firstHighlightLeftOffset,
                                            _textRegion.Top  + (startIndex.Line * _font.LineHeight),
                                            (int) firstHighlightWidth,
                                            _font.LineHeight - 1);
@@ -145,7 +145,7 @@ namespace Blish_HUD.Controls {
                 for (int i = startIndex.Line + 1; i < endIndex.Line; i++) {
                     float fullWidth = MeasureStringWidth(lines[i]);
 
-                    regions[i - startIndex.Line] = new Rectangle(_textRegion.Left - 1,
+                    regions[i - startIndex.Line] = new Rectangle(_textRegion.Left,
                                                                  _textRegion.Top  + (i * _font.LineHeight),
                                                                  (int) fullWidth,
                                                                  _font.LineHeight - 1);
@@ -154,7 +154,7 @@ namespace Blish_HUD.Controls {
                 // Last line
                 float lastHighlightWidth = MeasureStringWidth(lines[endIndex.Line].Substring(0, endIndex.Character));
 
-                regions[lineSpans] = new Rectangle(_textRegion.Left - 1,
+                regions[lineSpans] = new Rectangle(_textRegion.Left,
                                                    _textRegion.Top  + (endIndex.Line * _font.LineHeight),
                                                    (int) lastHighlightWidth,
                                                    _font.LineHeight - 1);
@@ -184,7 +184,7 @@ namespace Blish_HUD.Controls {
                                    _font.LineHeight * cursor.Line);
             }
 
-            return new Rectangle(_textRegion.X + offset.X - 2,
+            return new Rectangle(_textRegion.X + offset.X,
                                  _textRegion.Y + offset.Y + 2,
                                  2,
                                  _font.LineHeight - 4);

--- a/Blish HUD/Controls/TextBox.cs
+++ b/Blish HUD/Controls/TextBox.cs
@@ -117,7 +117,7 @@ namespace Blish_HUD.Controls {
                 default: break;
             }
 
-            return new Rectangle(_textRegion.Left + (int)highlightLeftOffset - 1,
+            return new Rectangle(_textRegion.Left + (int)highlightLeftOffset,
                                  _textRegion.Y,
                                  (int)highlightWidth,
                                  _font.LineHeight - 1);
@@ -136,7 +136,7 @@ namespace Blish_HUD.Controls {
                 default: break;
             }
 
-            return new Rectangle(_textRegion.X + (int)textOffset - 2,
+            return new Rectangle(_textRegion.X + (int)textOffset,
                                  _textRegion.Y + 2,
                                  2,
                                  _font.LineHeight - 4);

--- a/Blish HUD/Controls/TextBox.cs
+++ b/Blish HUD/Controls/TextBox.cs
@@ -104,7 +104,7 @@ namespace Blish_HUD.Controls {
             if (selectionLength <= 0 || selectionStart + selectionLength > _text.Length) return Rectangle.Empty;
 
             float highlightLeftOffset = MeasureStringWidth(_text.Substring(0, selectionStart));
-            float highlightWidth      = MeasureStringWidth(_text.Substring(selectionStart, selectionLength));
+            float highlightWidth      = MeasureStringWidth(_text.Substring(selectionStart, selectionLength)) + 1;
 
             switch (this.HorizontalAlignment)
             {

--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -429,11 +429,7 @@ namespace Blish_HUD.Controls {
         }
 
         protected float MeasureStringWidth(string text) {
-            if (string.IsNullOrEmpty(text)) return 0;
-
-            var lastGlyph = _font.GetGlyphs(text).Last();
-
-            return lastGlyph.Position.X + (lastGlyph.FontRegion?.Width ?? 0);
+            return _font.MeasureStringLogical(text).X;
         }
 
         protected int GetClosestLeftWordBoundary(int index) {

--- a/Blish HUD/_Extensions/BitmapFontExtensions.cs
+++ b/Blish HUD/_Extensions/BitmapFontExtensions.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Extended;
+using MonoGame.Extended.BitmapFonts;
+using SharpDX.DirectWrite;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blish_HUD {
+    public static class BitmapFontExtensions {
+
+        /// <summary>
+        /// Measures the "Logical" size of the string. 
+        /// Unlike standard MeasureString, this includes the 'Advance' of trailing whitespace.
+        /// </summary>
+        public static Vector2 MeasureStringLogical(this BitmapFont font, string text) {
+            if (string.IsNullOrEmpty(text))
+                return Vector2.Zero;
+
+            var size = Vector2.Zero;
+            var currentX = 0f;
+
+            for (var i = 0; i < text.Length; i++) {
+                var c = text[i];
+
+                // Handle Newline
+                if (c == '\n') {
+                    size.X = Math.Max(size.X, currentX);
+                    size.Y += font.LineHeight;
+                    currentX = 0;
+                    continue;
+                }
+
+                var region = font.GetCharacterRegion(c);
+                if (region == null)
+                    continue;
+
+                // Use XAdvance (logical width) instead of TextureRegion.Width (visual width)
+                currentX += region.XAdvance + font.LetterSpacing;
+
+                if (BitmapFont.UseKernings && i < text.Length - 1) {
+                    if (region.Kernings.TryGetValue(text[i + 1], out var kerning)) {
+                        currentX += kerning;
+                    }
+                }
+            }
+
+            size.X = Math.Max(size.X, currentX);
+            size.Y += font.LineHeight; // Ensure at least one line height
+
+            return size;
+        }
+    }
+}


### PR DESCRIPTION
This adds a new extension function to BitmapFonts that helps give the measured string using XAdvance.  The result is especially helpful for correcting all of the misalignments with our TextInput controls (both the wonky cursor position when around spaces and the highlights themselves).

Now the cursor and highlights are rendered perfectly regardless of your proximity to a space.

**Take a close look at the cursor and the boundaries of text highlights in the current version of Blish HUD:**

https://github.com/user-attachments/assets/1b9a2c15-bb5c-4704-96d4-a1abcbc9f697

Notice:
- highlights don't quite cover the word and let some outside of the box.
- Cursor position only moves a couple of pixels around spaces, making it hard to tell which side of the space your cursor is on.

**This is the result using the new measurements:**

https://github.com/user-attachments/assets/f1d4978a-5414-4a58-82ad-f463d85c18dd

