### PR TITLE
Fix debug module subtoken not generated when UserEnabledPermissions is null in debug mode.

### DIFF
--- a/Blish HUD/GameServices/ModuleService.cs
+++ b/Blish HUD/GameServices/ModuleService.cs
@@ -300,6 +300,10 @@ namespace Blish_HUD {
                     Logger.Warn("Failed to load module from path {modulePath}.", ApplicationSettings.Instance.DebugModulePath);
                 }
 
+                if (debugModule != null && debugModule.State.UserEnabledPermissions == null) {
+                    debugModule.State.UserEnabledPermissions = debugModule.Manifest.ApiPermissions.Keys.ToArray();
+                }
+
                 debugModule?.TryEnable();
             }
 


### PR DESCRIPTION
## Discussion Reference
https://discord.com/channels/531175899588984842/536970543736291346/1510516325837967542

## Is this a breaking change?
No

## Summary
When loading a module in debug mode via `--debug-module`, `UserEnabledPermissions` 
on the module state is never set, causing subtoken generation to be skipped entirely. 
This means `Gw2ApiManager.SubtokenUpdated` never fires and all authenticated GW2 API 
calls fail silently in debug mode.

**Root cause:** `ModuleService.Load()` calls `TryEnable()` on the debug module, which 
internally attempts to generate a subtoken using `UserEnabledPermissions`. In debug 
mode this value is `null` because there is no settings UI flow to populate it.

**Fix:** Before calling `TryEnable()`, check if `UserEnabledPermissions` is null and 
populate it from the module's manifest API permission keys.

**Tested:** Verified that `SubtokenUpdated` now fires correctly in debug mode and 
authenticated API calls succeed.