### PR TITLE
Split module settings into their own files.

### DIFF
--- a/Blish HUD/GameServices/Modules/Managers/SettingsManager.cs
+++ b/Blish HUD/GameServices/Modules/Managers/SettingsManager.cs
@@ -6,11 +6,14 @@ namespace Blish_HUD.Modules.Managers {
         public SettingCollection ModuleSettings { get; }
 
         private SettingsManager(ModuleManager module) {
-            if (module.State.Settings == null) {
-                module.State.Settings = new SettingCollection(true);
-            }
+            SettingCollection settings = GameService.Settings.LoadModuleSettings(module.Manifest.Namespace)
+                                      ?? new SettingCollection(true);
 
-            this.ModuleSettings = module.State.Settings;
+            module.State.Settings = settings;
+            this.ModuleSettings   = settings;
+
+            // Register so that the periodic save includes this module's settings
+            GameService.Settings.RegisterModuleSettings(module.Manifest.Namespace, settings);
         }
 
         internal static SettingsManager GetModuleInstance(ModuleManager module) {

--- a/Blish HUD/GameServices/Modules/ModuleManager.cs
+++ b/Blish HUD/GameServices/Modules/ModuleManager.cs
@@ -145,6 +145,10 @@ namespace Blish_HUD.Modules {
             this.State.Enabled = this.Enabled;
             GameService.Settings.Save();
 
+            // Flush module settings to their own file and free them from memory
+            GameService.Settings.UnregisterModuleSettings(this.Manifest.Namespace);
+            this.State.Settings = null;
+
             GameService.Module.SortMenuItems();
         }
 

--- a/Blish HUD/GameServices/Modules/ModuleState.cs
+++ b/Blish HUD/GameServices/Modules/ModuleState.cs
@@ -12,6 +12,7 @@ namespace Blish_HUD.Modules {
 
         public bool IgnoreDependencies { get; set; }
 
+        [JsonIgnore]
         public SettingCollection Settings { get; set; }
 
     }

--- a/Blish HUD/GameServices/SettingsService.cs
+++ b/Blish HUD/GameServices/SettingsService.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Blish_HUD.Content.Serialization;
 using Blish_HUD.Controls;
 using Blish_HUD.Settings;
 using Microsoft.Xna.Framework;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Blish_HUD {
 
@@ -16,7 +18,9 @@ namespace Blish_HUD {
 
         private const int SAVE_INTERVAL = 4;
 
-        private const string SETTINGS_FILENAME = "settings.json";
+        private const string SETTINGS_FILENAME  = "settings.json";
+        private const string SETTINGS_PMBACKUP  = "settings-premigration.json";
+        private const string SETTINGS_DIRECTORY = "settings";
 
         [Obsolete]
         public delegate void SettingTypeRendererDelegate(SettingEntry setting, Panel settingPanel);
@@ -27,10 +31,15 @@ namespace Blish_HUD {
         [JsonIgnore]
         private string _settingsPath;
 
+        [JsonIgnore]
+        private string _settingsDirectory;
+
         internal SettingCollection Settings { get; private set; }
 
         private bool   _dirtySave;
         private double _saveBuffer;
+
+        private readonly Dictionary<string, SettingCollection> _moduleSettings = new Dictionary<string, SettingCollection>();
 
         protected override void Initialize() {
             JsonReaderSettings = new JsonSerializerSettings() {
@@ -45,7 +54,8 @@ namespace Blish_HUD {
                 }
             };
 
-            _settingsPath = Path.Combine(DirectoryUtil.BasePath, SETTINGS_FILENAME);
+            _settingsPath      = Path.Combine(DirectoryUtil.BasePath, SETTINGS_FILENAME);
+            _settingsDirectory = DirectoryUtil.RegisterDirectory(SETTINGS_DIRECTORY);
 
             // If settings aren't there, generate the file
             if (!File.Exists(_settingsPath)) PrepareSettingsFirstTime();
@@ -53,11 +63,100 @@ namespace Blish_HUD {
             LoadSettings();
         }
 
+        private void MigrateModuleSettings(string rawJson) {
+            // Migrates module settings from the settings.json into individual per-module files under the settings/ directory.
+            try {
+                var root = JObject.Parse(rawJson);
+
+                // Root is a SettingCollection
+                var rootEntries = root["Entries"] as JArray;
+                if (rootEntries == null) return;
+
+                // Find the "ModuleConfiguration" entry
+                var moduleConfigValue = FindSettingEntryValue(rootEntries, "ModuleConfiguration") as JObject;
+                if (moduleConfigValue == null) return;
+
+                // Inside ModuleConfiguration, find "ModuleStates" entry
+                var configEntries = moduleConfigValue["Entries"] as JArray;
+                if (configEntries == null) return;
+
+                var moduleStatesValue = FindSettingEntryValue(configEntries, "ModuleStates");
+                if (moduleStatesValue == null || moduleStatesValue.Type != JTokenType.Object) return;
+
+                // Check if any modules actually have settings to migrate
+                bool hasSettingsToMigrate = moduleStatesValue.Children<JProperty>().Any(p => p.Value is JObject state && state["Settings"] != null && state["Settings"].Type != JTokenType.Null);
+
+                if (!hasSettingsToMigrate) return;
+
+                // Back up the original settings file before we touch anything
+                // Only create the backup if one doesn't already exist (a previous
+                // partial migration may have left one behind)
+                string backupPath = Path.Combine(DirectoryUtil.BasePath, SETTINGS_PMBACKUP);
+
+                if (!File.Exists(backupPath)) {
+                    try {
+                        File.Copy(_settingsPath, backupPath);
+                        Logger.Info($"Created backup of settings file before migration at '{backupPath}'.");
+                    } catch (Exception ex) {
+                        Logger.Warn(ex, $"Failed to create backup of settings file at '{backupPath}' before migration. Aborting migration to avoid potential data loss.");
+                        return;
+                    }
+                }
+
+                bool migrated = false;
+
+                foreach (var moduleProp in moduleStatesValue.Children<JProperty>().ToList()) {
+                    var moduleState = moduleProp.Value as JObject;
+                    if (moduleState == null) continue;
+
+                    JToken settingsToken = moduleState["Settings"];
+                    if (settingsToken == null || settingsToken.Type == JTokenType.Null) continue;
+
+                    // Write settings to per-module file
+                    string moduleSettingsPath = GetModuleSettingsPath(moduleProp.Name);
+
+                    try {
+                        string settingsJson = settingsToken.ToString(Formatting.None);
+                        WriteFileAtomic(moduleSettingsPath, settingsJson);
+
+                        Logger.Info($"Migrated settings for module '{moduleProp.Name}' to '{moduleSettingsPath}'.");
+                    } catch (Exception ex) {
+                        Logger.Warn(ex, $"Failed to migrate settings for module '{moduleProp.Name}'.");
+                        continue;
+                    }
+
+                    // Remove settings from the module state in the main file.
+                    moduleState.Remove("Settings");
+                    migrated = true;
+                }
+
+                if (migrated) {
+                    WriteFileAtomic(_settingsPath, root.ToString(Formatting.None));
+                    Logger.Info("Completed migration of module settings to individual files.");
+                }
+            } catch (Exception ex) {
+                Logger.Warn(ex, "An error occurred while attempting to migrate module settings.");
+            }
+        }
+
+        private static JToken FindSettingEntryValue(JArray entries, string key) {
+            foreach (var entry in entries) {
+                if (string.Equals(entry["Key"]?.ToString(), key, StringComparison.OrdinalIgnoreCase)) {
+                    return entry["Value"];
+                }
+            }
+
+            return null;
+        }
+
         private void LoadSettings(bool alreadyFailed = false) {
             string rawSettings = null;
 
             try {
                 rawSettings = File.ReadAllText(_settingsPath);
+
+                // Migrate module settings out of settings.json into per-module files before loading
+                MigrateModuleSettings(rawSettings);
 
                 this.Settings = JsonConvert.DeserializeObject<SettingCollection>(rawSettings, JsonReaderSettings) ?? new SettingCollection(false);
             } catch (UnauthorizedAccessException) {
@@ -100,18 +199,15 @@ namespace Blish_HUD {
         }
 
         private void PerformSave() {
-            string rawSettings = JsonConvert.SerializeObject(this.Settings, Formatting.Indented, JsonReaderSettings);
+            string rawSettings = JsonConvert.SerializeObject(this.Settings, Formatting.None, JsonReaderSettings);
 
             try {
-                string tempSettingsPath = $"{_settingsPath}.new";
-                using (var settingsWriter = new StreamWriter(tempSettingsPath, false)) {
-                    settingsWriter.Write(rawSettings);
-                }
+                // Save settings.json
+                WriteFileAtomic(_settingsPath, rawSettings);
 
-                if (File.Exists(_settingsPath)) {
-                    File.Replace(tempSettingsPath, _settingsPath, null);
-                } else {
-                    File.Move(tempSettingsPath, _settingsPath);
+                // Save all registered module settings to their individual files
+                foreach (var mkp in _moduleSettings) {
+                    PerformModuleSettingsSave(mkp.Key, mkp.Value);
                 }
             } catch (UnauthorizedAccessException) {
                 Blish_HUD.Debug.Contingency.NotifyFileSaveAccessDenied(_settingsPath, Strings.GameServices.Debug.ContingencyMessages.FileSaveAccessDenied_Action_ToSaveSettings);
@@ -125,6 +221,64 @@ namespace Blish_HUD {
 
             Logger.Debug("Settings were saved successfully.");
         }
+
+        private static void WriteFileAtomic(string filePath, string content) {
+            string tempPath = $"{filePath}.new";
+
+            using (var writer = new StreamWriter(tempPath, false)) {
+                writer.Write(content);
+            }
+
+            if (File.Exists(filePath)) {
+                File.Replace(tempPath, filePath, null);
+            } else {
+                File.Move(tempPath, filePath);
+            }
+        }
+
+        #region Module Settings
+
+        private void PerformModuleSettingsSave(string moduleNamespace, SettingCollection settings) {
+            string moduleSettingsPath = GetModuleSettingsPath(moduleNamespace);
+
+            try {
+                string rawModuleSettings = JsonConvert.SerializeObject(settings, Formatting.None, JsonReaderSettings);
+                WriteFileAtomic(moduleSettingsPath, rawModuleSettings);
+            } catch (Exception ex) {
+                Logger.Warn(ex, $"Failed to save settings for module '{moduleNamespace}'.");
+            }
+        }
+
+        private string GetModuleSettingsPath(string moduleNamespace) {
+            return Path.Combine(_settingsDirectory, $"{moduleNamespace}.json");
+        }
+
+        internal SettingCollection LoadModuleSettings(string moduleNamespace) {
+            string path = GetModuleSettingsPath(moduleNamespace);
+
+            if (!File.Exists(path)) return null;
+
+            try {
+                string rawSettings = File.ReadAllText(path);
+                return JsonConvert.DeserializeObject<SettingCollection>(rawSettings, JsonReaderSettings);
+            } catch (Exception ex) {
+                Logger.Warn(ex, path, $"Failed to load settings for module '{moduleNamespace}'.");
+                return null;
+            }
+        }
+
+        internal void RegisterModuleSettings(string moduleNamespace, SettingCollection settings) {
+            _moduleSettings[moduleNamespace] = settings;
+        }
+
+        internal void UnregisterModuleSettings(string moduleNamespace) {
+            if (_moduleSettings.TryGetValue(moduleNamespace, out var settings)) {
+                PerformModuleSettingsSave(moduleNamespace, settings);
+                _moduleSettings.Remove(moduleNamespace);
+            }
+        }
+
+        #endregion
 
         protected override void Load() { /* NOOP */ }
 

--- a/Blish HUD/GameServices/SettingsService.cs
+++ b/Blish HUD/GameServices/SettingsService.cs
@@ -209,14 +209,17 @@ namespace Blish_HUD {
                 foreach (var mkp in _moduleSettings) {
                     PerformModuleSettingsSave(mkp.Key, mkp.Value);
                 }
-            } catch (UnauthorizedAccessException) {
+            } catch (UnauthorizedAccessException ex) {
                 Blish_HUD.Debug.Contingency.NotifyFileSaveAccessDenied(_settingsPath, Strings.GameServices.Debug.ContingencyMessages.FileSaveAccessDenied_Action_ToSaveSettings);
+                Logger.Warn(ex, "Failed to save settings.");
+                return;
             } catch (Exception ex) {
                 Logger.Warn(ex, "Failed to save settings.");
                 return;
+            } finally {
+                _saveBuffer = 0;
             }
-
-            _saveBuffer = 0;
+            
             _dirtySave  = false;
 
             Logger.Debug("Settings were saved successfully.");

--- a/Blish HUD/GameServices/SettingsService.cs
+++ b/Blish HUD/GameServices/SettingsService.cs
@@ -40,6 +40,7 @@ namespace Blish_HUD {
         private double _saveBuffer;
 
         private readonly Dictionary<string, SettingCollection> _moduleSettings = new Dictionary<string, SettingCollection>();
+        private readonly object _moduleSettingsLock = new object();
 
         protected override void Initialize() {
             JsonReaderSettings = new JsonSerializerSettings() {
@@ -206,7 +207,13 @@ namespace Blish_HUD {
                 WriteFileAtomic(_settingsPath, rawSettings);
 
                 // Save all registered module settings to their individual files
-                foreach (var mkp in _moduleSettings) {
+                KeyValuePair<string, SettingCollection>[] modulesToSave;
+
+                lock (_moduleSettingsLock) {
+                    modulesToSave = _moduleSettings.ToArray();
+                }
+
+                foreach (var mkp in modulesToSave) {
                     PerformModuleSettingsSave(mkp.Key, mkp.Value);
                 }
             } catch (UnauthorizedAccessException ex) {
@@ -271,13 +278,17 @@ namespace Blish_HUD {
         }
 
         internal void RegisterModuleSettings(string moduleNamespace, SettingCollection settings) {
-            _moduleSettings[moduleNamespace] = settings;
+            lock (_moduleSettingsLock) { 
+                _moduleSettings[moduleNamespace] = settings;
+            }
         }
 
         internal void UnregisterModuleSettings(string moduleNamespace) {
-            if (_moduleSettings.TryGetValue(moduleNamespace, out var settings)) {
-                PerformModuleSettingsSave(moduleNamespace, settings);
-                _moduleSettings.Remove(moduleNamespace);
+            lock (_moduleSettingsLock) { 
+                if (_moduleSettings.TryGetValue(moduleNamespace, out var settings)) {
+                    PerformModuleSettingsSave(moduleNamespace, settings);
+                    _moduleSettings.Remove(moduleNamespace);
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

Module settings are stored along with all other settings within the `setting.json` file.  To avoid deserializing module-specific types when a module isn't loaded, the settings are kept as raw JSON strings (via `SettingCollection`'s lazy loading).  However, this means the full JSON blob for every module (including those that are disabled) is held in memory at all times.  For users with many modules, this results in a large `settings.json` and unnecessary memory usage.

## Solution

Module settings are migrated out of `settings.json` into individual files under a new `settings/` directory, named by module namespace (e.g. `settings/bh.community.pathing.json`).  Settings are only loaded into memory when a module is enabled, and flushed back to disk and freed when it's disabled.

## Settings migration

- A migration takes place if module settings are detected in the `settings.json` file.  When the migration occurs, a backup of the original settings file is made (if one doesn't already exist), just in case.

## Results

<img width="872" height="56" alt="image" src="https://github.com/user-attachments/assets/e1622062-292e-453c-9761-c8f5f8c64355" />

<img width="697" height="1233" alt="image" src="https://github.com/user-attachments/assets/c3a619b2-f66f-4193-881a-c2a27fb5d6c4" />
