### PR TITLE
Fix: Wrong size measurement for WrapTextSegment

### DIFF
--- a/Blish HUD/_Utils/DrawUtil.cs
+++ b/Blish HUD/_Utils/DrawUtil.cs
@@ -1,10 +1,10 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.BitmapFonts;
-using System;
 using System.Linq;
 using System.Text;
 using Blish_HUD.Controls;
+using System.Collections.Generic;
 
 namespace Blish_HUD {
     public static class DrawUtil {
@@ -45,23 +45,23 @@ namespace Blish_HUD {
         /// <remarks> Source: https://stackoverflow.com/a/15987581/595437 </remarks>
         private static string WrapTextSegment(BitmapFont spriteFont, string text, float maxLineWidth) {
             string[] words      = text.Split(' ');
-            var      sb         = new StringBuilder();
-            float    lineWidth  = 0f;
-            float    spaceWidth = spriteFont.MeasureString(" ").Width;
+            var lines = new List<string>();
+            var sb = new StringBuilder();
 
             foreach (string word in words) {
-                Vector2 size = spriteFont.MeasureString(word);
+                string appendingString = word + " ";
+                Vector2 size = spriteFont.MeasureString(appendingString);
 
-                if (lineWidth + size.X < maxLineWidth) {
-                    sb.Append(word + " ");
-                    lineWidth += size.X + spaceWidth;
+                if (spriteFont.MeasureString(sb.ToString()).Width + size.X < maxLineWidth) {
+                    sb.Append(appendingString);
                 } else {
-                    sb.Append("\n" + word + " ");
-                    lineWidth = size.X + spaceWidth;
+                    lines.Add(sb.ToString());
+                    sb = new StringBuilder();
+                    sb.Append(appendingString);
                 }
             }
 
-            return sb.ToString();
+            return string.Join("\n", lines);
         }
 
         public static string WrapText(BitmapFont spriteFont, string text, float maxLineWidth) {

--- a/Blish HUD/_Utils/DrawUtil.cs
+++ b/Blish HUD/_Utils/DrawUtil.cs
@@ -61,6 +61,7 @@ namespace Blish_HUD {
                 }
             }
 
+            lines.Add(sb.ToString());
             return string.Join("\n", lines);
         }
 


### PR DESCRIPTION
In specific edge cases `DrawUtil.WrapText` produces a string that is greater than the `maxLineWidth` you give him.
This happens because the previous implementation of `WrapTextSegment` didn't properly measured the string after appending a word.
The size of the space changes depending on which letter the space precedes so we can't use a fixed SpaceWidth for the whole wrapping and we need to measure the actual size of the string to not exceeed the `maxLineWidth`.

I don't know all the implications this change could occure, but i can't think of any problem with it, but that is limited to the knowledge i have regarding this function and usage all around Blish.

Also i don't know if `MeasureString("some string") + MeasureString("some other string")` will be the same as `MeasureString("some string" + "some other string")`. This could create another even more edgy case where we need to measure the resulting string before we create it to not exceed the `maxLineWidth`

This is intended to not break any existing implementation and should only fix an edge case.

Also unrelated to the current issue: `DrawUtil.WrapText` adds an unnecessary space at every line at the end.

Minimal reproduction that produces a wrong LineWidth string:
```
var test = "invidunt ut labore et dolore magna aliquyam erat, sed";
var result = DrawUtil.WrapText(GameService.Content.GetFont(FontFace.Menomonia, FontSize.Size16, FontStyle.Regular), test, 360);
var lineWidth = GameService.Content.GetFont(FontFace.Menomonia, FontSize.Size16, FontStyle.Regular).MeasureString(result); // lineWidth = 363
```