### PR TITLE
Fix: Mouse wheel scrolling

### DIFF
--- a/Blish HUD/Controls/Scrollbar.cs
+++ b/Blish HUD/Controls/Scrollbar.cs
@@ -16,7 +16,6 @@ namespace Blish_HUD.Controls {
         private const int SCROLL_ARROW      = 50;
         private const int SCROLL_CONT_ARROW = 10;
         private const int SCROLL_CONT_TRACK = 15;
-        private const int SCROLL_WHEEL      = 30;
 
         #region Load Static
 
@@ -162,13 +161,16 @@ namespace Blish_HUD.Controls {
 
             if (scrollValue == 0) return;
 
-            // Handle the scroll value overflow (happens when scrolling a lot in one direction)
+            // Handle the scroll value overflow (happens when scrolling fast in one direction)
             if (scrollValue < -32000) {
                 scrollValue += 65536;
             }
 
-            float scrollDirection = Math.Sign(scrollValue);
-            ScrollAnimated((int)scrollDirection * -SCROLL_WHEEL * System.Windows.Forms.SystemInformation.MouseWheelScrollLines);
+            // Propotional scroll amount based on the scroll value, with a minimum of 8
+            float scrollMultiplier = scrollValue / 8f;
+            scrollMultiplier = Math.Max(8f, Math.Abs(scrollMultiplier)) * Math.Sign(scrollValue);
+
+            ScrollAnimated(-(int)scrollMultiplier * System.Windows.Forms.SystemInformation.MouseWheelScrollLines);
         }
 
         private ClickFocus GetScrollFocus(Point mousePos) => mousePos switch {

--- a/Blish HUD/Controls/Scrollbar.cs
+++ b/Blish HUD/Controls/Scrollbar.cs
@@ -161,11 +161,6 @@ namespace Blish_HUD.Controls {
 
             if (scrollValue == 0) return;
 
-            // Handle the scroll value overflow (happens when scrolling fast in one direction)
-            if (scrollValue < -32000) {
-                scrollValue += 65536;
-            }
-
             // Propotional scroll amount based on the scroll value, with a minimum of 8
             float scrollMultiplier = scrollValue / 8f;
             scrollMultiplier = Math.Max(8f, Math.Abs(scrollMultiplier)) * Math.Sign(scrollValue);

--- a/Blish HUD/Controls/Scrollbar.cs
+++ b/Blish HUD/Controls/Scrollbar.cs
@@ -158,10 +158,17 @@ namespace Blish_HUD.Controls {
                 ctrl = ctrl.Parent;
             }
 
-            if (GameService.Input.Mouse.State.ScrollWheelValue == 0) return;
+            int scrollValue = GameService.Input.Mouse.State.ScrollWheelValue;
 
-            float normalScroll = Math.Sign(GameService.Input.Mouse.State.ScrollWheelValue);
-            ScrollAnimated((int)normalScroll * -SCROLL_WHEEL * System.Windows.Forms.SystemInformation.MouseWheelScrollLines);
+            if (scrollValue == 0) return;
+
+            // Handle the scroll value overflow (happens when scrolling a lot in one direction)
+            if (scrollValue < -32000) {
+                scrollValue += 65536;
+            }
+
+            float scrollDirection = Math.Sign(scrollValue);
+            ScrollAnimated((int)scrollDirection * -SCROLL_WHEEL * System.Windows.Forms.SystemInformation.MouseWheelScrollLines);
         }
 
         private ClickFocus GetScrollFocus(Point mousePos) => mousePos switch {

--- a/Blish HUD/Controls/Scrollbar.cs
+++ b/Blish HUD/Controls/Scrollbar.cs
@@ -16,6 +16,7 @@ namespace Blish_HUD.Controls {
         private const int SCROLL_ARROW      = 50;
         private const int SCROLL_CONT_ARROW = 10;
         private const int SCROLL_CONT_TRACK = 15;
+        private const int SCROLL_WHEEL = 15;
 
         #region Load Static
 
@@ -161,8 +162,8 @@ namespace Blish_HUD.Controls {
 
             if (scrollValue == 0) return;
 
-            // Propotional scroll amount based on the scroll value, with a minimum of 8
-            float scrollMultiplier = scrollValue / 8f;
+            // Proportional scroll amount based on the scroll value, with a minimum of 8
+            float scrollMultiplier = (scrollValue / 120f) * SCROLL_WHEEL;
             scrollMultiplier = Math.Max(8f, Math.Abs(scrollMultiplier)) * Math.Sign(scrollValue);
 
             ScrollAnimated(-(int)scrollMultiplier * System.Windows.Forms.SystemInformation.MouseWheelScrollLines);

--- a/Blish HUD/GameServices/Input/Mouse/MouseEventArgs.cs
+++ b/Blish HUD/GameServices/Input/Mouse/MouseEventArgs.cs
@@ -40,8 +40,8 @@ namespace Blish_HUD.Input {
 
         internal int WheelDelta {
             get {
-                int v                                              = Convert.ToInt32((this.MouseData & 0xFFFF0000) >> 16);
-                if (v > SystemInformation.MouseWheelScrollDelta) v -= ushort.MaxValue + 1;
+                int v             = (int)((this.MouseData & 0xFFFF0000) >> 16);
+                if (v > 32768) v -= ushort.MaxValue + 1;
                 return v;
             }
         }

--- a/Blish HUD/GameServices/Input/Mouse/MouseEventArgs.cs
+++ b/Blish HUD/GameServices/Input/Mouse/MouseEventArgs.cs
@@ -41,7 +41,7 @@ namespace Blish_HUD.Input {
         internal int WheelDelta {
             get {
                 int v             = (int)((this.MouseData & 0xFFFF0000) >> 16);
-                if (v > 32768) v -= ushort.MaxValue + 1;
+                if (v >= 32768) v -= ushort.MaxValue + 1;
                 return v;
             }
         }


### PR DESCRIPTION
## Description
When using the mouse wheel to scroll through a control, `GameService.Input.Mouse.State.ScrollWheelValue` seems to overflow the value from the up direction to -65536 when scrolling fast. This causes the direction to reverse.

Since the value is also proportional to the speed of the mouse wheel, this also seems to be a good candidate for #392 
It feels very natural scrolling through lists now.

## Is this a breaking change?
No
