### PR TITLE
Deliver typed characters to a focused module text box

### DIFF
--- a/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
+++ b/Blish HUD/GameServices/Input/Keyboard/KeyboardHandler.cs
@@ -206,7 +206,7 @@ namespace Blish_HUD.Input {
 
             if (GameService.Overlay.InterfaceHidden) return false;
 
-            if (GameService.Gw2Mumble.IsAvailable && GameService.Gw2Mumble.UI.IsTextInputFocused) return false;
+            if (_textInputDelegate == null && GameService.Gw2Mumble.IsAvailable && GameService.Gw2Mumble.UI.IsTextInputFocused) return false;
 
             // Handle the escape key
             if (key == Keys.Escape && eventType == KeyboardEventType.KeyDown) {


### PR DESCRIPTION
## Is this a breaking change?

No

----------------

If you click a text box in the game first, then click a text box in a Blish HUD module, the module shows a cursor but everything you type goes to the game. Backspace is the exception and still reaches the module, which is why it looks half working rather than broken. This one-line change delivers the typed characters to a module's text box when one is registered to receive them.
