### PR TITLE
Implement CTRL + Backspace/Delete & Collapse Selection on Left/Right Arrow

### DIFF
--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -190,7 +190,7 @@ namespace Blish_HUD.Controls {
         /// </summary>
         public int Length => _text.Length;
 
-        /// Get state of modifier keys
+        // Get state of modifier keys
         protected bool IsShiftDown => GameService.Input.Keyboard.ActiveModifiers.HasFlag(ModifierKeys.Shift);
         protected bool IsCtrlDown  => GameService.Input.Keyboard.ActiveModifiers.HasFlag(ModifierKeys.Ctrl);
         protected bool IsAltDown   => GameService.Input.Keyboard.ActiveModifiers.HasFlag(ModifierKeys.Alt);
@@ -281,9 +281,9 @@ namespace Blish_HUD.Controls {
         }
 
         public void ReplaceAll(string value) {
-            Replace(0, 
-                    string.IsNullOrEmpty(value) 
-                        ? 0 
+            Replace(0,
+                    string.IsNullOrEmpty(value)
+                        ? 0
                         : value.Length,
                     value);
         }
@@ -384,7 +384,8 @@ namespace Blish_HUD.Controls {
         }
 
         protected void ResetSelection() {
-            this.SelectionStart = _selectionEnd = _cursorIndex;
+            this.SelectionEnd   = _cursorIndex;
+            this.SelectionStart = _cursorIndex;
         }
 
         protected void UpdateSelection() {
@@ -414,7 +415,7 @@ namespace Blish_HUD.Controls {
             return lastGlyph.Position.X + (lastGlyph.FontRegion?.Width ?? 0);
         }
 
-        protected int GetClosestLeftWordBoundary(int index) {
+        protected int GetClosestLeftWordSelectionBoundary(int index) {
             string text = _text;
             if (string.IsNullOrEmpty(text)) {
                 return 0;
@@ -432,7 +433,7 @@ namespace Blish_HUD.Controls {
             return ++index;
         }
 
-        protected int GetClosestRightWordBoundary(int index) {
+        protected int GetClosestRightWordSelectionBoundary(int index) {
             string text = _text;
             if (string.IsNullOrEmpty(text)) {
                 return 0;
@@ -448,6 +449,70 @@ namespace Blish_HUD.Controls {
             }
 
             return index;
+        }
+
+        protected int GetClosestLeftWordNavigationBoundary(int index) {
+            if (index <= 0) return 0;
+
+            // Walk through any contiguous whitespace to the left of the cursor
+            while (index > 0 && char.IsWhiteSpace(_text[index - 1])) {
+                index--;
+            }
+
+            if (index == 0) return 0;
+
+            // Determine if we're working with a block of word characters or seperator characters
+            bool targetIsSeparator = WordSeperators.Contains(_text[index - 1]);
+
+            // Keep walking backwards as long as the character type matches the target type
+            while (index > 0) {
+                bool currentIsSeparator = WordSeperators.Contains(_text[index - 1]);
+
+                if (currentIsSeparator != targetIsSeparator) {
+                    break;
+                }
+
+                index--;
+            }
+
+            return index;
+        }
+
+        protected int GetClosestRightWordNavigationBoundary(int index) {
+            if (index >= _text.Length) return _text.Length;
+
+            // Walk through any contiguous whitespace to the right of the cursor
+            while (index < _text.Length && char.IsWhiteSpace(_text[index])) {
+                index++;
+            }
+
+            if (index >= _text.Length) return _text.Length;
+
+            // Determine if we're working with a block of word characters or seperator characters
+            bool targetIsSeparator = WordSeperators.Contains(_text[index]);
+
+            // Keep walking forwards as long as the character type matches the target type
+            while (index < _text.Length) {
+                bool currentIsSeparator = WordSeperators.Contains(_text[index]);
+
+                if (currentIsSeparator != targetIsSeparator) {
+                    break;
+                }
+
+                index++;
+            }
+
+            return index;
+        }
+
+        [Obsolete("Use GetClosestLeftWordSelectionBoundary or GetClosestLeftWordNavigationBoundary instead.")]
+        protected int GetClosestLeftWordBoundary(int index) {
+            return GetClosestLeftWordSelectionBoundary(index);
+        }
+
+        [Obsolete("Use GetClosestRightWordSelectionBoundary or GetClosestRightWordNavigationBoundary instead.")]
+        protected int GetClosestRightWordBoundary(int index) {
+            return GetClosestRightWordSelectionBoundary(index);
         }
 
         protected int GetClosestLeftCharacterBoundary(int index) {
@@ -659,6 +724,16 @@ namespace Blish_HUD.Controls {
 
         protected virtual void HandleBackspace() {
             if (_selectionStart == _selectionEnd) {
+                if (this.IsCtrlDown) {
+                    int deleteToIndex = GetClosestLeftWordNavigationBoundary(_cursorIndex);
+
+                    if (Delete(deleteToIndex, _cursorIndex - deleteToIndex)) {
+                        UserSetCursorIndex(deleteToIndex);
+                        ResetSelection();
+                    }
+                    return;
+                }
+
                 int toIndex = _cursorIndex;
                 int fromIndex = GetClosestLeftCharacterBoundary(toIndex - 1);
 
@@ -673,6 +748,13 @@ namespace Blish_HUD.Controls {
 
         protected virtual void HandleDelete() {
             if (_selectionStart == _selectionEnd) {
+                if (this.IsCtrlDown) {
+                    int deleteToIndex = GetClosestRightWordNavigationBoundary(_cursorIndex);
+
+                    Delete(_cursorIndex, deleteToIndex - _cursorIndex);
+                    return;
+                }
+
                 int fromIndex = _cursorIndex;
                 int toIndex = GetClosestRightCharacterBoundary(fromIndex + 1);
 
@@ -683,12 +765,15 @@ namespace Blish_HUD.Controls {
         }
 
         protected virtual void HandleLeft(bool ctrlDown) {
-            int newIndex = _cursorIndex - 1;
+            int newIndex;
 
             if (ctrlDown) {
-                newIndex = GetClosestLeftWordBoundary(newIndex);
+                newIndex = GetClosestLeftWordNavigationBoundary(_cursorIndex);
+            } else if (_selectionStart != _selectionEnd && !this.IsShiftDown) {
+                // Collapse the selection to the left side
+                newIndex = Math.Min(_selectionStart, _selectionEnd);
             } else {
-                newIndex = GetClosestLeftCharacterBoundary(newIndex);
+                newIndex = GetClosestLeftCharacterBoundary(_cursorIndex);
             }
 
             UserSetCursorIndex(newIndex);
@@ -696,12 +781,15 @@ namespace Blish_HUD.Controls {
         }
 
         protected virtual void HandleRight(bool ctrlDown) {
-            int newIndex = _cursorIndex + 1;
+            int newIndex;
 
             if (ctrlDown) {
-                newIndex = GetClosestRightWordBoundary(newIndex);
+                newIndex = GetClosestRightWordNavigationBoundary(_cursorIndex);
+            } else if (_selectionStart != _selectionEnd && !this.IsShiftDown) {
+                // Collapse the selection to the right side
+                newIndex = Math.Max(_selectionStart, _selectionEnd);
             } else {
-                newIndex = GetClosestRightCharacterBoundary(newIndex);
+                newIndex = GetClosestRightCharacterBoundary(_cursorIndex);
             }
 
             UserSetCursorIndex(newIndex);
@@ -783,8 +871,8 @@ namespace Blish_HUD.Controls {
 
         protected void HandleMouseDoubleClick() {
             if (_cursorIndex == _prevCursorIndex) {
-                this.SelectionStart = GetClosestLeftWordBoundary(_cursorIndex);
-                this.SelectionEnd = GetClosestRightWordBoundary(_cursorIndex);
+                this.SelectionStart = GetClosestLeftWordSelectionBoundary(_cursorIndex);
+                this.SelectionEnd   = GetClosestRightWordSelectionBoundary(_cursorIndex);
             }
         }
 

--- a/Blish HUD/Controls/TextInputBase.cs
+++ b/Blish HUD/Controls/TextInputBase.cs
@@ -773,7 +773,7 @@ namespace Blish_HUD.Controls {
                 // Collapse the selection to the left side
                 newIndex = Math.Min(_selectionStart, _selectionEnd);
             } else {
-                newIndex = GetClosestLeftCharacterBoundary(_cursorIndex);
+                newIndex = GetClosestLeftCharacterBoundary(_cursorIndex - 1);
             }
 
             UserSetCursorIndex(newIndex);
@@ -789,7 +789,7 @@ namespace Blish_HUD.Controls {
                 // Collapse the selection to the right side
                 newIndex = Math.Max(_selectionStart, _selectionEnd);
             } else {
-                newIndex = GetClosestRightCharacterBoundary(_cursorIndex);
+                newIndex = GetClosestRightCharacterBoundary(_cursorIndex + 1);
             }
 
             UserSetCursorIndex(newIndex);


### PR DESCRIPTION
Implements deleting to the next word boundary when holding CTRL and pressing Delete or Backspace.

It now properly collapses the selection to the left or right selection index when you press left or right.  Also fixes an issue with the selection area sometimes not invalidating.